### PR TITLE
CLI:  remove unused x86 tools

### DIFF
--- a/src/Sign.Cli/Sign.Cli.csproj
+++ b/src/Sign.Cli/Sign.Cli.csproj
@@ -52,21 +52,6 @@
     <SdkFile64 Include="$(WinSdkBinDir)\x64\wintrust.dll.ini" />
     <SdkFile64 Include="$(WinSdkBinDir)\x64\SignTool.exe.manifest" />
 
-    <SdkFile86 Include="$(WinSdkBinDir)\x86\appxsip.dll" />
-    <SdkFile86 Include="$(WinSdkBinDir)\x86\appxpackaging.dll" />
-    <SdkFile86 Include="$(WinSdkBinDir)\x86\opcservices.dll" />
-    <SdkFile86 Include="$(WinSdkBinDir)\x86\Microsoft.Windows.Build.Appx.AppxPackaging.dll.manifest" />
-    <SdkFile86 Include="$(WinSdkBinDir)\x86\Microsoft.Windows.Build.Appx.AppxSip.dll.manifest" />
-    <SdkFile86 Include="$(WinSdkBinDir)\x86\Microsoft.Windows.Build.Appx.OpcServices.dll.manifest" />
-    <SdkFile86 Include="$(WinSdkBinDir)\x86\Microsoft.Windows.Build.Signing.mssign32.dll.manifest" />
-    <SdkFile86 Include="$(WinSdkBinDir)\x86\Microsoft.Windows.Build.Signing.wintrust.dll.manifest" />
-    <SdkFile86 Include="$(WinSdkBinDir)\x86\makeappx.exe" />
-    <SdkFile86 Include="$(WinSdkBinDir)\x86\makepri.exe" />
-    <SdkFile86 Include="$(WinSdkBinDir)\x86\mssign32.dll" />
-    <SdkFile86 Include="$(WinSdkBinDir)\x86\wintrust.dll" />
-    <SdkFile86 Include="$(WinSdkBinDir)\x86\wintrust.dll.ini" />
-    <SdkFile86 Include="$(WinSdkBinDir)\x86\SignTool.exe.manifest" />
-
     <SdkFile86 Include="$(NetSdkBinDir)\mage.exe" />
   </ItemGroup>
 


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/465.

Currently, the only target platform is Windows x64, so these x86 tools are unused.

Note that mage.exe is an x86 tool that is still used.