### PR TITLE
CLI:  add SDK tools to NuGet package

### DIFF
--- a/src/Sign.Cli/Sign.Cli.csproj
+++ b/src/Sign.Cli/Sign.Cli.csproj
@@ -77,4 +77,11 @@
     <Error Condition="'$(WinSdkBinDir)' == ''" Text="No supported WinSDK could be found!" />
   </Target>
 
+  <ItemGroup>
+    <Content Include="$(OutputPath)\tools\**">
+      <Pack>true</Pack>
+      <PackagePath>tools\$(TargetFramework)\any\tools</PackagePath>
+    </Content>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/459.

This change adds redistributable Windows SDK tools and .NET Framework tools (mage.exe) to the NuGet package.  This is necessary because the CLI requires these local copies.  (They may not already exist on a machine.)

CC @clairernovotny