### PR TITLE
CLI:  add 3rd party notices file to package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,10 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RepositoryRootDirectory>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'README.md'))</RepositoryRootDirectory>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(DotNetBuildOffline)' == 'true'">
     <!--
       Arcade has a special version prop for CodeAnalysis.CSharp in GenFacades

--- a/src/Sign.Cli/Sign.Cli.csproj
+++ b/src/Sign.Cli/Sign.Cli.csproj
@@ -67,6 +67,10 @@
       <Pack>true</Pack>
       <PackagePath>tools\$(TargetFramework)\any\tools</PackagePath>
     </Content>
+    <Content Include="$(RepositoryRootDirectory)\THIRD-PARTY-NOTICES.txt">
+      <Pack>true</Pack>
+      <PackagePath>\</PackagePath>
+    </Content>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/483.

This change adds https://github.com/dotnet/sign/blob/cli/THIRD-PARTY-NOTICES.txt to the root of the package.