### PR TITLE
CLI: add license to package

### DIFF
--- a/src/Sign.Cli/Sign.Cli.csproj
+++ b/src/Sign.Cli/Sign.Cli.csproj
@@ -67,6 +67,10 @@
       <Pack>true</Pack>
       <PackagePath>tools\$(TargetFramework)\any\tools</PackagePath>
     </Content>
+    <Content Include="$(RepositoryRootDirectory)\LICENSE.txt">
+      <Pack>true</Pack>
+      <PackagePath>\</PackagePath>
+    </Content>
     <Content Include="$(RepositoryRootDirectory)\THIRD-PARTY-NOTICES.txt">
       <Pack>true</Pack>
       <PackagePath>\</PackagePath>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/496.

This change adds the license file to the root of the NuGet package.