### PR TITLE
CLI:  fix CA1305

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,8 @@ csharp_prefer_simple_using_statement = false
 
 # CA1304: Specify CultureInfo
 dotnet_diagnostic.CA1304.severity = warning
+# CA1305: Specify IFormatProvider
+dotnet_diagnostic.CA1305.severity = warning
 # CA1310: Specify StringComparison for correctness
 dotnet_diagnostic.CA1310.severity = warning
 # CA1311: Specify a culture or use an invariant version

--- a/src/Sign.Core/FileList/Globber.cs
+++ b/src/Sign.Core/FileList/Globber.cs
@@ -22,8 +22,8 @@
 // SOFTWARE.
 
 #pragma warning disable CS8600
-#pragma warning disable CS8602
 
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.FileSystemGlobbing;
 
@@ -183,8 +183,8 @@ namespace Sign.Core
             {
                 // console.error("numset", numset[1], numset[2])
                 var suf = ExpandBraces(pattern.Substring(numset.Length)).ToList();
-                int start = int.Parse(numset.Groups[1].Value),
-                end = int.Parse(numset.Groups[2].Value),
+                int start = int.Parse(numset.Groups[1].Value, NumberFormatInfo.CurrentInfo),
+                end = int.Parse(numset.Groups[2].Value, NumberFormatInfo.CurrentInfo),
                 inc = start > end ? -1 : 1;
                 var retVal = new List<string>();
                 for (var w = start; w != (end + inc); w += inc)


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/450.

This change resolves 2 [CA1305](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1305) warnings and enables an analyzer to catch regressions.

Note that this code change has no runtime behavioral impact.  [`int.Parse(string)` uses `NumberFormatInfo.CurrentInfo` behind the scenes](https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/Int32.cs,134). 