### PR TITLE
Update tool name from ".NET Sign CLI" to "Sign CLI"

### DIFF
--- a/src/Sign.Cli/Sign.Cli.csproj
+++ b/src/Sign.Cli/Sign.Cli.csproj
@@ -5,7 +5,7 @@
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
     <OutputType>Exe</OutputType>
-    <PackageDescription>.NET Sign CLI</PackageDescription>
+    <PackageDescription>Sign CLI</PackageDescription>
     <PackAsTool>true</PackAsTool>
     <RollForward>Major</RollForward>
     <RootNamespace>Sign.Cli</RootNamespace>

--- a/src/Sign.Cli/SignCommand.cs
+++ b/src/Sign.Cli/SignCommand.cs
@@ -9,7 +9,7 @@ namespace Sign.Cli
     internal sealed class SignCommand : Command
     {
         internal SignCommand()
-            : base("sign", ".NET Sign CLI")
+            : base("sign", "Sign CLI")
         {
             CodeCommand codeCommand = new();
 


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/510.

This change updates the tool's name from ".NET Sign CLI" to simply "Sign CLI".