### PR TITLE
Update NuGet.* dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,10 @@
     <!-- Only use release versions.  Pre-release versions are signed with an untrusted certificate. -->
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
     <PackageVersion Include="Moq" Version="4.18.1" />
+    <!-- Lift this dependency from NuGetKeyVaultSignTool.Core to get the latest version. -->
+    <PackageVersion Include="NuGet.Packaging" Version="6.4.0" />
+    <!-- Lift this dependency from NuGetKeyVaultSignTool.Core to get the latest version. -->
+    <PackageVersion Include="NuGet.Protocol" Version="6.4.0" />
     <PackageVersion Include="NuGetKeyVaultSignTool.Core" Version="3.2.3" />
     <PackageVersion Include="OpenVsixSignTool.Core" Version="0.3.2" />
     <PackageVersion Include="RSAKeyVaultProvider" Version="2.1.1" />

--- a/src/Sign.Core/Sign.Core.csproj
+++ b/src/Sign.Core/Sign.Core.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" PrivateAssets="analyzers;build;compile;contentfiles" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="NuGetKeyVaultSignTool.Core" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="OpenVsixSignTool.Core" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="RSAKeyVaultProvider" PrivateAssets="analyzers;build;compile;contentfiles" />


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/555.

This change brings in version 6.4.0 of NuGet dependencies instead of 6.0.0-preview.4.243.

CC @clairernovotny