### PR TITLE
Update .NET and Arcade SDK's

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,12 +1,12 @@
 {
   "tools": {
-    "dotnet": "7.0.100-rc.1.22431.12",
+    "dotnet": "7.0.100",
     "runtimes": {
       "dotnet/x64": [ "6.0.11" ]
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.22528.1",
-    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.22528.1"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.22606.1",
+    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.22606.1"
   }
 }


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/509.

This change updates the .NET 7 SDK version used from pre-GA preview to GA.  It also updates the Arcade SDK version.