### PR TITLE
CLI:  fix bugs and add tests

### DIFF
--- a/src/Sign.Core/Containers/ContainerProvider.cs
+++ b/src/Sign.Core/Containers/ContainerProvider.cs
@@ -52,6 +52,7 @@ namespace Sign.Core
             _zipExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 ".appxupload",
+                ".clickonce",
                 ".msixupload",
                 ".nupkg",
                 ".snupkg",

--- a/src/Sign.Core/SignatureProviders/NuGetSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/NuGetSignatureProvider.cs
@@ -25,6 +25,8 @@ namespace Sign.Core
 
         public bool CanSign(FileInfo file)
         {
+            ArgumentNullException.ThrowIfNull(file, nameof(file));
+
             return string.Equals(file.Extension, ".nupkg", StringComparison.OrdinalIgnoreCase)
                 || string.Equals(file.Extension, ".snupkg", StringComparison.OrdinalIgnoreCase);
         }

--- a/src/Sign.Core/SignatureProviders/RSAPKCS1SHA256SignatureDescription.cs
+++ b/src/Sign.Core/SignatureProviders/RSAPKCS1SHA256SignatureDescription.cs
@@ -2,9 +2,11 @@ using System.Security.Cryptography;
 
 namespace Sign.Core
 {
-    internal sealed class RSAPKCS1SHA256SignatureDescription : RSAPKCS1SignatureDescription
+    // This type and its default constructor are public because:
+    //   "Algorithms added to CryptoConfig must be accessible from outside their assembly."
+    public sealed class RSAPKCS1SHA256SignatureDescription : RSAPKCS1SignatureDescription
     {
-        internal RSAPKCS1SHA256SignatureDescription()
+        public RSAPKCS1SHA256SignatureDescription()
             : base("SHA256")
         {
         }

--- a/src/Sign.Core/SignatureProviders/RSAPKCS1SHA256SignatureDescription.cs
+++ b/src/Sign.Core/SignatureProviders/RSAPKCS1SHA256SignatureDescription.cs
@@ -4,6 +4,7 @@ namespace Sign.Core
 {
     // This type and its default constructor are public because:
     //   "Algorithms added to CryptoConfig must be accessible from outside their assembly."
+    // See https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.cryptoconfig.addalgorithm?view=net-7.0#exceptions
     public sealed class RSAPKCS1SHA256SignatureDescription : RSAPKCS1SignatureDescription
     {
         public RSAPKCS1SHA256SignatureDescription()

--- a/src/Sign.Core/SignatureProviders/RSAPKCS1SignatureDescription.cs
+++ b/src/Sign.Core/SignatureProviders/RSAPKCS1SignatureDescription.cs
@@ -2,7 +2,7 @@ using System.Security.Cryptography;
 
 namespace Sign.Core
 {
-    internal abstract class RSAPKCS1SignatureDescription : SignatureDescription
+    public abstract class RSAPKCS1SignatureDescription : SignatureDescription
     {
         public RSAPKCS1SignatureDescription(string hashAlgorithmName)
         {

--- a/test/Sign.Core.Test/Containers/ContainerProviderTests.cs
+++ b/test/Sign.Core.Test/Containers/ContainerProviderTests.cs
@@ -176,6 +176,7 @@ namespace Sign.Core.Test
 
         [Theory]
         [InlineData(".appxupload")]
+        [InlineData(".clickonce")]
         [InlineData(".msixupload")]
         [InlineData(".nupkg")]
         [InlineData(".snupkg")]

--- a/test/Sign.Core.Test/SignatureProviders/AppInstallerServiceSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/AppInstallerServiceSignatureProviderTests.cs
@@ -36,6 +36,15 @@ namespace Sign.Core.Test
             Assert.Equal("logger", exception.ParamName);
         }
 
+        [Fact]
+        public void CanSign_WhenFileIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => _provider.CanSign(file: null!));
+
+            Assert.Equal("file", exception.ParamName);
+        }
+
         [Theory]
         [InlineData(".appInstaller")] // Turkish I (U+0049)
         [InlineData(".appinstaller")] // Turkish i (U+0069)

--- a/test/Sign.Core.Test/SignatureProviders/AzureSignToolSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/AzureSignToolSignatureProviderTests.cs
@@ -15,6 +15,15 @@ namespace Sign.Core.Test
                 Mock.Of<ILogger<ISignatureProvider>>());
         }
 
+        [Fact]
+        public void CanSign_WhenFileIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => _provider.CanSign(file: null!));
+
+            Assert.Equal("file", exception.ParamName);
+        }
+
         [Theory]
         [InlineData(".appx")]
         [InlineData(".appxbundle")]

--- a/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
@@ -1,10 +1,13 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace Sign.Core.Test
 {
-    public class ClickOnceSignatureProviderTests
+    public sealed class ClickOnceSignatureProviderTests : IDisposable
     {
+        private readonly DirectoryService _directoryService = new(Mock.Of<ILogger<IDirectoryService>>());
         private readonly ClickOnceSignatureProvider _provider;
 
         public ClickOnceSignatureProviderTests()
@@ -19,10 +22,138 @@ namespace Sign.Core.Test
                 Mock.Of<ILogger<ISignatureProvider>>());
         }
 
-        [Fact]
-        public void CanSign_WhenFileExtensionMatches_ReturnsTrue()
+        public void Dispose()
         {
-            FileInfo file = new("file.clickonce");
+            _directoryService.Dispose();
+        }
+
+        [Fact]
+        public void Constructor_WhenKeyVaultServiceIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new ClickOnceSignatureProvider(
+                    keyVaultService: null!,
+                    Mock.Of<IContainerProvider>(),
+                    Mock.Of<IServiceProvider>(),
+                    Mock.Of<IDirectoryService>(),
+                    Mock.Of<IMageCli>(),
+                    Mock.Of<IManifestSigner>(),
+                    Mock.Of<ILogger<ISignatureProvider>>()));
+
+            Assert.Equal("keyVaultService", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenContainerProviderIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new ClickOnceSignatureProvider(
+                    Mock.Of<IKeyVaultService>(),
+                    containerProvider: null!,
+                    Mock.Of<IServiceProvider>(),
+                    Mock.Of<IDirectoryService>(),
+                    Mock.Of<IMageCli>(),
+                    Mock.Of<IManifestSigner>(),
+                    Mock.Of<ILogger<ISignatureProvider>>()));
+
+            Assert.Equal("containerProvider", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenServiceProviderIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new ClickOnceSignatureProvider(
+                    Mock.Of<IKeyVaultService>(),
+                    Mock.Of<IContainerProvider>(),
+                    serviceProvider: null!,
+                    Mock.Of<IDirectoryService>(),
+                    Mock.Of<IMageCli>(),
+                    Mock.Of<IManifestSigner>(),
+                    Mock.Of<ILogger<ISignatureProvider>>()));
+
+            Assert.Equal("serviceProvider", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenDirectoryServiceIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new ClickOnceSignatureProvider(
+                    Mock.Of<IKeyVaultService>(),
+                    Mock.Of<IContainerProvider>(),
+                    Mock.Of<IServiceProvider>(),
+                    directoryService: null!,
+                    Mock.Of<IMageCli>(),
+                    Mock.Of<IManifestSigner>(),
+                    Mock.Of<ILogger<ISignatureProvider>>()));
+
+            Assert.Equal("directoryService", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenMageCliIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new ClickOnceSignatureProvider(
+                    Mock.Of<IKeyVaultService>(),
+                    Mock.Of<IContainerProvider>(),
+                    Mock.Of<IServiceProvider>(),
+                    Mock.Of<IDirectoryService>(),
+                    mageCli: null!,
+                    Mock.Of<IManifestSigner>(),
+                    Mock.Of<ILogger<ISignatureProvider>>()));
+
+            Assert.Equal("mageCli", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenManifestSignerIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new ClickOnceSignatureProvider(
+                    Mock.Of<IKeyVaultService>(),
+                    Mock.Of<IContainerProvider>(),
+                    Mock.Of<IServiceProvider>(),
+                    Mock.Of<IDirectoryService>(),
+                    Mock.Of<IMageCli>(),
+                    manifestSigner: null!,
+                    Mock.Of<ILogger<ISignatureProvider>>()));
+
+            Assert.Equal("manifestSigner", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenLoggerIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new ClickOnceSignatureProvider(
+                    Mock.Of<IKeyVaultService>(),
+                    Mock.Of<IContainerProvider>(),
+                    Mock.Of<IServiceProvider>(),
+                    Mock.Of<IDirectoryService>(),
+                    Mock.Of<IMageCli>(),
+                    Mock.Of<IManifestSigner>(),
+                    logger: null!));
+
+            Assert.Equal("logger", exception.ParamName);
+        }
+
+        [Fact]
+        public void CanSign_WhenFileIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => _provider.CanSign(file: null!));
+
+            Assert.Equal("file", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(".clickonce")]
+        [InlineData(".CLICKONCE")] // test case insensitivity
+        public void CanSign_WhenFileExtensionMatches_ReturnsTrue(string extension)
+        {
+            FileInfo file = new($"file{extension}");
 
             Assert.True(_provider.CanSign(file));
         }
@@ -36,6 +167,206 @@ namespace Sign.Core.Test
             FileInfo file = new($"file{extension}");
 
             Assert.False(_provider.CanSign(file));
+        }
+
+        [Fact]
+        public async Task SignAsync_WhenFilesIsNull_Throws()
+        {
+            ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                () => _provider.SignAsync(
+                    files: null!,
+                    new SignOptions(HashAlgorithmName.SHA256)));
+
+            Assert.Equal("files", exception.ParamName);
+        }
+
+        [Fact]
+        public async Task SignAsync_WhenOptionsIsNull_Throws()
+        {
+            ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                () => _provider.SignAsync(
+                    Enumerable.Empty<FileInfo>(),
+                    options: null!));
+
+            Assert.Equal("options", exception.ParamName);
+        }
+
+        [Fact]
+        public async Task SignAsync_WhenFilesIsClickOnceFile_Signs()
+        {
+            using (TemporaryDirectory temporaryDirectory = new(_directoryService))
+            {
+                FileInfo clickOnceFile = new(
+                    Path.Combine(
+                        temporaryDirectory.Directory.FullName,
+                        $"{Path.GetRandomFileName()}.clickonce"));
+
+                ContainerSpy containerSpy = new(clickOnceFile);
+
+                FileInfo applicationFile = AddFile(
+                    containerSpy,
+                    temporaryDirectory.Directory,
+                    string.Empty,
+                    "MyApp.application");
+                FileInfo dllDeployFile = AddFile(
+                    containerSpy,
+                    temporaryDirectory.Directory,
+                    string.Empty,
+                    "MyApp_1_0_0_0", "MyApp.dll.deploy");
+                // This is an incomplete manifest --- just enough to satisfy SignAsync(...)'s requirements.
+                FileInfo manifestFile = AddFile(
+                    containerSpy,
+                    temporaryDirectory.Directory,
+                    @"<?xml version=""1.0"" encoding=""utf-8""?>
+<asmv1:assembly xsi:schemaLocation=""urn:schemas-microsoft-com:asm.v1 assembly.adaptive.xsd"" manifestVersion=""1.0"" xmlns:asmv1=""urn:schemas-microsoft-com:asm.v1"" xmlns=""urn:schemas-microsoft-com:asm.v2"" xmlns:asmv2=""urn:schemas-microsoft-com:asm.v2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:co.v1=""urn:schemas-microsoft-com:clickonce.v1"" xmlns:asmv3=""urn:schemas-microsoft-com:asm.v3"" xmlns:dsig=""http://www.w3.org/2000/09/xmldsig#"" xmlns:co.v2=""urn:schemas-microsoft-com:clickonce.v2"">
+  <publisherIdentity name=""CN=Test certificate (DO NOT TRUST), O=unit.test"" />
+</asmv1:assembly>",
+                    "MyApp_1_0_0_0", "MyApp.dll.manifest");
+                FileInfo exeDeployFile = AddFile(
+                    containerSpy,
+                    temporaryDirectory.Directory,
+                    string.Empty,
+                    "MyApp_1_0_0_0", "MyApp.exe.deploy");
+                FileInfo jsonDeployFile = AddFile(
+                    containerSpy,
+                    temporaryDirectory.Directory,
+                    string.Empty,
+                    "MyApp_1_0_0_0", "MyApp.json.deploy");
+
+                SignOptions options = new(
+                    "PublisherName",
+                    "Description",
+                    new Uri("https://description.test"),
+                    HashAlgorithmName.SHA256,
+                    HashAlgorithmName.SHA256,
+                    new Uri("http://timestamp.test"),
+                    matcher: null,
+                    antiMatcher: null);
+
+                using (X509Certificate2 certificate = CreateCertificate())
+                using (RSA privateKey = certificate.GetRSAPrivateKey()!)
+                {
+                    Mock<IKeyVaultService> keyVaultService = new();
+
+                    keyVaultService.Setup(x => x.GetCertificateAsync())
+                        .ReturnsAsync(certificate);
+
+                    keyVaultService.Setup(x => x.GetRsaAsync())
+                        .ReturnsAsync(privateKey);
+
+                    Mock<IContainerProvider> containerProvider = new();
+
+                    containerProvider.Setup(x => x.GetContainer(It.IsAny<FileInfo>()))
+                        .Returns(containerSpy);
+
+                    Mock<IServiceProvider> serviceProvider = new();
+                    AggregatingSignatureProviderSpy aggregatingSignatureProviderSpy = new();
+
+                    serviceProvider.Setup(x => x.GetService(It.IsAny<Type>()))
+                        .Returns(aggregatingSignatureProviderSpy);
+
+                    IDirectoryService directoryService = Mock.Of<IDirectoryService>();
+                    Mock<IMageCli> mageCli = new();
+                    string expectedArgs = $"-update \"{manifestFile.FullName}\" -a sha256RSA -n \"{options.PublisherName}\"";
+                    mageCli.Setup(x => x.RunAsync(
+                            It.Is<string>(args => string.Equals(expectedArgs, args, StringComparison.Ordinal))))
+                        .ReturnsAsync(0);
+
+                    expectedArgs = $"-update \"{applicationFile.FullName}\" -a sha256RSA -n \"{options.PublisherName}\" -appm \"{manifestFile.FullName}\" -pub \"Test certificate (DO NOT TRUST)\"  -SupportURL https://description.test/";
+                    mageCli.Setup(x => x.RunAsync(
+                            It.Is<string>(args => string.Equals(expectedArgs, args, StringComparison.Ordinal))))
+                        .ReturnsAsync(0);
+
+                    Mock<IManifestSigner> manifestSigner = new();
+
+                    manifestSigner.Setup(
+                        x => x.Sign(
+                            It.Is<FileInfo>(fi => ReferenceEquals(manifestFile, fi)),
+                            It.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
+                            It.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
+                            It.Is<SignOptions>(o => ReferenceEquals(options, o))));
+
+                    manifestSigner.Setup(
+                        x => x.Sign(
+                            It.Is<FileInfo>(fi => ReferenceEquals(applicationFile, fi)),
+                            It.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
+                            It.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
+                            It.Is<SignOptions>(o => ReferenceEquals(options, o))));
+
+                    ILogger<ISignatureProvider> logger = Mock.Of<ILogger<ISignatureProvider>>();
+                    ClickOnceSignatureProvider provider = new(
+                        keyVaultService.Object,
+                        containerProvider.Object,
+                        serviceProvider.Object,
+                        directoryService,
+                        mageCli.Object,
+                        manifestSigner.Object,
+                        logger);
+
+                    await provider.SignAsync(new[] { clickOnceFile }, options);
+
+                    Assert.Equal(1, containerSpy.OpenAsync_CallCount);
+                    Assert.Equal(0, containerSpy.GetFilesWithMatcher_CallCount);
+                    Assert.Equal(2, containerSpy.GetFiles_CallCount);
+                    Assert.Equal(1, containerSpy.SaveAsync_CallCount);
+                    Assert.Equal(1, containerSpy.Dispose_CallCount);
+
+                    // Verify that files have been renamed back.
+                    foreach (FileInfo file in containerSpy.Files)
+                    {
+                        file.Refresh();
+
+                        Assert.True(file.Exists);
+                    }
+
+                    Assert.Equal(3, aggregatingSignatureProviderSpy.FilesSubmittedForSigning.Count);
+                    Assert.Collection(
+                        aggregatingSignatureProviderSpy.FilesSubmittedForSigning,
+                        file => Assert.Equal(
+                            Path.Combine(dllDeployFile.DirectoryName!, Path.GetFileNameWithoutExtension(dllDeployFile.Name)),
+                            file.FullName),
+                        file => Assert.Equal(
+                            Path.Combine(exeDeployFile.DirectoryName!, Path.GetFileNameWithoutExtension(exeDeployFile.Name)),
+                            file.FullName),
+                        file => Assert.Equal(
+                            Path.Combine(jsonDeployFile.DirectoryName!, Path.GetFileNameWithoutExtension(jsonDeployFile.Name)),
+                            file.FullName));
+
+                    mageCli.VerifyAll();
+                    manifestSigner.VerifyAll();
+                }
+            }
+        }
+
+        private static FileInfo AddFile(
+            ContainerSpy containerSpy,
+            DirectoryInfo directory,
+            string fileContent,
+            params string[] fileParts)
+        {
+            string[] parts = new[] { directory.FullName }.Concat(fileParts).ToArray();
+            FileInfo file = new(Path.Combine(parts));
+
+            // The file needs to exist because it will be renamed.
+            file.Directory!.Create();
+            File.WriteAllText(file.FullName, fileContent);
+
+            containerSpy.Files.Add(file);
+
+            return file;
+        }
+
+        private static X509Certificate2 CreateCertificate()
+        {
+            RSA keyPair = RSA.Create(keySizeInBits: 3072);
+            CertificateRequest request = new(
+                "CN=Common Name, O=Organization, L=City, S=State, C=Country",
+                keyPair,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+            DateTimeOffset now = DateTimeOffset.Now;
+
+            return request.CreateSelfSigned(now.AddMinutes(-5), now.AddMinutes(5));
         }
     }
 }

--- a/test/Sign.Core.Test/SignatureProviders/NuGetSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/NuGetSignatureProviderTests.cs
@@ -51,6 +51,15 @@ namespace Sign.Core.Test
             Assert.Equal("logger", exception.ParamName);
         }
 
+        [Fact]
+        public void CanSign_WhenFileIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => _provider.CanSign(file: null!));
+
+            Assert.Equal("file", exception.ParamName);
+        }
+
         [Theory]
         [InlineData(".nupkg")]
         [InlineData(".NUPKG")] // test case insensitivity

--- a/test/Sign.Core.Test/SignatureProviders/VsixSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/VsixSignatureProviderTests.cs
@@ -51,6 +51,15 @@ namespace Sign.Core.Test
             Assert.Equal("logger", exception.ParamName);
         }
 
+        [Fact]
+        public void CanSign_WhenFileIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => _provider.CanSign(file: null!));
+
+            Assert.Equal("file", exception.ParamName);
+        }
+
         [Theory]
         [InlineData(".vsix")]
         [InlineData(".VSIX")] // test case insensitivity

--- a/test/Sign.Core.Test/TestInfrastructure/AggregatingSignatureProviderSpy.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/AggregatingSignatureProviderSpy.cs
@@ -1,0 +1,19 @@
+namespace Sign.Core.Test
+{
+    internal sealed class AggregatingSignatureProviderSpy : IAggregatingSignatureProvider
+    {
+        internal List<FileInfo> FilesSubmittedForSigning { get; } = new();
+
+        public bool CanSign(FileInfo file)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SignAsync(IEnumerable<FileInfo> files, SignOptions options)
+        {
+            FilesSubmittedForSigning.AddRange(files);
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/469.

This change fixes the 3 bugs described in the issue and adds unit tests and, in particular, one unit test which thoroughly verifies `ClickOnceSignatureProvider.SignAsync(...)` behavior.

Note that adding `.clickonce` file extension as a supported ZIP container extension follows current behavior in the existing SignService CLI but should be viewed as a temporary change.  For details see https://github.com/dotnet/sign/issues/470.