### PR TITLE
CI: update build machine image to support .NET 7.0.100 SDK

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -43,10 +43,10 @@ stages:
         pool: # See https://helix.dot.net/ for VM names.
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals windows.vs2019.amd64
+            demands: ImageOverride -equals windows.vs2022preview.amd64
           ${{ else }}:
             name: NetCore-Public
-            demands: ImageOverride -equals windows.vs2019.amd64.open
+            demands: ImageOverride -equals windows.vs2022preview.amd64.open
         variables:
         # Only enable publishing in official builds.
         - ${{ if and(eq(variables['System.TeamProject'], 'internal'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/513.

This change fixes the internal build by using a newer VM image with VS 2022 instead of VS 2019.