### PR TITLE
Add SDK tools to NuGet package

### DIFF
--- a/scripts/VerifyNuGetPackage.ps1
+++ b/scripts/VerifyNuGetPackage.ps1
@@ -43,7 +43,7 @@ Function VerifyPackage([System.IO.FileInfo] $packageFile, [string[]] $expectedEn
     }
 }
 
-[string[]] $packageFilePaths = [System.IO.Directory]::GetFiles('E:\git\sign\artifacts\packages\Release\Shipping', '*.nupkg')
+[string[]] $packageFilePaths = [System.IO.Directory]::GetFiles($PackageDirectoryPath, '*.nupkg')
 
 If ($packageFilePaths.Count -ne 1)
 {

--- a/scripts/VerifyNuGetPackage.ps1
+++ b/scripts/VerifyNuGetPackage.ps1
@@ -1,0 +1,93 @@
+﻿param
+(
+    [Parameter(Mandatory = $True)]
+    [string] $PackageDirectoryPath
+)
+
+Add-Type -AssemblyName 'System.IO.Compression'
+
+[int] $ErrorExitCode = 1
+
+Function VerifyPackage([System.IO.FileInfo] $packageFile, [string[]] $expectedEntryFullNames)
+{
+    [System.IO.FileStream] $stream = $packageFile.OpenRead()
+
+    Try
+    {
+        $zipArchive = New-Object System.IO.Compression.ZipArchive -ArgumentList @($stream, [System.IO.Compression.ZipArchiveMode]::Read)
+
+        Try
+        {
+            ForEach ($expectedEntryFullName in $expectedEntryFullNames)
+            {
+                [System.IO.Compression.ZipArchiveEntry] $actualEntry = $zipArchive.GetEntry($expectedEntryFullName)
+
+                If ($actualEntry)
+                {
+                    Write-Host "The NuGet package contains $expectedEntryFullName"
+                }
+                Else
+                {
+                    Throw "The NuGet package does not contain $expectedEntryFullName"
+                }
+            }
+        }
+        Finally
+        {
+            $zipArchive.Dispose()
+        }
+    }
+    Finally
+    {
+        $stream.Dispose()
+    }
+}
+
+[string[]] $packageFilePaths = [System.IO.Directory]::GetFiles('E:\git\sign\artifacts\packages\Release\Shipping', '*.nupkg')
+
+If ($packageFilePaths.Count -ne 1)
+{
+    Write-Error "Exactly one package was expected (but not found) in $PackageDirectoryPath"
+
+    Exit $ErrorExitCode
+}
+
+[string] $sourcePackageFilePath = $packageFilePaths[0]
+[System.IO.FileInfo] $destinationFile = [System.IO.FileInfo]::new(
+    [System.IO.Path]::Combine(
+        [System.IO.Path]::GetTempPath(),
+        "$([System.IO.Path]::GetRandomFileName()).zip"))
+[bool] $overwrite = $True
+[System.IO.File]::Copy($sourcePackageFilePath, $destinationFile.FullName, $overwrite)
+
+[string[]] $expectedEntryFullNames =
+    'tools/net6.0/any/tools/SDK/x64/appxpackaging.dll',
+    'tools/net6.0/any/tools/SDK/x64/appxsip.dll',
+    'tools/net6.0/any/tools/SDK/x64/makeappx.exe',
+    'tools/net6.0/any/tools/SDK/x64/makepri.exe',
+    'tools/net6.0/any/tools/SDK/x64/Microsoft.Windows.Build.Appx.AppxPackaging.dll.manifest',
+    'tools/net6.0/any/tools/SDK/x64/Microsoft.Windows.Build.Appx.AppxSip.dll.manifest',
+    'tools/net6.0/any/tools/SDK/x64/Microsoft.Windows.Build.Appx.OpcServices.dll.manifest',
+    'tools/net6.0/any/tools/SDK/x64/Microsoft.Windows.Build.Signing.mssign32.dll.manifest',
+    'tools/net6.0/any/tools/SDK/x64/Microsoft.Windows.Build.Signing.wintrust.dll.manifest',
+    'tools/net6.0/any/tools/SDK/x64/mssign32.dll',
+    'tools/net6.0/any/tools/SDK/x64/opcservices.dll',
+    'tools/net6.0/any/tools/SDK/x64/SignTool.exe.manifest',
+    'tools/net6.0/any/tools/SDK/x64/wintrust.dll',
+    'tools/net6.0/any/tools/SDK/x64/wintrust.dll.ini',
+    'tools/net6.0/any/tools/SDK/x86/mage.exe'
+
+Try
+{
+    VerifyPackage -packageFile $destinationFile -expectedEntryFullNames $expectedEntryFullNames
+}
+Catch
+{
+    Write-Error $_.Exception.Message
+
+    Exit $ErrorExitCode
+}
+Finally
+{
+    $destinationFile.Delete()
+}

--- a/src/Sign.Cli/Sign.Cli.csproj
+++ b/src/Sign.Cli/Sign.Cli.csproj
@@ -32,6 +32,10 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <!--
+    Arcade uses its own NuGet packages folder in the repository's root directory.
+    Everything else (Visual Studio, dotnet.exe CLI, etc.) defaults to NuGet's global packages folder.
+    -->
     <NuGetPackagesDirectory>$(NUGET_PACKAGES)</NuGetPackagesDirectory>
     <NuGetPackagesDirectory Condition=" '$(NuGetPackagesDirectory)' == '' " >$(NuGetPackageRoot)</NuGetPackagesDirectory>
     <WinSdkBinDir Condition=" '$(WinSdkBinDir)' == '' ">$(NuGetPackagesDirectory)microsoft.windows.sdk.buildtools\10.0.25231-preview\bin\10.0.25231.0</WinSdkBinDir>

--- a/src/Sign.Cli/Sign.Cli.csproj
+++ b/src/Sign.Cli/Sign.Cli.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <WinSdkBinDir Condition=" '$(WinSdkBinDir)' == '' ">$(NuGetPackageRoot)microsoft.windows.sdk.buildtools\10.0.25231-preview\bin\10.0.25231.0</WinSdkBinDir>
+    <WinSdkBinDir Condition=" '$(WinSdkBinDir)' == '' ">$(NUGET_PACKAGES)microsoft.windows.sdk.buildtools\10.0.25231-preview\bin\10.0.25231.0</WinSdkBinDir>
     <NetSdkBinDir Condition=" '$(NetSdkBinDir)' == '' ">$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools</NetSdkBinDir>
   </PropertyGroup>
 
@@ -60,6 +60,16 @@
     <Copy Condition="'$(WinSdkBinDir)' != ''" SourceFiles="@(SdkFile86)" DestinationFolder="$(OutputPath)\tools\SDK\x86" SkipUnchangedFiles="true" />
 
     <Error Condition="'$(WinSdkBinDir)' == ''" Text="No supported WinSDK could be found!" />
+  </Target>
+
+  <Target Name="VerifyNuGetPackage" AfterTargets="Pack">
+    <PropertyGroup>
+      <PowerShellFilePath Condition=" '$(PowerShellFilePath)' == '' ">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</PowerShellFilePath>
+      <ScriptFilePath Condition=" '$(ScriptFilePath)' == '' ">$(RepositoryRootDirectory)\scripts\VerifyNuGetPackage.ps1</ScriptFilePath>
+    </PropertyGroup>
+
+    <Exec Command="$(PowerShellFilePath) -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;&apos;$(ScriptFilePath)&apos; &apos;$(ArtifactsShippingPackagesDir)&apos; } &quot;"
+          LogStandardErrorAsError="true" />
   </Target>
 
   <ItemGroup>

--- a/src/Sign.Cli/Sign.Cli.csproj
+++ b/src/Sign.Cli/Sign.Cli.csproj
@@ -32,7 +32,9 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <WinSdkBinDir Condition=" '$(WinSdkBinDir)' == '' ">$(NUGET_PACKAGES)microsoft.windows.sdk.buildtools\10.0.25231-preview\bin\10.0.25231.0</WinSdkBinDir>
+    <NuGetPackagesDirectory>$(NUGET_PACKAGES)</NuGetPackagesDirectory>
+    <NuGetPackagesDirectory Condition=" '$(NuGetPackagesDirectory)' == '' " >$(NuGetPackageRoot)</NuGetPackagesDirectory>
+    <WinSdkBinDir Condition=" '$(WinSdkBinDir)' == '' ">$(NuGetPackagesDirectory)microsoft.windows.sdk.buildtools\10.0.25231-preview\bin\10.0.25231.0</WinSdkBinDir>
     <NetSdkBinDir Condition=" '$(NetSdkBinDir)' == '' ">$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools</NetSdkBinDir>
   </PropertyGroup>
 
@@ -68,7 +70,7 @@
       <ScriptFilePath Condition=" '$(ScriptFilePath)' == '' ">$(RepositoryRootDirectory)\scripts\VerifyNuGetPackage.ps1</ScriptFilePath>
     </PropertyGroup>
 
-    <Exec Command="$(PowerShellFilePath) -NonInteractive -executionpolicy Unrestricted -command &quot;&amp; { &amp;&apos;$(ScriptFilePath)&apos; &apos;$(ArtifactsShippingPackagesDir)&apos; } &quot;"
+    <Exec Command="$(PowerShellFilePath) -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; { &amp;&apos;$(ScriptFilePath)&apos; &apos;$(ArtifactsShippingPackagesDir)&apos; } &quot;"
           LogStandardErrorAsError="true" />
   </Target>
 
@@ -76,10 +78,12 @@
     <Content Include="@(SdkFile64)">
       <Pack>true</Pack>
       <PackagePath>tools\$(TargetFramework)\any\tools\SDK\x64</PackagePath>
+      <Visible>false</Visible>
     </Content>
     <Content Include="@(SdkFile86)">
       <Pack>true</Pack>
       <PackagePath>tools\$(TargetFramework)\any\tools\SDK\x86</PackagePath>
+      <Visible>false</Visible>
     </Content>
     <Content Include="$(RepositoryRootDirectory)\LICENSE.txt">
       <Pack>true</Pack>
@@ -90,5 +94,4 @@
       <PackagePath>\</PackagePath>
     </Content>
   </ItemGroup>
-
 </Project>

--- a/src/Sign.Cli/Sign.Cli.csproj
+++ b/src/Sign.Cli/Sign.Cli.csproj
@@ -73,9 +73,13 @@
   </Target>
 
   <ItemGroup>
-    <Content Include="$(OutputPath)\tools\**">
+    <Content Include="@(SdkFile64)">
       <Pack>true</Pack>
-      <PackagePath>tools\$(TargetFramework)\any\tools</PackagePath>
+      <PackagePath>tools\$(TargetFramework)\any\tools\SDK\x64</PackagePath>
+    </Content>
+    <Content Include="@(SdkFile86)">
+      <Pack>true</Pack>
+      <PackagePath>tools\$(TargetFramework)\any\tools\SDK\x86</PackagePath>
     </Content>
     <Content Include="$(RepositoryRootDirectory)\LICENSE.txt">
       <Pack>true</Pack>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/525.

This change fixes a bug where Windows SDK tools were not included in the NuGet package.  The root problem is that the NuGet packages directory is different between `dotnet restore` and an Arcade `eng\common\CIBuild.cmd`; [Arcade installs packages to a .packages directory in the repository's root directory](https://github.com/dotnet/arcade/blob/6ef9e132005430f2920e0c26128bf9ba15c7644e/eng/common/tools.sh#L324).  NuGet pack could not find the Windows SDK package because it was looking in the wrong packages directory.

This change also adds pack verification to the CI build to ensure this does not regress.

CC @clairernovotny