### PR TITLE
Update verbosity description

### DIFF
--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -97,7 +97,7 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512..
+        ///   Looks up a localized string similar to Digest algorithm to hash files with. Allowed values are &apos;sha256&apos;, &apos;sha384&apos;, and &apos;sha512&apos;..
         /// </summary>
         internal static string FileDigestOptionDescription {
             get {
@@ -124,7 +124,7 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid value for {0}. The value must be sha256, sha384, or sha512..
+        ///   Looks up a localized string similar to Invalid value for {0}. The value must be &apos;sha256&apos;, &apos;sha384&apos;, or &apos;sha512&apos;..
         /// </summary>
         internal static string InvalidDigestValue {
             get {
@@ -205,7 +205,7 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sets the verbosity level. Allowed values are None, Critical, Error, Warning, Information, Debug, and Trace..
+        ///   Looks up a localized string similar to Sets the verbosity level. Allowed values are &apos;none&apos;, &apos;critical&apos;, &apos;error&apos;, &apos;warning&apos;, &apos;information&apos;, &apos;debug&apos;, and &apos;trace&apos;..
         /// </summary>
         internal static string VerbosityOptionDescription {
             get {

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -205,7 +205,7 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]..
+        ///   Looks up a localized string similar to Sets the verbosity level. Allowed values are None, Critical, Error, Warning, Information, Debug, and Trace..
         /// </summary>
         internal static string VerbosityOptionDescription {
             get {

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -174,8 +174,8 @@
     <comment>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</comment>
   </data>
   <data name="VerbosityOptionDescription" xml:space="preserve">
-    <value>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</value>
-    <comment>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</comment>
+    <value>Sets the verbosity level. Allowed values are None, Critical, Error, Warning, Information, Debug, and Trace.</value>
+    <comment>{Locked="None","Critical","Error","Warning","Information","Debug","Trace"} are option values and should not be localized.</comment>
   </data>
   <data name="x86NotSupported" xml:space="preserve">
     <value>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</value>

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -130,7 +130,7 @@
     <value>Description URL of the signing certificate.</value>
   </data>
   <data name="FileDigestOptionDescription" xml:space="preserve">
-    <value>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</value>
+    <value>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</value>
     <comment>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</comment>
   </data>
   <data name="FileListOptionDescription" xml:space="preserve">
@@ -141,7 +141,7 @@
     <comment>{0} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
   </data>
   <data name="InvalidDigestValue" xml:space="preserve">
-    <value>Invalid value for {0}. The value must be sha256, sha384, or sha512.</value>
+    <value>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</value>
     <comment>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</comment>
   </data>
   <data name="InvalidMaxConcurrencyValue" xml:space="preserve">
@@ -174,8 +174,8 @@
     <comment>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</comment>
   </data>
   <data name="VerbosityOptionDescription" xml:space="preserve">
-    <value>Sets the verbosity level. Allowed values are None, Critical, Error, Warning, Information, Debug, and Trace.</value>
-    <comment>{Locked="None","Critical","Error","Warning","Information","Debug","Trace"} are option values and should not be localized.</comment>
+    <value>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</value>
+    <comment>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</comment>
   </data>
   <data name="x86NotSupported" xml:space="preserve">
     <value>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</value>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
-        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
@@ -38,8 +38,8 @@
         <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
-        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
-        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -83,9 +83,9 @@
         <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
-        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
-        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+        <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
+        <target state="new">Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</target>
+        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
-        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
@@ -38,8 +38,8 @@
         <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
-        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
-        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -83,9 +83,9 @@
         <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
-        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
-        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+        <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
+        <target state="new">Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</target>
+        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
-        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">Algoritmo de resumen con el que se van a aplicar algoritmos hash a los archivos. Los valores permitidos son sha256, sha384 y sha512.</target>
+        <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="needs-review-translation">Algoritmo de resumen con el que se van a aplicar algoritmos hash a los archivos. Los valores permitidos son sha256, sha384 y sha512.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
@@ -38,8 +38,8 @@
         <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
-        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
-        <target state="translated">Valor no válido para {0}. El valor debe ser sha256, sha384 o sha512.</target>
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="needs-review-translation">Valor no válido para {0}. El valor debe ser sha256, sha384 o sha512.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -83,9 +83,9 @@
         <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
-        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="translated">Establecer el nivel de detalle. Los valores permitidos son q[uiet], m[inimal], n[ormal], d[etailed] y diag[nostic]</target>
-        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+        <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
+        <target state="needs-review-translation">Establecer el nivel de detalle. Los valores permitidos son q[uiet], m[inimal], n[ormal], d[etailed] y diag[nostic]</target>
+        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
-        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
@@ -38,8 +38,8 @@
         <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
-        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
-        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -83,9 +83,9 @@
         <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
-        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
-        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+        <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
+        <target state="new">Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</target>
+        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
-        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">Algoritmo di digest con cui eseguire l'hashing dei file. I valori consentiti sono sha256, sha384 e sha512.</target>
+        <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="needs-review-translation">Algoritmo di digest con cui eseguire l'hashing dei file. I valori consentiti sono sha256, sha384 e sha512.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
@@ -38,8 +38,8 @@
         <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
-        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
-        <target state="translated">Valore non valido per {0}. Il valore deve essere sha256, sha384 o sha512.</target>
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="needs-review-translation">Valore non valido per {0}. Il valore deve essere sha256, sha384 o sha512.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -83,9 +83,9 @@
         <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
-        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="translated">Imposta il livello di dettaglio. I valori consentiti sono q[uiet], m[inimal], n[ormal], d[etailed] e diag[nostic].</target>
-        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+        <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
+        <target state="needs-review-translation">Imposta il livello di dettaglio. I valori consentiti sono q[uiet], m[inimal], n[ormal], d[etailed] e diag[nostic].</target>
+        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
-        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
@@ -38,8 +38,8 @@
         <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
-        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
-        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -83,9 +83,9 @@
         <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
-        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
-        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+        <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
+        <target state="new">Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</target>
+        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
-        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">파일을 해시하는 다이제스트 알고리즘입니다. 허용되는 값은 sha256, sha384 및 sha512입니다.</target>
+        <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="needs-review-translation">파일을 해시하는 다이제스트 알고리즘입니다. 허용되는 값은 sha256, sha384 및 sha512입니다.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
@@ -38,8 +38,8 @@
         <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
-        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
-        <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 sha256, sha384 또는 sha512여야 합니다.</target>
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="needs-review-translation">{0}에 대한 값이 잘못되었습니다. 값은 sha256, sha384 또는 sha512여야 합니다.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -83,9 +83,9 @@
         <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
-        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="translated">세부 정보 표시 수준을 설정합니다. 허용되는 값은 q[uiet], m[inimal], n[ormal], d[etailed] 및 diag[nostic]입니다.</target>
-        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+        <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
+        <target state="needs-review-translation">세부 정보 표시 수준을 설정합니다. 허용되는 값은 q[uiet], m[inimal], n[ormal], d[etailed] 및 diag[nostic]입니다.</target>
+        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
-        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
@@ -38,8 +38,8 @@
         <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
-        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
-        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -83,9 +83,9 @@
         <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
-        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
-        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+        <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
+        <target state="new">Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</target>
+        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
-        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
@@ -38,8 +38,8 @@
         <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
-        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
-        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -83,9 +83,9 @@
         <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
-        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
-        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+        <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
+        <target state="new">Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</target>
+        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
-        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
@@ -38,8 +38,8 @@
         <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
-        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
-        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -83,9 +83,9 @@
         <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
-        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
-        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+        <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
+        <target state="new">Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</target>
+        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
-        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
@@ -38,8 +38,8 @@
         <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
-        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
-        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -83,9 +83,9 @@
         <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
-        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
-        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+        <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
+        <target state="new">Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</target>
+        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
-        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
@@ -38,8 +38,8 @@
         <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
-        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
-        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -83,9 +83,9 @@
         <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
-        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
-        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+        <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
+        <target state="new">Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</target>
+        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
-        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">用於雜湊檔案的摘要演算法。允許的值為 sha256、sha384 和 sha512。</target>
+        <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="needs-review-translation">用於雜湊檔案的摘要演算法。允許的值為 sha256、sha384 和 sha512。</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
@@ -38,8 +38,8 @@
         <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
-        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
-        <target state="translated">{0} 的值無效。值必須是 sha256、sha384 或 sha512。</target>
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="needs-review-translation">{0} 的值無效。值必須是 sha256、sha384 或 sha512。</target>
         <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -83,9 +83,9 @@
         <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
-        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="translated">設定詳細資訊層級。允許的值為 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。</target>
-        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+        <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
+        <target state="needs-review-translation">設定詳細資訊層級。允許的值為 q[uiet]、m[inimal]、n[ormal]、d[etailed] 和 diag[nostic]。</target>
+        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/559.

This change updates the description for `--verbosity` option to display the correct allowed values.

CC @clairernovotny