### PR TITLE
Require timestamping for signing

### DIFF
--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -55,11 +55,17 @@ namespace Sign.Cli
                 DirectoryInfo baseDirectory = context.ParseResult.GetValueForOption(_codeCommand.BaseDirectoryOption)!;
                 string? publisherName = context.ParseResult.GetValueForOption(_codeCommand.PublisherNameOption);
                 string? description = context.ParseResult.GetValueForOption(_codeCommand.DescriptionOption);
-                Uri? descriptionUrl = context.ParseResult.GetValueForOption(_codeCommand.DescriptionUrlOption);
+                // This option is required.  If its value fails to parse we won't have reached here,
+                // and after successful parsing its value will never be null.
+                // Non-null is already guaranteed; the null-forgiving operator (!) just simplifies code.
+                Uri descriptionUrl = context.ParseResult.GetValueForOption(_codeCommand.DescriptionUrlOption)!;
                 string? fileListFilePath = context.ParseResult.GetValueForOption(_codeCommand.FileListOption);
                 HashAlgorithmName fileHashAlgorithmName = context.ParseResult.GetValueForOption(_codeCommand.FileDigestOption);
                 HashAlgorithmName timestampHashAlgorithmName = context.ParseResult.GetValueForOption(_codeCommand.TimestampDigestOption);
-                Uri? timestampUrl = context.ParseResult.GetValueForOption(_codeCommand.TimestampUrlOption);
+                // This option is required.  If its value fails to parse we won't have reached here,
+                // and after successful parsing its value will never be null.
+                // Non-null is already guaranteed; the null-forgiving operator (!) just simplifies code.
+                Uri timestampUrl = context.ParseResult.GetValueForOption(_codeCommand.TimestampUrlOption)!;
                 LogLevel verbosity = context.ParseResult.GetValueForOption(_codeCommand.VerbosityOption);
                 string? output = context.ParseResult.GetValueForOption(_codeCommand.OutputOption);
                 int maxConcurrency = context.ParseResult.GetValueForOption(_codeCommand.MaxConcurrencyOption);
@@ -83,7 +89,7 @@ namespace Sign.Cli
                 // Make sure this is rooted
                 if (!Path.IsPathRooted(baseDirectory.FullName))
                 {
-                    context.Console.Error.WriteLine("--base-directory parameter must be rooted if specified");
+                    context.Console.Error.WriteLine("--base-directory argument must be rooted if specified.");
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
                 }

--- a/src/Sign.Cli/CodeCommand.cs
+++ b/src/Sign.Cli/CodeCommand.cs
@@ -123,7 +123,7 @@ namespace Sign.Cli
                 !(string.Equals(Uri.UriSchemeHttp, uri.Scheme, StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(Uri.UriSchemeHttps, uri.Scheme, StringComparison.OrdinalIgnoreCase)))
             {
-                result.ErrorMessage = $"Unsupported value for --{result.Argument.Name}.  The value must be an HTTP or HTTPS URL.";
+                result.ErrorMessage = $"Unsupported value for --{result.Argument.Name}.  The value must be an absolute HTTP or HTTPS URL.";
 
                 return null;
             }

--- a/src/Sign.Cli/CodeCommand.cs
+++ b/src/Sign.Cli/CodeCommand.cs
@@ -13,14 +13,14 @@ namespace Sign.Cli
     {
         internal Option<DirectoryInfo> BaseDirectoryOption { get; } = new(new[] { "-b", "--base-directory" }, ParseBaseDirectoryOption, description: "Base directory for files to override the working directory.");
         internal Option<string> DescriptionOption { get; } = new(new[] { "-d", "--description" }, "Description of the signing certificate.");
-        internal Option<Uri> DescriptionUrlOption { get; } = new(new[] { "-u", "--description-url" }, "Description URL of the signing certificate.");
+        internal Option<Uri?> DescriptionUrlOption { get; } = new(new[] { "-u", "--description-url" }, ParseUrl, description: "Description URL of the signing certificate.");
         internal Option<HashAlgorithmName> FileDigestOption { get; } = new(new[] { "-fd", "--file-digest" }, ParseHashAlgorithmName, description: "Digest algorithm to hash the file with. Allowed values are sha256, sha384, and sha512.");
         internal Option<string?> FileListOption = new(new[] { "-fl", "--file-list" }, "Path to file containing paths of files to sign within an archive.");
         internal Option<int> MaxConcurrencyOption { get; } = new(new[] { "-m", "--max-concurrency" }, ParseMaxConcurrencyOption, description: "Maximum concurrency (default is 4)");
         internal Option<string?> OutputOption { get; } = new(new[] { "-o", "--output" }, "Output file or directory. If omitted, overwrites input file.");
         internal Option<string?> PublisherNameOption { get; } = new(new[] { "-pn", "--publisher-name" }, "Publisher name (ClickOnce).");
         internal Option<HashAlgorithmName> TimestampDigestOption { get; } = new(new[] { "-td", "--timestamp-digest" }, ParseHashAlgorithmName, description: "Used with the -t switch to request a digest algorithm used by the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.");
-        internal Option<Uri> TimestampUrlOption { get; } = new(new[] { "-t", "--timestamp-url" }, "RFC 3161 timestamp server URL. If this option is not specified, the signed file will not be timestamped.");
+        internal Option<Uri?> TimestampUrlOption { get; } = new(new[] { "-t", "--timestamp-url" }, ParseUrl, description: "RFC 3161 timestamp server URL.");
         internal Option<LogLevel> VerbosityOption { get; } = new(new[] { "-v", "--verbosity" }, () => LogLevel.Warning, "Sets the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].");
 
         internal CodeCommand()
@@ -28,6 +28,7 @@ namespace Sign.Cli
         {
             DescriptionOption.IsRequired = true;
             DescriptionUrlOption.IsRequired = true;
+            TimestampUrlOption.IsRequired = true;
 
             MaxConcurrencyOption.SetDefaultValue(4);
             FileDigestOption.SetDefaultValue(HashAlgorithmName.SHA256);
@@ -113,6 +114,21 @@ namespace Sign.Cli
 
                     return HashAlgorithmName.SHA256;
             }
+        }
+
+        private static Uri? ParseUrl(ArgumentResult result)
+        {
+            if (result.Tokens.Count != 1 ||
+                !Uri.TryCreate(result.Tokens[0].Value, UriKind.Absolute, out Uri? uri) ||
+                !(string.Equals(Uri.UriSchemeHttp, uri.Scheme, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(Uri.UriSchemeHttps, uri.Scheme, StringComparison.OrdinalIgnoreCase)))
+            {
+                result.ErrorMessage = $"Unsupported value for --{result.Argument.Name}.  The value must be an HTTP or HTTPS URL.";
+
+                return null;
+            }
+
+            return uri;
         }
     }
 }

--- a/src/Sign.Core/ISigner.cs
+++ b/src/Sign.Core/ISigner.cs
@@ -17,7 +17,7 @@ namespace Sign.Core
             string? publisherName,
             string? description,
             Uri? descriptionUrl,
-            Uri? timestampUrl,
+            Uri timestampUrl,
             int maxConcurrency,
             HashAlgorithmName fileHashAlgorithm,
             HashAlgorithmName timestampHashAlgorithm,

--- a/src/Sign.Core/SignatureProviders/SignOptions.cs
+++ b/src/Sign.Core/SignatureProviders/SignOptions.cs
@@ -16,7 +16,7 @@ namespace Sign.Core
         internal Matcher? AntiMatcher { get; }
         internal HashAlgorithmName FileHashAlgorithm { get; } = HashAlgorithmName.SHA256;
         internal HashAlgorithmName TimestampHashAlgorithm { get; } = HashAlgorithmName.SHA256;
-        internal Uri? TimestampService { get; }
+        internal Uri TimestampService { get; }
 
         internal SignOptions(
             string? publisherName,
@@ -24,7 +24,7 @@ namespace Sign.Core
             Uri? descriptionUrl,
             HashAlgorithmName fileHashAlgorithm,
             HashAlgorithmName timestampHashAlgorithm,
-            Uri? timestampService,
+            Uri timestampService,
             Matcher? matcher,
             Matcher? antiMatcher)
         {
@@ -38,9 +38,9 @@ namespace Sign.Core
             AntiMatcher = antiMatcher;
         }
 
-        internal SignOptions(HashAlgorithmName fileHashAlgorithm)
+        internal SignOptions(HashAlgorithmName fileHashAlgorithm, Uri timestampService)
             : this(publisherName: null, description: null, descriptionUrl: null, fileHashAlgorithm,
-                  HashAlgorithmName.SHA256, timestampService: null, matcher: null, antiMatcher: null)
+                HashAlgorithmName.SHA256, timestampService, matcher: null, antiMatcher: null)
         {
         }
     }

--- a/src/Sign.Core/Signer.cs
+++ b/src/Sign.Core/Signer.cs
@@ -33,7 +33,7 @@ namespace Sign.Core
             string? publisherName,
             string? description,
             Uri? descriptionUrl,
-            Uri? timestampUrl,
+            Uri timestampUrl,
             int maxConcurrency,
             HashAlgorithmName fileHashAlgorithm,
             HashAlgorithmName timestampHashAlgorithm,

--- a/test/Sign.Cli.Test/CodeCommandTests.cs
+++ b/test/Sign.Cli.Test/CodeCommandTests.cs
@@ -125,9 +125,9 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
-        public void TimestampUrlOption_Always_IsNotRequired()
+        public void TimestampUrlOption_Always_IsRequired()
         {
-            Assert.False(_command.TimestampUrlOption.IsRequired);
+            Assert.True(_command.TimestampUrlOption.IsRequired);
         }
 
         [Fact]

--- a/test/Sign.Cli.Test/Options/TimestampUrlOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/TimestampUrlOptionTests.cs
@@ -7,7 +7,7 @@ namespace Sign.Cli.Test
     public class TimestampUrlOptionTests : UriOptionTests
     {
         public TimestampUrlOptionTests()
-            : base(new CodeCommand().TimestampUrlOption, "-t", "--timestamp-url", isRequired: false)
+            : base(new CodeCommand().TimestampUrlOption, "-t", "--timestamp-url", isRequired: true)
         {
         }
     }

--- a/test/Sign.Cli.Test/Options/UriOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/UriOptionTests.cs
@@ -6,11 +6,11 @@ using System.CommandLine;
 
 namespace Sign.Cli.Test
 {
-    public abstract class UriOptionTests : OptionTests<Uri>
+    public abstract class UriOptionTests : OptionTests<Uri?>
     {
         private static readonly Uri ExpectedValue = new("https://domain.test");
 
-        protected UriOptionTests(Option<Uri> option, string shortOption, string longOption, bool isRequired)
+        protected UriOptionTests(Option<Uri?> option, string shortOption, string longOption, bool isRequired)
             : base(option, shortOption, longOption, ExpectedValue, isRequired)
         {
         }
@@ -19,6 +19,33 @@ namespace Sign.Cli.Test
         public void Option_WhenValueFailsToParse_HasError()
         {
             VerifyHasError("3");
+        }
+
+        [Theory]
+        [InlineData("http://domain.test")]
+        [InlineData("https://domain.test")]
+        public void Option_WithShortOptionAndValidUrl_ParsesValue(string url)
+        {
+            Uri expectedValue = new(url, UriKind.Absolute);
+
+            Verify($"{ShortOption} {expectedValue.OriginalString}", expectedValue);
+        }
+
+        [Theory]
+        [InlineData("//domain.test")]
+        [InlineData("/path")]
+        [InlineData("file:///file.bin")]
+        public void Option_WithShortOptionAndInvalidUrl_HasErrors(string invalidUrl)
+        {
+            VerifyHasError($"{ShortOption} {invalidUrl}");
+        }
+
+        protected override void VerifyEqual(Uri? expectedValue, Uri? actualValue)
+        {
+            Assert.NotNull(expectedValue);
+            Assert.NotNull(actualValue);
+            Assert.Equal(expectedValue.IsAbsoluteUri, actualValue.IsAbsoluteUri);
+            Assert.Equal(expectedValue.AbsoluteUri, actualValue.AbsoluteUri);
         }
     }
 }

--- a/test/Sign.Cli.Test/SignCommandTests.cs
+++ b/test/Sign.Cli.Test/SignCommandTests.cs
@@ -45,17 +45,17 @@ namespace Sign.Cli.Test
         public void Command_WhenRequiredArgumentIsMissing_HasError()
         {
             string command = "code azure-key-vault --description a --description-url https://description.test "
-                + "-kvu https://keyvault.test -kvc b -kvm";
+                + "-kvu https://keyvault.test -kvc b -kvm --timestamp-url http://timestamp.test";
             ParseResult result = _parser.Parse(command);
 
             Assert.NotEmpty(result.Errors);
         }
 
         [Fact]
-        public void Command_WhenRequiredArgumentsArePresent_HasNoError()
+        public void Command_WhenRequiredArgumentIsPresent_HasNoError()
         {
             string command = "code azure-key-vault --description a --description-url https://description.test "
-                + "-kvu https://keyvault.test -kvc b -kvm c";
+                + "-kvu https://keyvault.test -kvc b -kvm --timestamp-url http://timestamp.test c";
             ParseResult result = _parser.Parse(command);
 
             Assert.Empty(result.Errors);

--- a/test/Sign.Core.Test/SignatureProviders/AggregatingSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/AggregatingSignatureProviderTests.cs
@@ -145,9 +145,7 @@ namespace Sign.Core.Test
             AggregatingSignatureProvider provider = CreateProvider();
 
             ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(
-                () => provider.SignAsync(
-                    files: null!,
-                    new SignOptions(HashAlgorithmName.SHA256, new Uri("http://timestamp.test"))));
+                () => provider.SignAsync(files: null!, _options));
 
             Assert.Equal("files", exception.ParamName);
         }
@@ -158,9 +156,7 @@ namespace Sign.Core.Test
             AggregatingSignatureProvider provider = CreateProvider();
 
             ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(
-                () => provider.SignAsync(
-                    Enumerable.Empty<FileInfo>(),
-                    options: null!));
+                () => provider.SignAsync(Enumerable.Empty<FileInfo>(), options: null!));
 
             Assert.Equal("options", exception.ParamName);
         }

--- a/test/Sign.Core.Test/SignatureProviders/AggregatingSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/AggregatingSignatureProviderTests.cs
@@ -10,7 +10,7 @@ namespace Sign.Core.Test
 {
     public partial class AggregatingSignatureProviderTests
     {
-        private static readonly SignOptions _options = new(HashAlgorithmName.SHA256);
+        private static readonly SignOptions _options = new(HashAlgorithmName.SHA256, new Uri("http://timestamp.test"));
 
         [Fact]
         public void Constructor_WhenSignatureProvidersIsNull_Throws()
@@ -147,7 +147,7 @@ namespace Sign.Core.Test
             ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(
                 () => provider.SignAsync(
                     files: null!,
-                    new SignOptions(HashAlgorithmName.SHA256)));
+                    new SignOptions(HashAlgorithmName.SHA256, new Uri("http://timestamp.test"))));
 
             Assert.Equal("files", exception.ParamName);
         }

--- a/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
@@ -179,7 +179,7 @@ namespace Sign.Core.Test
             ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(
                 () => _provider.SignAsync(
                     files: null!,
-                    new SignOptions(HashAlgorithmName.SHA256)));
+                    new SignOptions(HashAlgorithmName.SHA256, new Uri("http://timestamp.test"))));
 
             Assert.Equal("files", exception.ParamName);
         }

--- a/test/Sign.Core.Test/SignatureProviders/DefaultSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/DefaultSignatureProviderTests.cs
@@ -10,7 +10,7 @@ namespace Sign.Core.Test
 {
     public class DefaultSignatureProviderTests
     {
-        private static readonly Uri TimestampServiceUrl = new("http://timestamp.test");
+        private static readonly SignOptions _options = new(HashAlgorithmName.SHA256, new Uri("http://timestamp.test"));
 
         [Fact]
         public void Constructor_WhenServiceProviderIsNull_Throws()
@@ -86,9 +86,7 @@ namespace Sign.Core.Test
             DefaultSignatureProvider provider = CreateWithAzureSignTool();
 
             ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(
-                () => provider.SignAsync(
-                    files: null!,
-                    new SignOptions(HashAlgorithmName.SHA256, TimestampServiceUrl)));
+                () => provider.SignAsync(files: null!, _options));
 
             Assert.Equal("files", exception.ParamName);
         }
@@ -99,9 +97,8 @@ namespace Sign.Core.Test
             DefaultSignatureProvider provider = CreateWithAzureSignTool();
 
             ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(
-                () => provider.SignAsync(
-                    Enumerable.Empty<FileInfo>(),
-                    options: null!));
+                () => provider.SignAsync(Enumerable.Empty<FileInfo>(), options: null!));
+
             Assert.Equal("options", exception.ParamName);
         }
 
@@ -124,9 +121,7 @@ namespace Sign.Core.Test
 
             DefaultSignatureProvider provider = new(serviceProvider);
 
-            await provider.SignAsync(
-                Enumerable.Empty<FileInfo>(),
-                new SignOptions(HashAlgorithmName.SHA256, TimestampServiceUrl));
+            await provider.SignAsync(Enumerable.Empty<FileInfo>(), _options);
 
             mock.VerifyAll();
         }

--- a/test/Sign.Core.Test/SignatureProviders/DefaultSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/DefaultSignatureProviderTests.cs
@@ -10,6 +10,8 @@ namespace Sign.Core.Test
 {
     public class DefaultSignatureProviderTests
     {
+        private static readonly Uri TimestampServiceUrl = new("http://timestamp.test");
+
         [Fact]
         public void Constructor_WhenServiceProviderIsNull_Throws()
         {
@@ -86,7 +88,7 @@ namespace Sign.Core.Test
             ArgumentNullException exception = await Assert.ThrowsAsync<ArgumentNullException>(
                 () => provider.SignAsync(
                     files: null!,
-                    new SignOptions(HashAlgorithmName.SHA256)));
+                    new SignOptions(HashAlgorithmName.SHA256, TimestampServiceUrl)));
 
             Assert.Equal("files", exception.ParamName);
         }
@@ -124,7 +126,7 @@ namespace Sign.Core.Test
 
             await provider.SignAsync(
                 Enumerable.Empty<FileInfo>(),
-                new SignOptions(HashAlgorithmName.SHA256));
+                new SignOptions(HashAlgorithmName.SHA256, TimestampServiceUrl));
 
             mock.VerifyAll();
         }


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/538.

This change makes timestamping required.

CC @clairernovotny