### PR TITLE
Test:  improve tests by checking error messages

### DIFF
--- a/test/Sign.Cli.Test/Options/BaseDirectoryOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/BaseDirectoryOptionTests.cs
@@ -3,13 +3,14 @@
 // See the LICENSE.txt file in the project root for more information.
 
 using System.CommandLine.Parsing;
+using System.Globalization;
 
 namespace Sign.Cli.Test
 {
     public class BaseDirectoryOptionTests : DirectoryInfoOptionTests
     {
         public BaseDirectoryOptionTests()
-            : base(new CodeCommand().BaseDirectoryOption, "-b", "--base-directory", isRequired: false)
+            : base(new CodeCommand().BaseDirectoryOption, "-b", "--base-directory")
         {
         }
 
@@ -27,7 +28,9 @@ namespace Sign.Cli.Test
         [InlineData(@".\directory")]
         public void Option_WhenValueIsNotRooted_HasError(string relativePath)
         {
-            VerifyHasError($"{LongOption} {relativePath}");
+            VerifyHasErrors(
+                $"{LongOption} {relativePath}",
+                string.Format(CultureInfo.CurrentCulture, Resources.InvalidBaseDirectoryValue, "--base-directory"));
         }
 
         [Fact]

--- a/test/Sign.Cli.Test/Options/DescriptionOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/DescriptionOptionTests.cs
@@ -9,7 +9,7 @@ namespace Sign.Cli.Test
         private const string ExpectedValue = "peach";
 
         public DescriptionOptionTests()
-            : base(new CodeCommand().DescriptionOption, "-d", "--description", ExpectedValue, isRequired: true)
+            : base(new CodeCommand().DescriptionOption, "-d", "--description", ExpectedValue)
         {
         }
     }

--- a/test/Sign.Cli.Test/Options/DescriptionUrlOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/DescriptionUrlOptionTests.cs
@@ -7,7 +7,7 @@ namespace Sign.Cli.Test
     public class DescriptionUrlOptionTests : UriOptionTests
     {
         public DescriptionUrlOptionTests()
-            : base(new CodeCommand().DescriptionUrlOption, "-u", "--description-url", isRequired: true)
+            : base(new CodeCommand().DescriptionUrlOption, "-u", "--description-url")
         {
         }
     }

--- a/test/Sign.Cli.Test/Options/DirectoryInfoOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/DirectoryInfoOptionTests.cs
@@ -10,8 +10,8 @@ namespace Sign.Cli.Test
     {
         private static readonly DirectoryInfo ExpectedValue = new(Path.GetTempPath());
 
-        protected DirectoryInfoOptionTests(Option<DirectoryInfo> option, string shortOption, string longOption, bool isRequired)
-            : base(option, shortOption, longOption, ExpectedValue, isRequired)
+        protected DirectoryInfoOptionTests(Option<DirectoryInfo> option, string shortOption, string longOption)
+            : base(option, shortOption, longOption, ExpectedValue)
         {
         }
 

--- a/test/Sign.Cli.Test/Options/FileDigestOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/FileDigestOptionTests.cs
@@ -7,7 +7,7 @@ namespace Sign.Cli.Test
     public class FileDigestOptionTests : HashAlgorithmNameOptionTests
     {
         public FileDigestOptionTests()
-            : base(new CodeCommand().FileDigestOption, "-fd", "--file-digest", isRequired: false)
+            : base(new CodeCommand().FileDigestOption, "-fd", "--file-digest")
         {
         }
     }

--- a/test/Sign.Cli.Test/Options/HashAlgorithmNameOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/HashAlgorithmNameOptionTests.cs
@@ -12,8 +12,8 @@ namespace Sign.Cli.Test
     {
         private static readonly HashAlgorithmName ExpectedValue = HashAlgorithmName.SHA256;
 
-        protected HashAlgorithmNameOptionTests(Option<HashAlgorithmName> option, string shortOption, string longOption, bool isRequired)
-            : base(option, shortOption, longOption, ExpectedValue, isRequired)
+        protected HashAlgorithmNameOptionTests(Option<HashAlgorithmName> option, string shortOption, string longOption)
+            : base(option, shortOption, longOption, ExpectedValue)
         {
         }
 
@@ -47,7 +47,9 @@ namespace Sign.Cli.Test
         [InlineData("sha-256")]
         public void Verbosity_WhenValueIsInvalid_HasError(string value)
         {
-            VerifyHasError($"{LongOption} {value}");
+            VerifyHasErrors(
+                $"{LongOption} {value}",
+                GetFormattedResourceString(Resources.InvalidDigestValue, LongOption));
         }
 
         [Fact]

--- a/test/Sign.Cli.Test/Options/Int32OptionTests.cs
+++ b/test/Sign.Cli.Test/Options/Int32OptionTests.cs
@@ -10,8 +10,8 @@ namespace Sign.Cli.Test
     {
         private const int ExpectedValue = 3;
 
-        protected Int32OptionTests(Option<int> option, string shortOption, string longOption, bool isRequired)
-            : base(option, shortOption, longOption, ExpectedValue, isRequired)
+        protected Int32OptionTests(Option<int> option, string shortOption, string longOption)
+            : base(option, shortOption, longOption, ExpectedValue)
         {
         }
     }

--- a/test/Sign.Cli.Test/Options/MaxConcurrencyOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/MaxConcurrencyOptionTests.cs
@@ -9,14 +9,16 @@ namespace Sign.Cli.Test
     public class MaxConcurrencyOptionTests : Int32OptionTests
     {
         public MaxConcurrencyOptionTests()
-            : base(new CodeCommand().MaxConcurrencyOption, "-m", "--max-concurrency", isRequired: false)
+            : base(new CodeCommand().MaxConcurrencyOption, "-m", "--max-concurrency")
         {
         }
 
         [Fact]
         public void Option_WhenValueFailsToParse_HasError()
         {
-            VerifyHasError("x");
+            const string value = "x";
+
+            VerifyHasErrors(value, GetUnrecognizedCommandOrArgumentMessage(value));
         }
 
         [Fact]
@@ -33,7 +35,9 @@ namespace Sign.Cli.Test
         [InlineData(-1)]
         public void Option_WhenValueIsLessThanOne_HasError(int value)
         {
-            VerifyHasError($"{LongOption} {value}");
+            VerifyHasErrors(
+                $"{LongOption} {value}",
+                GetFormattedResourceString(Resources.InvalidMaxConcurrencyValue, LongOption));
         }
     }
 }

--- a/test/Sign.Cli.Test/Options/OutputOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/OutputOptionTests.cs
@@ -9,7 +9,7 @@ namespace Sign.Cli.Test
         private const string ExpectedValue = "peach";
 
         public OutputOptionTests()
-            : base(new CodeCommand().OutputOption, "-o", "--output", ExpectedValue, isRequired: false)
+            : base(new CodeCommand().OutputOption, "-o", "--output", ExpectedValue)
         {
         }
     }

--- a/test/Sign.Cli.Test/Options/PublisherNameOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/PublisherNameOptionTests.cs
@@ -9,7 +9,7 @@ namespace Sign.Cli.Test
         private const string? ExpectedValue = "peach";
 
         public PublisherNameOptionTests()
-            : base(new CodeCommand().PublisherNameOption, "-pn", "--publisher-name", ExpectedValue, isRequired: false)
+            : base(new CodeCommand().PublisherNameOption, "-pn", "--publisher-name", ExpectedValue)
         {
         }
     }

--- a/test/Sign.Cli.Test/Options/TimestampDigestOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/TimestampDigestOptionTests.cs
@@ -7,7 +7,7 @@ namespace Sign.Cli.Test
     public class TimestampDigestOptionTests : HashAlgorithmNameOptionTests
     {
         public TimestampDigestOptionTests()
-            : base(new CodeCommand().TimestampDigestOption, "-td", "--timestamp-digest", isRequired: false)
+            : base(new CodeCommand().TimestampDigestOption, "-td", "--timestamp-digest")
         {
         }
     }

--- a/test/Sign.Cli.Test/Options/TimestampUrlOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/TimestampUrlOptionTests.cs
@@ -7,7 +7,7 @@ namespace Sign.Cli.Test
     public class TimestampUrlOptionTests : UriOptionTests
     {
         public TimestampUrlOptionTests()
-            : base(new CodeCommand().TimestampUrlOption, "-t", "--timestamp-url", isRequired: true)
+            : base(new CodeCommand().TimestampUrlOption, "-t", "--timestamp-url")
         {
         }
     }

--- a/test/Sign.Cli.Test/Options/UriOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/UriOptionTests.cs
@@ -10,15 +10,29 @@ namespace Sign.Cli.Test
     {
         private static readonly Uri ExpectedValue = new("https://domain.test");
 
-        protected UriOptionTests(Option<Uri?> option, string shortOption, string longOption, bool isRequired)
-            : base(option, shortOption, longOption, ExpectedValue, isRequired)
+        protected UriOptionTests(Option<Uri?> option, string shortOption, string longOption)
+            : base(option, shortOption, longOption, ExpectedValue)
         {
         }
 
         [Fact]
         public void Option_WhenValueFailsToParse_HasError()
         {
-            VerifyHasError("3");
+            const string value = "3";
+
+            if (Option.IsRequired)
+            {
+                VerifyHasErrors(
+                    value,
+                    GetOptionIsRequiredMessage(ShortOption),
+                    GetUnrecognizedCommandOrArgumentMessage(value));
+            }
+            else
+            {
+                VerifyHasErrors(
+                    value,
+                    GetUnrecognizedCommandOrArgumentMessage(value));
+            }
         }
 
         [Theory]
@@ -37,7 +51,9 @@ namespace Sign.Cli.Test
         [InlineData("file:///file.bin")]
         public void Option_WithShortOptionAndInvalidUrl_HasErrors(string invalidUrl)
         {
-            VerifyHasError($"{ShortOption} {invalidUrl}");
+            VerifyHasErrors(
+                $"{ShortOption} {invalidUrl}",
+                GetFormattedResourceString(Resources.InvalidUrlValue, LongOption));
         }
 
         protected override void VerifyEqual(Uri? expectedValue, Uri? actualValue)

--- a/test/Sign.Cli.Test/Options/VerbosityOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/VerbosityOptionTests.cs
@@ -11,7 +11,7 @@ namespace Sign.Cli.Test
         private const LogLevel ExpectedValue = LogLevel.Debug;
 
         public VerbosityOptionTests()
-            : base(new CodeCommand().VerbosityOption, "-v", "--verbosity", ExpectedValue, isRequired: false)
+            : base(new CodeCommand().VerbosityOption, "-v", "--verbosity", ExpectedValue)
         {
         }
 


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/544.

This change simplifies tests a bit and checks error messages.

CC @erdembayar, @clairernovotny