### PR TITLE
CLI:  add license headers and enable analyzer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,7 @@ dotnet_diagnostic.CA1304.severity = warning
 dotnet_diagnostic.CA1310.severity = warning
 # CA1311: Specify a culture or use an invariant version
 dotnet_diagnostic.CA1311.severity = warning
+
+# IDE0073: File header
+dotnet_diagnostic.IDE0073.severity = warning
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.\nSee the LICENSE.txt file in the project root for more information.

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,0 +1,95 @@
+.NET Core uses third-party libraries or other resources that may be
+distributed under licenses different than the .NET Core software.
+
+Attributions and license notices for test cases originally authored by
+third parties can be found in the respective test directories.
+
+In the event that we accidentally failed to list a required notice, please
+bring it to our attention. Post an issue or email us:
+
+           dotnet@microsoft.com
+
+The attached notices are provided for information only.
+
+License notice for .NET Reference Source
+-------------------------------
+
+﻿The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.
+
+Available at https://github.com/microsoft/referencesource/blob/master/LICENSE.txt
+
+
+License notice for FiddlerCert
+-------------------------------
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Kevin Jones
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Available at https://github.com/vcsjones/FiddlerCert/blob/main/license.txt
+
+
+License notice for Wyam
+-------------------------------
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Dave Glick
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Available at https://github.com/Wyamio/Wyam/blob/develop/LICENSE

--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;

--- a/src/Sign.Cli/CodeCommand.cs
+++ b/src/Sign.Cli/CodeCommand.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Security.Cryptography;

--- a/src/Sign.Cli/Kernel32.cs
+++ b/src/Sign.Cli/Kernel32.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 

--- a/src/Sign.Cli/Program.cs
+++ b/src/Sign.Cli/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;

--- a/src/Sign.Cli/SignCommand.cs
+++ b/src/Sign.Cli/SignCommand.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.CommandLine;
 
 namespace Sign.Cli

--- a/src/Sign.Core/Containers/AppxBundleContainer.cs
+++ b/src/Sign.Core/Containers/AppxBundleContainer.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 

--- a/src/Sign.Core/Containers/AppxContainer.cs
+++ b/src/Sign.Core/Containers/AppxContainer.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography.X509Certificates;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;

--- a/src/Sign.Core/Containers/Container.cs
+++ b/src/Sign.Core/Containers/Container.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 

--- a/src/Sign.Core/Containers/ContainerProvider.cs
+++ b/src/Sign.Core/Containers/ContainerProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 
 namespace Sign.Core

--- a/src/Sign.Core/Containers/IContainer.cs
+++ b/src/Sign.Core/Containers/IContainer.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Sign.Core

--- a/src/Sign.Core/Containers/IContainerProvider.cs
+++ b/src/Sign.Core/Containers/IContainerProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal interface IContainerProvider

--- a/src/Sign.Core/Containers/ZipContainer.cs
+++ b/src/Sign.Core/Containers/ZipContainer.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.IO.Compression;
 using Microsoft.Extensions.Logging;
 

--- a/src/Sign.Core/ExitCode.cs
+++ b/src/Sign.Core/ExitCode.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal static class ExitCode

--- a/src/Sign.Core/FileList/FileListReader.cs
+++ b/src/Sign.Core/FileList/FileListReader.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Sign.Core

--- a/src/Sign.Core/FileList/FileMatcher.cs
+++ b/src/Sign.Core/FileList/FileMatcher.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 

--- a/src/Sign.Core/FileList/Globber.cs
+++ b/src/Sign.Core/FileList/Globber.cs
@@ -1,3 +1,4 @@
+#pragma warning disable IDE0073 // The file header does not match the required text
 // The MIT License (MIT)
 // 
 // Copyright (c) 2014 Dave Glick

--- a/src/Sign.Core/FileList/IFileListReader.cs
+++ b/src/Sign.Core/FileList/IFileListReader.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Sign.Core

--- a/src/Sign.Core/FileList/IFileMatcher.cs
+++ b/src/Sign.Core/FileList/IFileMatcher.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 

--- a/src/Sign.Core/FileList/IMatcherFactory.cs
+++ b/src/Sign.Core/FileList/IMatcherFactory.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Sign.Core

--- a/src/Sign.Core/FileList/MatcherFactory.cs
+++ b/src/Sign.Core/FileList/MatcherFactory.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Sign.Core

--- a/src/Sign.Core/FileSystem/DirectoryService.cs
+++ b/src/Sign.Core/FileSystem/DirectoryService.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 

--- a/src/Sign.Core/FileSystem/FileInfoComparer.cs
+++ b/src/Sign.Core/FileSystem/FileInfoComparer.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Diagnostics.CodeAnalysis;
 
 namespace Sign.Core

--- a/src/Sign.Core/FileSystem/FileMetadataService.cs
+++ b/src/Sign.Core/FileSystem/FileMetadataService.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal sealed class FileMetadataService : IFileMetadataService

--- a/src/Sign.Core/FileSystem/IDirectoryService.cs
+++ b/src/Sign.Core/FileSystem/IDirectoryService.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal interface IDirectoryService : IDisposable

--- a/src/Sign.Core/FileSystem/IFileMetadataService.cs
+++ b/src/Sign.Core/FileSystem/IFileMetadataService.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal interface IFileMetadataService

--- a/src/Sign.Core/FileSystem/ITemporaryDirectory.cs
+++ b/src/Sign.Core/FileSystem/ITemporaryDirectory.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal interface ITemporaryDirectory : IDisposable

--- a/src/Sign.Core/FileSystem/TemporaryDirectory.cs
+++ b/src/Sign.Core/FileSystem/TemporaryDirectory.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal sealed class TemporaryDirectory : ITemporaryDirectory

--- a/src/Sign.Core/ISigner.cs
+++ b/src/Sign.Core/ISigner.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using Azure.Core;
 

--- a/src/Sign.Core/KeyVault/IKeyVaultService.cs
+++ b/src/Sign.Core/KeyVault/IKeyVaultService.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Azure.Core;

--- a/src/Sign.Core/KeyVault/KeyVaultService.cs
+++ b/src/Sign.Core/KeyVault/KeyVaultService.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Azure;

--- a/src/Sign.Core/Native/Kernel32.cs
+++ b/src/Sign.Core/Native/Kernel32.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 

--- a/src/Sign.Core/Native/Ntdsapi.cs
+++ b/src/Sign.Core/Native/Ntdsapi.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Runtime.InteropServices;
 
 namespace Sign.Core

--- a/src/Sign.Core/Native/mansign.cs
+++ b/src/Sign.Core/Native/mansign.cs
@@ -1,3 +1,4 @@
+#pragma warning disable IDE0073 // The file header does not match the required text
 // ==++==
 // 
 //   Copyright (c) Microsoft Corporation.  All rights reserved.
@@ -5,10 +6,35 @@
 // ==--==
 
 //
-// mansign.cs
+// The MIT License (MIT)
+//
+// Copyright (c) Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy 
+// of this software and associated documentation files (the "Software"), to deal 
+// in the Software without restriction, including without limitation the rights 
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+// copies of the Software, and to permit persons to whom the Software is 
+// furnished to do so, subject to the following conditions: 
+//
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software. 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+// SOFTWARE.
 //
 
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
+using System.Text;
+using System.Xml;
 
 using _FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 

--- a/src/Sign.Core/Native/mansign2.cs
+++ b/src/Sign.Core/Native/mansign2.cs
@@ -1,3 +1,4 @@
+#pragma warning disable IDE0073 // The file header does not match the required text
 // ==++==
 // 
 //   Copyright (c) Microsoft Corporation.  All rights reserved.
@@ -5,7 +6,27 @@
 // ==--==
 
 //
-// mansign.cs
+// The MIT License (MIT)
+//
+// Copyright (c) Microsoft Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy 
+// of this software and associated documentation files (the "Software"), to deal 
+// in the Software without restriction, including without limitation the rights 
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+// copies of the Software, and to permit persons to whom the Software is 
+// furnished to do so, subject to the following conditions: 
+//
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software. 
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+// SOFTWARE.
 //
 
 // From https://github.com/Microsoft/referencesource/blob/7de0d30c7c5ef56ab60fee41fcdb50005d24979a/inc/mansign2.cs

--- a/src/Sign.Core/ServiceProvider.cs
+++ b/src/Sign.Core/ServiceProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 

--- a/src/Sign.Core/SignatureProviders/AggregatingSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/AggregatingSignatureProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Sign.Core

--- a/src/Sign.Core/SignatureProviders/AppInstallerServiceSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/AppInstallerServiceSignatureProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography.X509Certificates;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;

--- a/src/Sign.Core/SignatureProviders/AzureSignToolSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/AzureSignToolSignatureProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using AzureSign.Core;

--- a/src/Sign.Core/SignatureProviders/ClickOnceSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/ClickOnceSignatureProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Xml.Linq;

--- a/src/Sign.Core/SignatureProviders/DefaultSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/DefaultSignatureProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Sign.Core

--- a/src/Sign.Core/SignatureProviders/DistinguishedNameParser.cs
+++ b/src/Sign.Core/SignatureProviders/DistinguishedNameParser.cs
@@ -1,3 +1,4 @@
+#pragma warning disable IDE0073 // The file header does not match the required text
 // The MIT License (MIT)
 // 
 // Copyright (c) 2015 Kevin Jones

--- a/src/Sign.Core/SignatureProviders/IAggregatingSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/IAggregatingSignatureProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal interface IAggregatingSignatureProvider : ISignatureProvider

--- a/src/Sign.Core/SignatureProviders/IAzureSignToolSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/IAzureSignToolSignatureProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal interface IAzureSignToolSignatureProvider : ISignatureProvider

--- a/src/Sign.Core/SignatureProviders/IDefaultSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/IDefaultSignatureProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal interface IDefaultSignatureProvider

--- a/src/Sign.Core/SignatureProviders/IManifestSigner.cs
+++ b/src/Sign.Core/SignatureProviders/IManifestSigner.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 

--- a/src/Sign.Core/SignatureProviders/ISignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/ISignatureProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal interface ISignatureProvider

--- a/src/Sign.Core/SignatureProviders/ManifestSigner.cs
+++ b/src/Sign.Core/SignatureProviders/ManifestSigner.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Deployment.Internal.CodeSigning;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;

--- a/src/Sign.Core/SignatureProviders/NuGetSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/NuGetSignatureProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;

--- a/src/Sign.Core/SignatureProviders/RSAPKCS1SHA256SignatureDescription.cs
+++ b/src/Sign.Core/SignatureProviders/RSAPKCS1SHA256SignatureDescription.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 
 namespace Sign.Core

--- a/src/Sign.Core/SignatureProviders/RSAPKCS1SignatureDescription.cs
+++ b/src/Sign.Core/SignatureProviders/RSAPKCS1SignatureDescription.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 
 namespace Sign.Core

--- a/src/Sign.Core/SignatureProviders/RetryingSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/RetryingSignatureProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;

--- a/src/Sign.Core/SignatureProviders/SignOptions.cs
+++ b/src/Sign.Core/SignatureProviders/SignOptions.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using Microsoft.Extensions.FileSystemGlobbing;
 

--- a/src/Sign.Core/SignatureProviders/VsixSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/VsixSignatureProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;

--- a/src/Sign.Core/Signer.cs
+++ b/src/Sign.Core/Signer.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Diagnostics;
 using System.Security.Authentication;
 using System.Security.Cryptography;

--- a/src/Sign.Core/Tools/CliTool.cs
+++ b/src/Sign.Core/Tools/CliTool.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 

--- a/src/Sign.Core/Tools/ICliTool.cs
+++ b/src/Sign.Core/Tools/ICliTool.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal interface ICliTool : ITool

--- a/src/Sign.Core/Tools/IMageCli.cs
+++ b/src/Sign.Core/Tools/IMageCli.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal interface IMageCli : ICliTool

--- a/src/Sign.Core/Tools/IMakeAppxCli.cs
+++ b/src/Sign.Core/Tools/IMakeAppxCli.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal interface IMakeAppxCli : ICliTool

--- a/src/Sign.Core/Tools/INuGetSignTool.cs
+++ b/src/Sign.Core/Tools/INuGetSignTool.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 

--- a/src/Sign.Core/Tools/IOpenVsixSignTool.cs
+++ b/src/Sign.Core/Tools/IOpenVsixSignTool.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using OpenVsixSignTool.Core;
 
 namespace Sign.Core

--- a/src/Sign.Core/Tools/ITool.cs
+++ b/src/Sign.Core/Tools/ITool.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal interface ITool

--- a/src/Sign.Core/Tools/IToolConfigurationProvider.cs
+++ b/src/Sign.Core/Tools/IToolConfigurationProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal interface IToolConfigurationProvider

--- a/src/Sign.Core/Tools/MageCli.cs
+++ b/src/Sign.Core/Tools/MageCli.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 
 namespace Sign.Core

--- a/src/Sign.Core/Tools/MakeAppxCli.cs
+++ b/src/Sign.Core/Tools/MakeAppxCli.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 
 namespace Sign.Core

--- a/src/Sign.Core/Tools/NuGetSignTool.cs
+++ b/src/Sign.Core/Tools/NuGetSignTool.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;

--- a/src/Sign.Core/Tools/OpenVsixSignTool.cs
+++ b/src/Sign.Core/Tools/OpenVsixSignTool.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 using OpenVsixSignTool.Core;
 

--- a/src/Sign.Core/Tools/Tool.cs
+++ b/src/Sign.Core/Tools/Tool.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 
 namespace Sign.Core

--- a/src/Sign.Core/Tools/ToolConfigurationProvider.cs
+++ b/src/Sign.Core/Tools/ToolConfigurationProvider.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core
 {
     internal sealed class ToolConfigurationProvider : IToolConfigurationProvider

--- a/test/Sign.Cli.Test/AzureKeyVaultCommandTests.cs
+++ b/test/Sign.Cli.Test/AzureKeyVaultCommandTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Parsing;

--- a/test/Sign.Cli.Test/CodeCommandTests.cs
+++ b/test/Sign.Cli.Test/CodeCommandTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.CommandLine;
 
 namespace Sign.Cli.Test

--- a/test/Sign.Cli.Test/Options/BaseDirectoryOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/BaseDirectoryOptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.CommandLine.Parsing;
 
 namespace Sign.Cli.Test

--- a/test/Sign.Cli.Test/Options/DescriptionOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/DescriptionOptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Cli.Test
 {
     public class DescriptionOptionTests : OptionTests<string>

--- a/test/Sign.Cli.Test/Options/DescriptionUrlOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/DescriptionUrlOptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Cli.Test
 {
     public class DescriptionUrlOptionTests : UriOptionTests

--- a/test/Sign.Cli.Test/Options/DirectoryInfoOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/DirectoryInfoOptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.CommandLine;
 
 namespace Sign.Cli.Test

--- a/test/Sign.Cli.Test/Options/FileDigestOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/FileDigestOptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Cli.Test
 {
     public class FileDigestOptionTests : HashAlgorithmNameOptionTests

--- a/test/Sign.Cli.Test/Options/HashAlgorithmNameOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/HashAlgorithmNameOptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Security.Cryptography;

--- a/test/Sign.Cli.Test/Options/Int32OptionTests.cs
+++ b/test/Sign.Cli.Test/Options/Int32OptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.CommandLine;
 
 namespace Sign.Cli.Test

--- a/test/Sign.Cli.Test/Options/MaxConcurrencyOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/MaxConcurrencyOptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.CommandLine.Parsing;
 
 namespace Sign.Cli.Test

--- a/test/Sign.Cli.Test/Options/OptionTests.cs
+++ b/test/Sign.Cli.Test/Options/OptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.CommandLine;
 using System.CommandLine.Parsing;
 

--- a/test/Sign.Cli.Test/Options/OutputOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/OutputOptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Cli.Test
 {
     public class OutputOptionTests : OptionTests<string?>

--- a/test/Sign.Cli.Test/Options/PublisherNameOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/PublisherNameOptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Cli.Test
 {
     public class PublisherNameOptionTests : OptionTests<string?>

--- a/test/Sign.Cli.Test/Options/TimestampDigestOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/TimestampDigestOptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Cli.Test
 {
     public class TimestampDigestOptionTests : HashAlgorithmNameOptionTests

--- a/test/Sign.Cli.Test/Options/TimestampUrlOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/TimestampUrlOptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Cli.Test
 {
     public class TimestampUrlOptionTests : UriOptionTests

--- a/test/Sign.Cli.Test/Options/UriOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/UriOptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.CommandLine;
 
 namespace Sign.Cli.Test

--- a/test/Sign.Cli.Test/Options/VerbosityOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/VerbosityOptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 
 namespace Sign.Cli.Test

--- a/test/Sign.Cli.Test/SignCommandTests.cs
+++ b/test/Sign.Cli.Test/SignCommandTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.CommandLine;
 using System.CommandLine.Parsing;
 

--- a/test/Sign.Cli.Test/Usings.cs
+++ b/test/Sign.Cli.Test/Usings.cs
@@ -1,1 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 global using Xunit;

--- a/test/Sign.Core.Test/Containers/AppxBundleContainerTests.cs
+++ b/test/Sign.Core.Test/Containers/AppxBundleContainerTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/test/Sign.Core.Test/Containers/AppxContainerTests.cs
+++ b/test/Sign.Core.Test/Containers/AppxContainerTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/test/Sign.Core.Test/Containers/ContainerProviderTests.cs
+++ b/test/Sign.Core.Test/Containers/ContainerProviderTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/test/Sign.Core.Test/Containers/ZipContainerTests.cs
+++ b/test/Sign.Core.Test/Containers/ZipContainerTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.IO.Compression;
 using System.Text;
 using Microsoft.Extensions.Logging;

--- a/test/Sign.Core.Test/FileList/FileListReaderTests.cs
+++ b/test/Sign.Core.Test/FileList/FileListReaderTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Sign.Core.Test

--- a/test/Sign.Core.Test/FileList/FileMatcherTests.cs
+++ b/test/Sign.Core.Test/FileList/FileMatcherTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 

--- a/test/Sign.Core.Test/FileList/MatcherFactoryTests.cs
+++ b/test/Sign.Core.Test/FileList/MatcherFactoryTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Sign.Core.Test

--- a/test/Sign.Core.Test/FileSystem/DirectoryServiceTests.cs
+++ b/test/Sign.Core.Test/FileSystem/DirectoryServiceTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/test/Sign.Core.Test/FileSystem/FileInfoComparerTests.cs
+++ b/test/Sign.Core.Test/FileSystem/FileInfoComparerTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core.Test
 {
     public class FileInfoComparerTests

--- a/test/Sign.Core.Test/FileSystem/FileMetadataServiceTests.cs
+++ b/test/Sign.Core.Test/FileSystem/FileMetadataServiceTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core.Test
 {
     public class FileMetadataServiceTests

--- a/test/Sign.Core.Test/FileSystem/TemporaryDirectoryTests.cs
+++ b/test/Sign.Core.Test/FileSystem/TemporaryDirectoryTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core.Test
 {
     public class TemporaryDirectoryTests

--- a/test/Sign.Core.Test/ServiceProviderTests.cs
+++ b/test/Sign.Core.Test/ServiceProviderTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 

--- a/test/Sign.Core.Test/SignatureProviders/AggregatingSignatureProviderTests.Containers.cs
+++ b/test/Sign.Core.Test/SignatureProviders/AggregatingSignatureProviderTests.Containers.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core.Test
 {
     public partial class AggregatingSignatureProviderTests

--- a/test/Sign.Core.Test/SignatureProviders/AggregatingSignatureProviderTests.PortableExecutableFiles.cs
+++ b/test/Sign.Core.Test/SignatureProviders/AggregatingSignatureProviderTests.PortableExecutableFiles.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core.Test
 {
     public partial class AggregatingSignatureProviderTests

--- a/test/Sign.Core.Test/SignatureProviders/AggregatingSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/AggregatingSignatureProviderTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Moq;

--- a/test/Sign.Core.Test/SignatureProviders/AppInstallerServiceSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/AppInstallerServiceSignatureProviderTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/test/Sign.Core.Test/SignatureProviders/AzureSignToolSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/AzureSignToolSignatureProviderTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;

--- a/test/Sign.Core.Test/SignatureProviders/DefaultSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/DefaultSignatureProviderTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;

--- a/test/Sign.Core.Test/SignatureProviders/DistinguishedNameParserTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/DistinguishedNameParserTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core.Test
 {
     public class DistinguishedNameParserTests

--- a/test/Sign.Core.Test/SignatureProviders/NuGetSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/NuGetSignatureProviderTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/test/Sign.Core.Test/SignatureProviders/RSAPKCS1SHA256SignatureDescriptionTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/RSAPKCS1SHA256SignatureDescriptionTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using System.Security.Cryptography;
 
 namespace Sign.Core.Test

--- a/test/Sign.Core.Test/SignatureProviders/VsixSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/VsixSignatureProviderTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/test/Sign.Core.Test/TestInfrastructure/AggregatingSignatureProviderSpy.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/AggregatingSignatureProviderSpy.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core.Test
 {
     internal sealed class AggregatingSignatureProviderSpy : IAggregatingSignatureProvider

--- a/test/Sign.Core.Test/TestInfrastructure/AggregatingSignatureProviderTest.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/AggregatingSignatureProviderTest.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 using Moq;

--- a/test/Sign.Core.Test/TestInfrastructure/ContainerProviderStub.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/ContainerProviderStub.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/test/Sign.Core.Test/TestInfrastructure/ContainerSpy.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/ContainerSpy.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Sign.Core.Test

--- a/test/Sign.Core.Test/TestInfrastructure/FileMetadataServiceStub.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/FileMetadataServiceStub.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core.Test
 {
     internal sealed class FileMetadataServiceStub : IFileMetadataService

--- a/test/Sign.Core.Test/TestInfrastructure/SignatureProviderSpy.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/SignatureProviderSpy.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/test/Sign.Core.Test/TestInfrastructure/TemporaryFile.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/TemporaryFile.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core.Test
 {
     internal sealed class TemporaryFile : IDisposable

--- a/test/Sign.Core.Test/Tools/ToolConfigurationProviderTests.cs
+++ b/test/Sign.Core.Test/Tools/ToolConfigurationProviderTests.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 namespace Sign.Core.Test
 {
     public class ToolConfigurationProviderTests

--- a/test/Sign.Core.Test/Usings.cs
+++ b/test/Sign.Core.Test/Usings.cs
@@ -1,1 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
 global using Xunit;


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/449.

This change adds license headers to all files and enables an analyzer to check for missing/incorrect headers.

Note:  this source branch is based on a target branch which currently has an open PR (https://github.com/dotnet/sign/pull/471).  The reason is that these PR's are intended to be merged in dependency order and chained branching simplifies PR diffs.  Once the target branch merges into the cli branch, I will retarget this PR at the cli branch.