### PR TITLE
CLI:  fix CI build

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -37,10 +37,10 @@ stages:
         pool:
           ${{ if ne(variables['System.TeamProject'], 'internal') }}:
             name: NetCore-Public
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
+            demands: ImageOverride -equals windows.vs2019.amd64.open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019
+            demands: ImageOverride -equals windows.vs2019.amd64
 
         strategy:
           matrix:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -34,7 +34,7 @@ stages:
       enableTelemetry: true
       jobs:
       - job: Windows
-        pool:
+        pool: # See https://helix.dot.net/ for VM names.
           ${{ if ne(variables['System.TeamProject'], 'internal') }}:
             name: NetCore-Public
             demands: ImageOverride -equals windows.vs2019.amd64.open


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/439.

The .NET engineering team removed some VM's.  This PR replaces those obsolete VM's with equivalent VM's.