### PR TITLE
CLI:  3rd party sign NuGetKeyVaultSignTool.Core.dll

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -15,6 +15,7 @@
   <ItemGroup>
     <FileSignInfo Include="AzureSign.Core.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
+    <FileSignInfo Include="NuGetKeyVaultSignTool.Core.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="OpenVsixSignTool.Core.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="RSAKeyVaultProvider.dll" CertificateName="3PartySHA2" />
   </ItemGroup>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/499.

Previously, I missed NuGetKeyVaultSignTool.Core.dll in https://github.com/dotnet/sign/pull/500.