### PR TITLE
CLI:  update dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,15 +9,16 @@
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.4.0" />
     <PackageVersion Include="AzureSign.Core" Version="3.0.0" />
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0-rc.2.22472.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0-rc.2.22472.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0-rc.2.22472.3" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.25231-preview" />
     <PackageVersion Include="Moq" Version="4.18.1" />
     <PackageVersion Include="NuGetKeyVaultSignTool.Core" Version="3.2.3" />
     <PackageVersion Include="OpenVsixSignTool.Core" Version="0.3.2" />
     <PackageVersion Include="RSAKeyVaultProvider" Version="2.1.1" />
     <PackageVersion Include="System.CommandLine" Version="$(GenAPISystemCommandLineVersion)" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="7.0.0-rc.2.22472.3" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="7.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Sign.Cli/Sign.Cli.csproj
+++ b/src/Sign.Cli/Sign.Cli.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" IncludeAssets="none" PrivateAssets="all" />
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 

--- a/src/Sign.Core/Sign.Core.csproj
+++ b/src/Sign.Core/Sign.Core.csproj
@@ -7,15 +7,16 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Azure.Security.KeyVault.Certificates" />
-    <PackageReference Include="AzureSign.Core" />
+    <PackageReference Include="Azure.Security.KeyVault.Certificates" PrivateAssets="analyzers;build;compile;contentfiles" />
+    <PackageReference Include="AzureSign.Core" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
-    <PackageReference Include="NuGetKeyVaultSignTool.Core" />
-    <PackageReference Include="OpenVsixSignTool.Core" />
-    <PackageReference Include="RSAKeyVaultProvider" />
-    <PackageReference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" PrivateAssets="analyzers;build;compile;contentfiles" />
+    <PackageReference Include="NuGetKeyVaultSignTool.Core" PrivateAssets="analyzers;build;compile;contentfiles" />
+    <PackageReference Include="OpenVsixSignTool.Core" PrivateAssets="analyzers;build;compile;contentfiles" />
+    <PackageReference Include="RSAKeyVaultProvider" PrivateAssets="analyzers;build;compile;contentfiles" />
+    <PackageReference Include="System.Security.Cryptography.Xml" PrivateAssets="analyzers;build;compile;contentfiles" />
+    <PackageReference Include="System.Text.Json" PrivateAssets="analyzers;build;compile;contentfiles" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/443.

This change updates package dependencies, mostly updating from a prerelease version of .NET 7 to its final .NET 7.0 version.  This change also uses `PrivateAssets` to prevent some dependencies from flowing unnecessarily to a referencing project.

Note:  this source branch is based on a target branch which currently has an open PR (https://github.com/dotnet/sign/pull/442).  The reason is because the cli branch build is currently broken and CI builds for PR's fail.  The current target branch has the fix.  Once the target branch merges into the cli branch, I will retarget this PR at the cli branch.