### PR TITLE
Fix discovery of package content

### DIFF
--- a/src/Sign.Cli/Program.cs
+++ b/src/Sign.Cli/Program.cs
@@ -20,8 +20,10 @@ namespace Sign.Cli
                 return ExitCode.Failed;
             }
 
-            string directory = Path.GetDirectoryName(Environment.ProcessPath!)!;
-            string baseDirectory = Path.Combine(directory, "tools", "SDK", "x64");
+            AppRootDirectoryLocator locator = new();
+            DirectoryInfo appRootDirectory = locator.Directory;
+
+            string baseDirectory = Path.Combine(appRootDirectory.FullName, "tools", "SDK", "x64");
 
             //
             // Ensure we invoke wintrust!DllMain before we get too far.
@@ -54,7 +56,7 @@ namespace Sign.Cli
             }
         }
 
-        internal static Parser CreateParser(IServiceProvider? serviceProvider = null)
+        internal static Parser CreateParser()
         {
             SignCommand command = new();
 

--- a/src/Sign.Core/FileSystem/AppRootDirectoryLocator.cs
+++ b/src/Sign.Core/FileSystem/AppRootDirectoryLocator.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.Core
+{
+    internal sealed class AppRootDirectoryLocator : IAppRootDirectoryLocator
+    {
+        private static readonly Lazy<DirectoryInfo> LazyDirectory = new(GetAppRootDirectory);
+
+        public DirectoryInfo Directory => LazyDirectory.Value;
+
+        // Dependency injection requires a public constructor.
+        public AppRootDirectoryLocator()
+        {
+        }
+
+        private static DirectoryInfo GetAppRootDirectory()
+        {
+            string filePath = typeof(AppRootDirectoryLocator).Assembly.Location;
+            FileInfo file = new(filePath);
+
+            return file.Directory!;
+        }
+    }
+}

--- a/src/Sign.Core/FileSystem/IAppRootDirectoryLocator.cs
+++ b/src/Sign.Core/FileSystem/IAppRootDirectoryLocator.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.Core
+{
+    internal interface IAppRootDirectoryLocator
+    {
+        DirectoryInfo Directory { get; }
+    }
+}

--- a/src/Sign.Core/ServiceProvider.cs
+++ b/src/Sign.Core/ServiceProvider.cs
@@ -34,6 +34,7 @@ namespace Sign.Core
                 builder.SetMinimumLevel(logLevel);
             });
 
+            services.AddSingleton<IAppRootDirectoryLocator, AppRootDirectoryLocator>();
             services.AddSingleton<IToolConfigurationProvider, ToolConfigurationProvider>();
             services.AddSingleton<IMatcherFactory, MatcherFactory>();
             services.AddSingleton<IFileListReader, FileListReader>();

--- a/src/Sign.Core/Tools/ToolConfigurationProvider.cs
+++ b/src/Sign.Core/Tools/ToolConfigurationProvider.cs
@@ -13,9 +13,11 @@ namespace Sign.Core
         public FileInfo SignToolManifest { get; }
 
         // Dependency injection requires a public constructor.
-        public ToolConfigurationProvider()
+        public ToolConfigurationProvider(IAppRootDirectoryLocator appRootDirectoryLocator)
         {
-            _rootDirectory = new DirectoryInfo(Path.GetDirectoryName(Environment.ProcessPath)!);
+            ArgumentNullException.ThrowIfNull(appRootDirectoryLocator, nameof(appRootDirectoryLocator));
+
+            _rootDirectory = appRootDirectoryLocator.Directory;
 
             DirectoryInfo sdkDirectory = new(Path.Combine(_rootDirectory.FullName, "tools", "SDK"));
 

--- a/test/Sign.Core.Test/FileSystem/AppRootDirectoryLocatorTests.cs
+++ b/test/Sign.Core.Test/FileSystem/AppRootDirectoryLocatorTests.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.Core.Test
+{
+    public class AppRootDirectoryLocatorTests
+    {
+        [Fact]
+        public void Directory_Always_ReturnsDirectoryOfSignCoreDll()
+        {
+            DirectoryInfo expectedResult = new FileInfo(typeof(AppRootDirectoryLocator).Assembly.Location).Directory!;
+
+            AppRootDirectoryLocator locator = new();
+            DirectoryInfo actualResult = locator.Directory;
+
+            Assert.Equal(expectedResult.FullName, actualResult.FullName);
+        }
+    }
+}

--- a/test/Sign.Core.Test/ServiceProviderTests.cs
+++ b/test/Sign.Core.Test/ServiceProviderTests.cs
@@ -25,6 +25,7 @@ namespace Sign.Core.Test
 
             // Start of tests
             Assert.NotNull(serviceProvider.GetRequiredService<ILogger<ServiceProviderTests>>());
+            Assert.NotNull(serviceProvider.GetRequiredService<IAppRootDirectoryLocator>());
             Assert.NotNull(serviceProvider.GetRequiredService<IToolConfigurationProvider>());
             Assert.NotNull(serviceProvider.GetRequiredService<IMatcherFactory>());
             Assert.NotNull(serviceProvider.GetRequiredService<IFileListReader>());

--- a/test/Sign.Core.Test/Tools/ToolConfigurationProviderTests.cs
+++ b/test/Sign.Core.Test/Tools/ToolConfigurationProviderTests.cs
@@ -6,8 +6,18 @@ namespace Sign.Core.Test
 {
     public class ToolConfigurationProviderTests
     {
-        private readonly ToolConfigurationProvider _provider = new();
-        private readonly DirectoryInfo _rootDirectory = new(Path.GetDirectoryName(Environment.ProcessPath)!);
+        private static readonly AppRootDirectoryLocator DirectoryLocator = new();
+        private readonly ToolConfigurationProvider _provider = new(DirectoryLocator);
+        private readonly DirectoryInfo _rootDirectory = DirectoryLocator.Directory!;
+
+        [Fact]
+        public void Constructor_WhenAppRootDirectoryLocatorIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new ToolConfigurationProvider(appRootDirectoryLocator: null!));
+
+            Assert.Equal("appRootDirectoryLocator", exception.ParamName);
+        }
 
         [Fact]
         public void Mage_Always_ReturnsFile()


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/531.

The issue is that the CLI currently uses `Environment.ProcessPath` to deduce the location of SDK tools.  However, when installed as a .NET global tool, the SDK tools directory is relative to a different directory, where the NuGet package is extracted.

This change uses a consistent way of obtaining the SDK tools directory by basing it on the location of Sign.Core.dll.

CC @clairernovotny