### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# review when someone opens a pull request.
+# For more on how to customize the CODEOWNERS file - https://help.github.com/en/articles/about-code-owners
+*       @dotnet/sign-maintainers


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/515.

This change adds a CODEOWNERS file so that the specified team is notified of PR's.