### PR TITLE
CLI:  block x86 with useful error message

### DIFF
--- a/src/Sign.Cli/Program.cs
+++ b/src/Sign.Cli/Program.cs
@@ -13,6 +13,13 @@ namespace Sign.Cli
     {
         internal static async Task<int> Main(string[] args)
         {
+            if (!Environment.Is64BitProcess)
+            {
+                Console.Error.WriteLine("Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.");
+
+                return ExitCode.Failed;
+            }
+
             string directory = Path.GetDirectoryName(Environment.ProcessPath!)!;
             string baseDirectory = Path.Combine(directory, "tools", "SDK", "x64");
 
@@ -26,13 +33,6 @@ namespace Sign.Cli
             Kernel32.SetDllDirectoryW(baseDirectory);
             Kernel32.LoadLibraryW($@"{baseDirectory}\wintrust.dll");
             Kernel32.LoadLibraryW($@"{baseDirectory}\mssign32.dll");
-
-            if (!Environment.Is64BitProcess)
-            {
-                Console.Error.WriteLine("Only Windows x64 is supported at this time.  See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.");
-
-                return ExitCode.Failed;
-            }
 
             // This is here because we need to P/Invoke into clr.dll for _AxlPublicKeyBlobToPublicKeyToken             
             string windir = Environment.GetEnvironmentVariable("windir")!;

--- a/src/Sign.Cli/Program.cs
+++ b/src/Sign.Cli/Program.cs
@@ -27,6 +27,13 @@ namespace Sign.Cli
             Kernel32.LoadLibraryW($@"{baseDirectory}\wintrust.dll");
             Kernel32.LoadLibraryW($@"{baseDirectory}\mssign32.dll");
 
+            if (!Environment.Is64BitProcess)
+            {
+                Console.Error.WriteLine("Only Windows x64 is supported at this time.  See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.");
+
+                return ExitCode.Failed;
+            }
+
             // This is here because we need to P/Invoke into clr.dll for _AxlPublicKeyBlobToPublicKeyToken             
             string windir = Environment.GetEnvironmentVariable("windir")!;
             string netfxDir = $@"{windir}\Microsoft.NET\Framework64\v4.0.30319";


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/475.

The upcoming preview explicitly only supports Windows x64.  This change blocks x86 with a link to upvote support for it.