### PR TITLE
Update AzureSign.Core from 3.0.0 to 4.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="Azure.Identity" Version="1.8.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.4.0" />
-    <PackageVersion Include="AzureSign.Core" Version="3.0.0" />
+    <PackageVersion Include="AzureSign.Core" Version="4.0.1" />
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/545.

This change updates AzureSign.Core from 3.0.0 to 4.0.1.

CC @clairernovotny