### PR TITLE
Update Windows SDK

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,8 @@
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.25262-preview" />
+    <!-- Only use release versions.  Pre-release versions are signed with an untrusted certificate. -->
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
     <PackageVersion Include="Moq" Version="4.18.1" />
     <PackageVersion Include="NuGetKeyVaultSignTool.Core" Version="3.2.3" />
     <PackageVersion Include="OpenVsixSignTool.Core" Version="0.3.2" />

--- a/src/Sign.Cli/Sign.Cli.csproj
+++ b/src/Sign.Cli/Sign.Cli.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" IncludeAssets="none" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" IncludeAssets="build" PrivateAssets="all" />
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 
@@ -32,40 +32,31 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <!--
-    Arcade uses its own NuGet packages folder in the repository's root directory.
-    Everything else (Visual Studio, dotnet.exe CLI, etc.) defaults to NuGet's global packages folder.
-    -->
-    <NuGetPackagesDirectory>$(NUGET_PACKAGES)</NuGetPackagesDirectory>
-    <NuGetPackagesDirectory Condition=" '$(NuGetPackagesDirectory)' == '' " >$(NuGetPackageRoot)</NuGetPackagesDirectory>
-    <WinSdkBinDir Condition=" '$(WinSdkBinDir)' == '' ">$(NuGetPackagesDirectory)microsoft.windows.sdk.buildtools\10.0.25262-preview\bin\10.0.25262.0</WinSdkBinDir>
     <NetSdkBinDir Condition=" '$(NetSdkBinDir)' == '' ">$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools</NetSdkBinDir>
   </PropertyGroup>
 
   <ItemGroup>
-    <SdkFile64 Include="$(WinSdkBinDir)\x64\appxsip.dll" />
-    <SdkFile64 Include="$(WinSdkBinDir)\x64\appxpackaging.dll" />
-    <SdkFile64 Include="$(WinSdkBinDir)\x64\opcservices.dll" />
-    <SdkFile64 Include="$(WinSdkBinDir)\x64\Microsoft.Windows.Build.Appx.AppxPackaging.dll.manifest" />
-    <SdkFile64 Include="$(WinSdkBinDir)\x64\Microsoft.Windows.Build.Appx.AppxSip.dll.manifest" />
-    <SdkFile64 Include="$(WinSdkBinDir)\x64\Microsoft.Windows.Build.Appx.OpcServices.dll.manifest" />
-    <SdkFile64 Include="$(WinSdkBinDir)\x64\Microsoft.Windows.Build.Signing.mssign32.dll.manifest" />
-    <SdkFile64 Include="$(WinSdkBinDir)\x64\Microsoft.Windows.Build.Signing.wintrust.dll.manifest" />
-    <SdkFile64 Include="$(WinSdkBinDir)\x64\makeappx.exe" />
-    <SdkFile64 Include="$(WinSdkBinDir)\x64\makepri.exe" />
-    <SdkFile64 Include="$(WinSdkBinDir)\x64\mssign32.dll" />
-    <SdkFile64 Include="$(WinSdkBinDir)\x64\wintrust.dll" />
-    <SdkFile64 Include="$(WinSdkBinDir)\x64\wintrust.dll.ini" />
-    <SdkFile64 Include="$(WinSdkBinDir)\x64\SignTool.exe.manifest" />
+    <SdkFile64 Include="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\appxsip.dll" />
+    <SdkFile64 Include="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\appxpackaging.dll" />
+    <SdkFile64 Include="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\opcservices.dll" />
+    <SdkFile64 Include="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\Microsoft.Windows.Build.Appx.AppxPackaging.dll.manifest" />
+    <SdkFile64 Include="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\Microsoft.Windows.Build.Appx.AppxSip.dll.manifest" />
+    <SdkFile64 Include="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\Microsoft.Windows.Build.Appx.OpcServices.dll.manifest" />
+    <SdkFile64 Include="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\Microsoft.Windows.Build.Signing.mssign32.dll.manifest" />
+    <SdkFile64 Include="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\Microsoft.Windows.Build.Signing.wintrust.dll.manifest" />
+    <SdkFile64 Include="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\makeappx.exe" />
+    <SdkFile64 Include="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\makepri.exe" />
+    <SdkFile64 Include="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\mssign32.dll" />
+    <SdkFile64 Include="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\wintrust.dll" />
+    <SdkFile64 Include="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\wintrust.dll.ini" />
+    <SdkFile64 Include="$(WindowsSDKBuildToolsBinVersionedFolder)\x64\SignTool.exe.manifest" />
 
     <SdkFile86 Include="$(NetSdkBinDir)\mage.exe" />
   </ItemGroup>
 
-  <Target Name="PrebuildScript" BeforeTargets="CoreBuild">
-    <Copy Condition="'$(WinSdkBinDir)' != ''" SourceFiles="@(SdkFile64)" DestinationFolder="$(OutputPath)\tools\SDK\x64" SkipUnchangedFiles="true" />
-    <Copy Condition="'$(WinSdkBinDir)' != ''" SourceFiles="@(SdkFile86)" DestinationFolder="$(OutputPath)\tools\SDK\x86" SkipUnchangedFiles="true" />
-
-    <Error Condition="'$(WinSdkBinDir)' == ''" Text="No supported WinSDK could be found!" />
+  <Target Name="CopySdkFiles" AfterTargets="Build">
+    <Copy SourceFiles="@(SdkFile64)" DestinationFolder="$(OutputPath)\tools\SDK\x64" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(SdkFile86)" DestinationFolder="$(OutputPath)\tools\SDK\x86" SkipUnchangedFiles="true" />
   </Target>
 
   <Target Name="VerifyNuGetPackage" AfterTargets="Pack">


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/527.

This change does a few things:
- Uses the latest release version of the Microsoft.Windows.SDK.BuildTools package.  Release versions are signed with trusted certificates, whereas preview versions are not.
- Updates (and simplifies) how the Sign.Cli project copies SDK files.  This was necessary because if Visual Studio is installed, a package in a shared Visual Studio NuGet fallback folder is referenced, and there isn't a great way to get the SDK tool file paths (for copying) later.  Pulling in the package's build assets vastly simplifies everything.
- Fixes internal CI build failures.

CC @clairernovotny