### PR TITLE
CLI:  sign 3rd party libraries

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -8,4 +8,14 @@
     <ItemsToSign Remove="@(ItemsToSign)" />
     <ItemsToSign Include="$(ArtifactsShippingPackagesDir)/*.nupkg" />
   </ItemGroup>
+
+  <!--
+    These 3rd-party libraries are already 3rd party signed; however, we must add a second signature with this certificate.
+  -->
+  <ItemGroup>
+    <FileSignInfo Include="AzureSign.Core.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="OpenVsixSignTool.Core.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="RSAKeyVaultProvider.dll" CertificateName="3PartySHA2" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/499.

All signable files must be signed.  In the case of already signed 3rd party files, we need to add a second (Microsoft 3rd party) signature.