### PR TITLE
Enable setting the publisher name and change old `--publisher-name` option to `--application-name`

### DIFF
--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -54,6 +54,7 @@ namespace Sign.Cli
             this.SetHandler(async (InvocationContext context) =>
             {
                 DirectoryInfo baseDirectory = context.ParseResult.GetValueForOption(_codeCommand.BaseDirectoryOption)!;
+                string? deploymentName = context.ParseResult.GetValueForOption(_codeCommand.DeploymentNameOption);
                 string? publisherName = context.ParseResult.GetValueForOption(_codeCommand.PublisherNameOption);
                 string? description = context.ParseResult.GetValueForOption(_codeCommand.DescriptionOption);
                 // This option is required.  If its value fails to parse we won't have reached here,
@@ -214,6 +215,7 @@ namespace Sign.Cli
                     output,
                     fileList,
                     baseDirectory,
+                    deploymentName,
                     publisherName,
                     description,
                     descriptionUrl,

--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -54,7 +54,7 @@ namespace Sign.Cli
             this.SetHandler(async (InvocationContext context) =>
             {
                 DirectoryInfo baseDirectory = context.ParseResult.GetValueForOption(_codeCommand.BaseDirectoryOption)!;
-                string? deploymentName = context.ParseResult.GetValueForOption(_codeCommand.DeploymentNameOption);
+                string? applicationName = context.ParseResult.GetValueForOption(_codeCommand.ApplicationNameOption);
                 string? publisherName = context.ParseResult.GetValueForOption(_codeCommand.PublisherNameOption);
                 string? description = context.ParseResult.GetValueForOption(_codeCommand.DescriptionOption);
                 // This option is required.  If its value fails to parse we won't have reached here,
@@ -215,7 +215,7 @@ namespace Sign.Cli
                     output,
                     fileList,
                     baseDirectory,
-                    deploymentName,
+                    applicationName,
                     publisherName,
                     description,
                     descriptionUrl,

--- a/src/Sign.Cli/CodeCommand.cs
+++ b/src/Sign.Cli/CodeCommand.cs
@@ -12,9 +12,9 @@ namespace Sign.Cli
 {
     internal sealed class CodeCommand : Command
     {
+        internal Option<string?> ApplicationNameOption { get; } = new(new[] { "-an", "--application-name" }, Resources.ApplicationNameOptionDescription);
         internal Option<DirectoryInfo> BaseDirectoryOption { get; } = new(new[] { "-b", "--base-directory" }, ParseBaseDirectoryOption, description: Resources.BaseDirectoryOptionDescription);
         internal Option<string> DescriptionOption { get; } = new(new[] { "-d", "--description" }, Resources.DescriptionOptionDescription);
-        internal Option<string?> DeploymentNameOption { get; } = new(new[] { "-dn", "--deployment-name" }, Resources.DeploymentNameOptionDescription);
         internal Option<Uri?> DescriptionUrlOption { get; } = new(new[] { "-u", "--description-url" }, ParseUrl, description: Resources.DescriptionUrlOptionDescription);
         internal Option<HashAlgorithmName> FileDigestOption { get; } = new(new[] { "-fd", "--file-digest" }, ParseHashAlgorithmName, description: Resources.FileDigestOptionDescription);
         internal Option<string?> FileListOption = new(new[] { "-fl", "--file-list" }, Resources.FileListOptionDescription);
@@ -40,7 +40,7 @@ namespace Sign.Cli
             // Global options are available on the adding command and all subcommands.
             // Order here is significant as it represents the order in which options are
             // displayed in help.
-            AddGlobalOption(DeploymentNameOption);
+            AddGlobalOption(ApplicationNameOption);
             AddGlobalOption(DescriptionOption);
             AddGlobalOption(DescriptionUrlOption);
             AddGlobalOption(BaseDirectoryOption);

--- a/src/Sign.Cli/CodeCommand.cs
+++ b/src/Sign.Cli/CodeCommand.cs
@@ -14,6 +14,7 @@ namespace Sign.Cli
     {
         internal Option<DirectoryInfo> BaseDirectoryOption { get; } = new(new[] { "-b", "--base-directory" }, ParseBaseDirectoryOption, description: Resources.BaseDirectoryOptionDescription);
         internal Option<string> DescriptionOption { get; } = new(new[] { "-d", "--description" }, Resources.DescriptionOptionDescription);
+        internal Option<string?> DeploymentNameOption { get; } = new(new[] { "-dn", "--deployment-name" }, Resources.DeploymentNameOptionDescription);
         internal Option<Uri?> DescriptionUrlOption { get; } = new(new[] { "-u", "--description-url" }, ParseUrl, description: Resources.DescriptionUrlOptionDescription);
         internal Option<HashAlgorithmName> FileDigestOption { get; } = new(new[] { "-fd", "--file-digest" }, ParseHashAlgorithmName, description: Resources.FileDigestOptionDescription);
         internal Option<string?> FileListOption = new(new[] { "-fl", "--file-list" }, Resources.FileListOptionDescription);
@@ -39,6 +40,7 @@ namespace Sign.Cli
             // Global options are available on the adding command and all subcommands.
             // Order here is significant as it represents the order in which options are
             // displayed in help.
+            AddGlobalOption(DeploymentNameOption);
             AddGlobalOption(DescriptionOption);
             AddGlobalOption(DescriptionUrlOption);
             AddGlobalOption(BaseDirectoryOption);

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Application name (ClickOnce)..
+        /// </summary>
+        internal static string ApplicationNameOptionDescription {
+            get {
+                return ResourceManager.GetString("ApplicationNameOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Base directory for files.  Overrides the current working directory..
         /// </summary>
         internal static string BaseDirectoryOptionDescription {
@@ -75,15 +84,6 @@ namespace Sign.Cli {
         internal static string CodeCommandDescription {
             get {
                 return ResourceManager.GetString("CodeCommandDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Deployment name (ClickOnce)..
-        /// </summary>
-        internal static string DeploymentNameOptionDescription {
-            get {
-                return ResourceManager.GetString("DeploymentNameOptionDescription", resourceCulture);
             }
         }
         

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Deployment name (ClickOnce)..
+        /// </summary>
+        internal static string DeploymentNameOptionDescription {
+            get {
+                return ResourceManager.GetString("DeploymentNameOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Description of the signing certificate..
         /// </summary>
         internal static string DescriptionOptionDescription {

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -117,14 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ApplicationNameOptionDescription" xml:space="preserve">
+    <value>Application name (ClickOnce).</value>
+  </data>
   <data name="BaseDirectoryOptionDescription" xml:space="preserve">
     <value>Base directory for files.  Overrides the current working directory.</value>
   </data>
   <data name="CodeCommandDescription" xml:space="preserve">
     <value>Sign binaries and containers.</value>
-  </data>
-  <data name="DeploymentNameOptionDescription" xml:space="preserve">
-    <value>Deployment name (ClickOnce).</value>
   </data>
   <data name="DescriptionOptionDescription" xml:space="preserve">
     <value>Description of the signing certificate.</value>

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -123,6 +123,9 @@
   <data name="CodeCommandDescription" xml:space="preserve">
     <value>Sign binaries and containers.</value>
   </data>
+  <data name="DeploymentNameOptionDescription" xml:space="preserve">
+    <value>Deployment name (ClickOnce).</value>
+  </data>
   <data name="DescriptionOptionDescription" xml:space="preserve">
     <value>Description of the signing certificate.</value>
   </data>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>Application name (ClickOnce).</source>
+        <target state="new">Application name (ClickOnce).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BaseDirectoryOptionDescription">
         <source>Base directory for files.  Overrides the current working directory.</source>
         <target state="new">Base directory for files.  Overrides the current working directory.</target>

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>Application name (ClickOnce).</source>
+        <target state="new">Application name (ClickOnce).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BaseDirectoryOptionDescription">
         <source>Base directory for files.  Overrides the current working directory.</source>
         <target state="new">Base directory for files.  Overrides the current working directory.</target>

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>Application name (ClickOnce).</source>
+        <target state="new">Application name (ClickOnce).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BaseDirectoryOptionDescription">
         <source>Base directory for files.  Overrides the current working directory.</source>
         <target state="translated">Directorio base para los archivos.  Invalida el directorio de trabajo actual.</target>

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>Application name (ClickOnce).</source>
+        <target state="new">Application name (ClickOnce).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BaseDirectoryOptionDescription">
         <source>Base directory for files.  Overrides the current working directory.</source>
         <target state="new">Base directory for files.  Overrides the current working directory.</target>

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>Application name (ClickOnce).</source>
+        <target state="new">Application name (ClickOnce).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BaseDirectoryOptionDescription">
         <source>Base directory for files.  Overrides the current working directory.</source>
         <target state="translated">Directory di base per i file.  Esegue l'override della directory di lavoro corrente.</target>

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>Application name (ClickOnce).</source>
+        <target state="new">Application name (ClickOnce).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BaseDirectoryOptionDescription">
         <source>Base directory for files.  Overrides the current working directory.</source>
         <target state="new">Base directory for files.  Overrides the current working directory.</target>

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>Application name (ClickOnce).</source>
+        <target state="new">Application name (ClickOnce).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BaseDirectoryOptionDescription">
         <source>Base directory for files.  Overrides the current working directory.</source>
         <target state="translated">파일의 기본 디렉터리입니다. 현재 작업 디렉터리를 재정의합니다.</target>

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>Application name (ClickOnce).</source>
+        <target state="new">Application name (ClickOnce).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BaseDirectoryOptionDescription">
         <source>Base directory for files.  Overrides the current working directory.</source>
         <target state="new">Base directory for files.  Overrides the current working directory.</target>

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>Application name (ClickOnce).</source>
+        <target state="new">Application name (ClickOnce).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BaseDirectoryOptionDescription">
         <source>Base directory for files.  Overrides the current working directory.</source>
         <target state="new">Base directory for files.  Overrides the current working directory.</target>

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>Application name (ClickOnce).</source>
+        <target state="new">Application name (ClickOnce).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BaseDirectoryOptionDescription">
         <source>Base directory for files.  Overrides the current working directory.</source>
         <target state="new">Base directory for files.  Overrides the current working directory.</target>

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>Application name (ClickOnce).</source>
+        <target state="new">Application name (ClickOnce).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BaseDirectoryOptionDescription">
         <source>Base directory for files.  Overrides the current working directory.</source>
         <target state="new">Base directory for files.  Overrides the current working directory.</target>

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>Application name (ClickOnce).</source>
+        <target state="new">Application name (ClickOnce).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BaseDirectoryOptionDescription">
         <source>Base directory for files.  Overrides the current working directory.</source>
         <target state="new">Base directory for files.  Overrides the current working directory.</target>

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationNameOptionDescription">
+        <source>Application name (ClickOnce).</source>
+        <target state="new">Application name (ClickOnce).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BaseDirectoryOptionDescription">
         <source>Base directory for files.  Overrides the current working directory.</source>
         <target state="translated">檔案的基底目錄。覆寫目前的工作目錄。</target>

--- a/src/Sign.Core/ISigner.cs
+++ b/src/Sign.Core/ISigner.cs
@@ -14,7 +14,7 @@ namespace Sign.Core
             string? outputFile,
             FileInfo? fileList,
             DirectoryInfo baseDirectory,
-            string? deploymentName,
+            string? applicationName,
             string? publisherName,
             string? description,
             Uri? descriptionUrl,

--- a/src/Sign.Core/ISigner.cs
+++ b/src/Sign.Core/ISigner.cs
@@ -14,6 +14,7 @@ namespace Sign.Core
             string? outputFile,
             FileInfo? fileList,
             DirectoryInfo baseDirectory,
+            string? deploymentName,
             string? publisherName,
             string? description,
             Uri? descriptionUrl,

--- a/src/Sign.Core/SignatureProviders/ClickOnceSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/ClickOnceSignatureProvider.cs
@@ -64,9 +64,9 @@ namespace Sign.Core
             Logger.LogInformation(Resources.ClickOnceSignatureProviderSigning, files.Count());
 
             var args = "-a sha256RSA";
-            if (!string.IsNullOrWhiteSpace(options.DeploymentName))
+            if (!string.IsNullOrWhiteSpace(options.ApplicationName))
             {
-                args += $@" -n ""{options.DeploymentName}""";
+                args += $@" -n ""{options.ApplicationName}""";
             }
 
             Uri? timeStampUrl = options.TimestampService;
@@ -129,7 +129,7 @@ namespace Sign.Core
                             throw new Exception(message);
                         }
 
-                        string publisherParam = "";
+                        string publisherParam = string.Empty;
 
                         if (string.IsNullOrEmpty(options.PublisherName))
                         {
@@ -140,7 +140,7 @@ namespace Sign.Core
                             string publisherName = publisherIdentity!.Attribute("name")!.Value;
                             Dictionary<string, List<string>> dict = DistinguishedNameParser.Parse(publisherName);
  
-                            if (dict.TryGetValue("CN", out var cns))
+                            if (dict.TryGetValue("CN", out List<string>? cns))
                             {
                                 // get the CN. it may be quoted
                                 publisherParam = $@"-pub ""{string.Join("+", cns.Select(s => s.Replace("\"", "")))}"" ";

--- a/src/Sign.Core/SignatureProviders/SignOptions.cs
+++ b/src/Sign.Core/SignatureProviders/SignOptions.cs
@@ -9,6 +9,7 @@ namespace Sign.Core
 {
     internal sealed class SignOptions
     {
+        internal string? DeploymentName { get; }
         internal string? PublisherName { get; }
         internal string? Description { get; }
         internal Uri? DescriptionUrl { get; }
@@ -19,6 +20,7 @@ namespace Sign.Core
         internal Uri TimestampService { get; }
 
         internal SignOptions(
+            string? deploymentName,
             string? publisherName,
             string? description,
             Uri? descriptionUrl,
@@ -28,6 +30,7 @@ namespace Sign.Core
             Matcher? matcher,
             Matcher? antiMatcher)
         {
+            DeploymentName = deploymentName;
             PublisherName = publisherName;
             Description = description;
             DescriptionUrl = descriptionUrl;
@@ -39,8 +42,9 @@ namespace Sign.Core
         }
 
         internal SignOptions(HashAlgorithmName fileHashAlgorithm, Uri timestampService)
-            : this(publisherName: null, description: null, descriptionUrl: null, fileHashAlgorithm,
-                HashAlgorithmName.SHA256, timestampService, matcher: null, antiMatcher: null)
+            : this(deploymentName: null, publisherName: null, description: null, descriptionUrl: null, 
+                  fileHashAlgorithm, HashAlgorithmName.SHA256, timestampService, matcher: null,
+                  antiMatcher: null)
         {
         }
     }

--- a/src/Sign.Core/SignatureProviders/SignOptions.cs
+++ b/src/Sign.Core/SignatureProviders/SignOptions.cs
@@ -9,7 +9,7 @@ namespace Sign.Core
 {
     internal sealed class SignOptions
     {
-        internal string? DeploymentName { get; }
+        internal string? ApplicationName { get; }
         internal string? PublisherName { get; }
         internal string? Description { get; }
         internal Uri? DescriptionUrl { get; }
@@ -20,7 +20,7 @@ namespace Sign.Core
         internal Uri TimestampService { get; }
 
         internal SignOptions(
-            string? deploymentName,
+            string? applicationName,
             string? publisherName,
             string? description,
             Uri? descriptionUrl,
@@ -30,7 +30,7 @@ namespace Sign.Core
             Matcher? matcher,
             Matcher? antiMatcher)
         {
-            DeploymentName = deploymentName;
+            ApplicationName = applicationName;
             PublisherName = publisherName;
             Description = description;
             DescriptionUrl = descriptionUrl;
@@ -42,7 +42,7 @@ namespace Sign.Core
         }
 
         internal SignOptions(HashAlgorithmName fileHashAlgorithm, Uri timestampService)
-            : this(deploymentName: null, publisherName: null, description: null, descriptionUrl: null, 
+            : this(applicationName: null, publisherName: null, description: null, descriptionUrl: null, 
                   fileHashAlgorithm, HashAlgorithmName.SHA256, timestampService, matcher: null,
                   antiMatcher: null)
         {

--- a/src/Sign.Core/Signer.cs
+++ b/src/Sign.Core/Signer.cs
@@ -33,6 +33,7 @@ namespace Sign.Core
             string? outputFile,
             FileInfo? fileList,
             DirectoryInfo baseDirectory,
+            string? deploymentName,
             string? publisherName,
             string? description,
             Uri? descriptionUrl,
@@ -67,6 +68,7 @@ namespace Sign.Core
             keyVaultService.Initialize(keyVaultUrl, tokenCredential, certificateName);
 
             SignOptions signOptions = new(
+                deploymentName,
                 publisherName,
                 description,
                 descriptionUrl,

--- a/src/Sign.Core/Signer.cs
+++ b/src/Sign.Core/Signer.cs
@@ -33,7 +33,7 @@ namespace Sign.Core
             string? outputFile,
             FileInfo? fileList,
             DirectoryInfo baseDirectory,
-            string? deploymentName,
+            string? applicationName,
             string? publisherName,
             string? description,
             Uri? descriptionUrl,
@@ -68,7 +68,7 @@ namespace Sign.Core
             keyVaultService.Initialize(keyVaultUrl, tokenCredential, certificateName);
 
             SignOptions signOptions = new(
-                deploymentName,
+                applicationName,
                 publisherName,
                 description,
                 descriptionUrl,

--- a/test/Sign.Cli.Test/Options/ApplicationNameOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/ApplicationNameOptionTests.cs
@@ -4,12 +4,12 @@
 
 namespace Sign.Cli.Test
 {
-    public class DeploymentNameOptionTests : OptionTests<string?>
+    public class ApplicationNameOptionTests : OptionTests<string?>
     {
         private const string? ExpectedValue = "peach";
 
-        public DeploymentNameOptionTests()
-            : base(new CodeCommand().DeploymentNameOption, "-dn", "--deployment-name", ExpectedValue)
+        public ApplicationNameOptionTests()
+            : base(new CodeCommand().ApplicationNameOption, "-an", "--application-name", ExpectedValue)
         {
         }
     }

--- a/test/Sign.Cli.Test/Options/DeploymentNameOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/DeploymentNameOptionTests.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.Cli.Test
+{
+    public class DeploymentNameOptionTests : OptionTests<string?>
+    {
+        private const string? ExpectedValue = "peach";
+
+        public DeploymentNameOptionTests()
+            : base(new CodeCommand().DeploymentNameOption, "-dn", "--deployment-name", ExpectedValue)
+        {
+        }
+    }
+}

--- a/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
@@ -238,6 +238,7 @@ namespace Sign.Core.Test
                     "MyApp_1_0_0_0", "MyApp.json.deploy");
 
                 SignOptions options = new(
+                    "DeploymentName",
                     "PublisherName",
                     "Description",
                     new Uri("https://description.test"),
@@ -271,12 +272,12 @@ namespace Sign.Core.Test
 
                     IDirectoryService directoryService = Mock.Of<IDirectoryService>();
                     Mock<IMageCli> mageCli = new();
-                    string expectedArgs = $"-update \"{manifestFile.FullName}\" -a sha256RSA -n \"{options.PublisherName}\"";
+                    string expectedArgs = $"-update \"{manifestFile.FullName}\" -a sha256RSA -n \"{options.DeploymentName}\"";
                     mageCli.Setup(x => x.RunAsync(
                             It.Is<string>(args => string.Equals(expectedArgs, args, StringComparison.Ordinal))))
                         .ReturnsAsync(0);
 
-                    expectedArgs = $"-update \"{applicationFile.FullName}\" -a sha256RSA -n \"{options.PublisherName}\" -appm \"{manifestFile.FullName}\" -pub \"Test certificate (DO NOT TRUST)\"  -SupportURL https://description.test/";
+                    expectedArgs = $"-update \"{applicationFile.FullName}\" -a sha256RSA -n \"{options.DeploymentName}\" -appm \"{manifestFile.FullName}\" -pub \"{options.PublisherName}\"  -SupportURL https://description.test/";
                     mageCli.Setup(x => x.RunAsync(
                             It.Is<string>(args => string.Equals(expectedArgs, args, StringComparison.Ordinal))))
                         .ReturnsAsync(0);

--- a/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
@@ -195,9 +195,13 @@ namespace Sign.Core.Test
             Assert.Equal("options", exception.ParamName);
         }
 
-        [Fact]
-        public async Task SignAsync_WhenFilesIsClickOnceFile_Signs()
+        [Theory]
+        [InlineData(null)]
+        [InlineData("PublisherName")]
+        public async Task SignAsync_WhenFilesIsClickOnceFile_Signs(string publisherName)
         {
+            const string commonName = "Test certificate (DO NOT TRUST)";
+
             using (TemporaryDirectory temporaryDirectory = new(_directoryService))
             {
                 FileInfo clickOnceFile = new(
@@ -221,9 +225,9 @@ namespace Sign.Core.Test
                 FileInfo manifestFile = AddFile(
                     containerSpy,
                     temporaryDirectory.Directory,
-                    @"<?xml version=""1.0"" encoding=""utf-8""?>
+                    @$"<?xml version=""1.0"" encoding=""utf-8""?>
 <asmv1:assembly xsi:schemaLocation=""urn:schemas-microsoft-com:asm.v1 assembly.adaptive.xsd"" manifestVersion=""1.0"" xmlns:asmv1=""urn:schemas-microsoft-com:asm.v1"" xmlns=""urn:schemas-microsoft-com:asm.v2"" xmlns:asmv2=""urn:schemas-microsoft-com:asm.v2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:co.v1=""urn:schemas-microsoft-com:clickonce.v1"" xmlns:asmv3=""urn:schemas-microsoft-com:asm.v3"" xmlns:dsig=""http://www.w3.org/2000/09/xmldsig#"" xmlns:co.v2=""urn:schemas-microsoft-com:clickonce.v2"">
-  <publisherIdentity name=""CN=Test certificate (DO NOT TRUST), O=unit.test"" />
+  <publisherIdentity name=""CN={commonName}, O=unit.test"" />
 </asmv1:assembly>",
                     "MyApp_1_0_0_0", "MyApp.dll.manifest");
                 FileInfo exeDeployFile = AddFile(
@@ -238,8 +242,8 @@ namespace Sign.Core.Test
                     "MyApp_1_0_0_0", "MyApp.json.deploy");
 
                 SignOptions options = new(
-                    "DeploymentName",
-                    "PublisherName",
+                    "ApplicationName",
+                    publisherName,
                     "Description",
                     new Uri("https://description.test"),
                     HashAlgorithmName.SHA256,
@@ -272,12 +276,23 @@ namespace Sign.Core.Test
 
                     IDirectoryService directoryService = Mock.Of<IDirectoryService>();
                     Mock<IMageCli> mageCli = new();
-                    string expectedArgs = $"-update \"{manifestFile.FullName}\" -a sha256RSA -n \"{options.DeploymentName}\"";
+                    string expectedArgs = $"-update \"{manifestFile.FullName}\" -a sha256RSA -n \"{options.ApplicationName}\"";
                     mageCli.Setup(x => x.RunAsync(
                             It.Is<string>(args => string.Equals(expectedArgs, args, StringComparison.Ordinal))))
                         .ReturnsAsync(0);
 
-                    expectedArgs = $"-update \"{applicationFile.FullName}\" -a sha256RSA -n \"{options.DeploymentName}\" -appm \"{manifestFile.FullName}\" -pub \"{options.PublisherName}\"  -SupportURL https://description.test/";
+                    string publisher;
+
+                    if (string.IsNullOrEmpty(options.PublisherName))
+                    {
+                        publisher = commonName;
+                    }
+                    else
+                    {
+                        publisher = options.PublisherName;
+                    }
+
+                    expectedArgs = $"-update \"{applicationFile.FullName}\" -a sha256RSA -n \"{options.ApplicationName}\" -appm \"{manifestFile.FullName}\" -pub \"{publisher}\"  -SupportURL https://description.test/";
                     mageCli.Setup(x => x.RunAsync(
                             It.Is<string>(args => string.Equals(expectedArgs, args, StringComparison.Ordinal))))
                         .ReturnsAsync(0);


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/567.

This change renames the existing `-pn` | `--publisher-name` option to `-dn` | `--deployment-name`.  This option was already setting the deployment name.  Also, this change introduces a new `-pn` | `--publisher-name` option for setting publisher name. 

CC @clairernovotny