### PR TITLE
CLI: warn if certificate is not time valid

### DIFF
--- a/src/Sign.Core/Certificates/CertificateVerifier.cs
+++ b/src/Sign.Core/Certificates/CertificateVerifier.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Extensions.Logging;
+
+namespace Sign.Core
+{
+    internal sealed class CertificateVerifier : ICertificateVerifier
+    {
+        private readonly ILogger _logger;
+
+        // Dependency injection requires a public constructor.
+        public CertificateVerifier(ILogger<ICertificateVerifier> logger)
+        {
+            ArgumentNullException.ThrowIfNull(logger, nameof(logger));
+
+            _logger = logger;
+        }
+
+        public void Verify(X509Certificate2 certificate)
+        {
+            ArgumentNullException.ThrowIfNull(certificate, nameof(certificate));
+
+            DateTime now = DateTime.Now;
+
+            if (now < certificate.NotBefore || certificate.NotAfter < now)
+            {
+                _logger.LogWarning("The certificate is not time valid.");
+            }
+        }
+    }
+}

--- a/src/Sign.Core/Certificates/CertificateVerifier.cs
+++ b/src/Sign.Core/Certificates/CertificateVerifier.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
@@ -25,9 +25,16 @@ namespace Sign.Core
 
             DateTime now = DateTime.Now;
 
-            if (now < certificate.NotBefore || certificate.NotAfter < now)
+            if (now < certificate.NotBefore)
             {
-                _logger.LogWarning("The certificate is not time valid.");
+                // See https://github.com/dotnet/roslyn-analyzers/issues/5626
+#pragma warning disable CA2254 // Template should be a static expression
+                _logger.LogWarning(Resources.CertificateIsNotYetTimeValid);
+            }
+            else if (certificate.NotAfter < now)
+            {
+                _logger.LogWarning(Resources.CertificateIsExpired);
+#pragma warning restore CA2254 // Template should be a static expression
             }
         }
     }

--- a/src/Sign.Core/Certificates/ICertificateVerifier.cs
+++ b/src/Sign.Core/Certificates/ICertificateVerifier.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace Sign.Core
+{
+    internal interface ICertificateVerifier
+    {
+        void Verify(X509Certificate2 certificate);
+    }
+}

--- a/src/Sign.Core/Certificates/ICertificateVerifier.cs
+++ b/src/Sign.Core/Certificates/ICertificateVerifier.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 

--- a/src/Sign.Core/Resources.Designer.cs
+++ b/src/Sign.Core/Resources.Designer.cs
@@ -61,6 +61,24 @@ namespace Sign.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The certificate is expired..
+        /// </summary>
+        internal static string CertificateIsExpired {
+            get {
+                return ResourceManager.GetString("CertificateIsExpired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The certificate is not yet time valid..
+        /// </summary>
+        internal static string CertificateIsNotYetTimeValid {
+            get {
+                return ResourceManager.GetString("CertificateIsNotYetTimeValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The value cannot be an empty string..
         /// </summary>
         internal static string ValueCannotBeEmptyString {

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CertificateIsExpired" xml:space="preserve">
+    <value>The certificate is expired.</value>
+  </data>
+  <data name="CertificateIsNotYetTimeValid" xml:space="preserve">
+    <value>The certificate is not yet time valid.</value>
+  </data>
   <data name="ValueCannotBeEmptyString" xml:space="preserve">
     <value>The value cannot be an empty string.</value>
   </data>

--- a/src/Sign.Core/ServiceProvider.cs
+++ b/src/Sign.Core/ServiceProvider.cs
@@ -54,6 +54,7 @@ namespace Sign.Core
             services.AddSingleton<IMakeAppxCli, MakeAppxCli>();
             services.AddSingleton<INuGetSignTool, NuGetSignTool>();
             services.AddSingleton<IOpenVsixSignTool, OpenVsixSignTool>();
+            services.AddSingleton<ICertificateVerifier, CertificateVerifier>();
             services.AddSingleton<ISigner, Signer>();
 
             return new ServiceProvider(services.BuildServiceProvider());

--- a/src/Sign.Core/Signer.cs
+++ b/src/Sign.Core/Signer.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using System.Security.Authentication;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using Azure.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileSystemGlobbing;
@@ -75,6 +76,13 @@ namespace Sign.Core
 
             try
             {
+                using (X509Certificate2 certificate = await keyVaultService.GetCertificateAsync())
+                {
+                    ICertificateVerifier certificateVerifier = _serviceProvider.GetRequiredService<ICertificateVerifier>();
+
+                    certificateVerifier.Verify(certificate);
+                }
+
                 await Parallel.ForEachAsync(inputFiles, parallelOptions, async (input, token) =>
                 {
                     FileInfo output;

--- a/test/Sign.Core.Test/Certificates/CertificateVerifierTests.cs
+++ b/test/Sign.Core.Test/Certificates/CertificateVerifierTests.cs
@@ -1,0 +1,128 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Sign.Core.Test
+{
+    public class CertificateVerifierTests
+    {
+        [Fact]
+        public void Constructor_WhenLoggerIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new CertificateVerifier(logger: null!));
+
+            Assert.Equal("logger", exception.ParamName);
+        }
+
+        [Fact]
+        public void Verify_WhenCertificateIsNull_Throws()
+        {
+            CertificateVerifier verifier = new(Mock.Of<ILogger<ICertificateVerifier>>());
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => verifier.Verify(certificate: null!));
+
+            Assert.Equal("certificate", exception.ParamName);
+        }
+
+        [Fact]
+        public void Verify_WhenCertificateIsNotYetTimeValid_LogsWarning()
+        {
+            Logger logger = new();
+            CertificateVerifier verifier = new(logger);
+            DateTimeOffset now = DateTimeOffset.Now;
+
+            using (X509Certificate2 certificate = CreateCertificate(
+                notBefore: now.AddDays(1),
+                notAfter: now.AddDays(2)))
+            {
+                verifier.Verify(certificate);
+            }
+
+            Assert.Equal(1, logger.Log_CallCount);
+        }
+
+        [Fact]
+        public void Verify_WhenCertificateIsExpired_LogsWarning()
+        {
+            Logger logger = new();
+            CertificateVerifier verifier = new(logger);
+            DateTimeOffset now = DateTimeOffset.Now;
+
+            using (X509Certificate2 certificate = CreateCertificate(
+                notBefore: now.AddDays(-2),
+                notAfter: now.AddDays(-1)))
+            {
+                verifier.Verify(certificate);
+            }
+
+            Assert.Equal(1, logger.Log_CallCount);
+        }
+
+        [Fact]
+        public void Verify_WhenCertificateIsTimeValid_DoesNotLogWarning()
+        {
+            Logger logger = new();
+            CertificateVerifier verifier = new(logger);
+            DateTimeOffset now = DateTimeOffset.Now;
+
+            using (X509Certificate2 certificate = CreateCertificate(
+                notBefore: now.AddDays(-1),
+                notAfter: now.AddDays(1)))
+            {
+                verifier.Verify(certificate);
+            }
+
+            Assert.Equal(0, logger.Log_CallCount);
+        }
+
+        private static X509Certificate2 CreateCertificate(DateTimeOffset notBefore, DateTimeOffset notAfter)
+        {
+            using (RSA keyPair = RSA.Create(keySizeInBits: 3072))
+            {
+                CertificateRequest certificateRequest = new(
+                    "CN=test.test",
+                    keyPair,
+                    HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1);
+
+                return certificateRequest.CreateSelfSigned(notBefore, notAfter);
+            }
+        }
+
+        private sealed class Logger : ILogger<ICertificateVerifier>
+        {
+            internal int Log_CallCount { get; private set; }
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+            {
+                return new NoOpDisposable();
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return true;
+            }
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                ++Log_CallCount;
+
+                Assert.Equal(LogLevel.Warning, logLevel);
+            }
+
+            private sealed class NoOpDisposable : IDisposable
+            {
+                public void Dispose()
+                {
+                }
+            }
+        }
+    }
+}

--- a/test/Sign.Core.Test/Certificates/CertificateVerifierTests.cs
+++ b/test/Sign.Core.Test/Certificates/CertificateVerifierTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
@@ -34,7 +34,7 @@ namespace Sign.Core.Test
         [Fact]
         public void Verify_WhenCertificateIsNotYetTimeValid_LogsWarning()
         {
-            Logger logger = new();
+            Logger logger = new(Resources.CertificateIsNotYetTimeValid);
             CertificateVerifier verifier = new(logger);
             DateTimeOffset now = DateTimeOffset.Now;
 
@@ -51,7 +51,7 @@ namespace Sign.Core.Test
         [Fact]
         public void Verify_WhenCertificateIsExpired_LogsWarning()
         {
-            Logger logger = new();
+            Logger logger = new(Resources.CertificateIsExpired);
             CertificateVerifier verifier = new(logger);
             DateTimeOffset now = DateTimeOffset.Now;
 
@@ -98,7 +98,14 @@ namespace Sign.Core.Test
 
         private sealed class Logger : ILogger<ICertificateVerifier>
         {
+            private readonly string? _expectedMessage;
+
             internal int Log_CallCount { get; private set; }
+
+            internal Logger(string? expectedMessage = null)
+            {
+                _expectedMessage = expectedMessage;
+            }
 
             public IDisposable? BeginScope<TState>(TState state) where TState : notnull
             {
@@ -115,6 +122,10 @@ namespace Sign.Core.Test
                 ++Log_CallCount;
 
                 Assert.Equal(LogLevel.Warning, logLevel);
+
+                string actualMessage = formatter(state, exception);
+
+                Assert.Equal(_expectedMessage, actualMessage);
             }
 
             private sealed class NoOpDisposable : IDisposable

--- a/test/Sign.Core.Test/ServiceProviderTests.cs
+++ b/test/Sign.Core.Test/ServiceProviderTests.cs
@@ -47,6 +47,7 @@ namespace Sign.Core.Test
             Assert.NotNull(serviceProvider.GetRequiredService<IMakeAppxCli>());
             Assert.NotNull(serviceProvider.GetRequiredService<INuGetSignTool>());
             Assert.NotNull(serviceProvider.GetRequiredService<IOpenVsixSignTool>());
+            Assert.NotNull(serviceProvider.GetRequiredService<ICertificateVerifier>());
             Assert.NotNull(serviceProvider.GetRequiredService<ISigner>());
         }
     }


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/502.

If a certificate is not yet valid or is expired, a warning will display "The certificate is not time valid."