### PR TITLE
Enable signing already signed NuGet package

### DIFF
--- a/src/Sign.Core/Containers/ContainerProvider.cs
+++ b/src/Sign.Core/Containers/ContainerProvider.cs
@@ -15,6 +15,7 @@ namespace Sign.Core
         private readonly IKeyVaultService _keyVaultService;
         private readonly ILogger _logger;
         private readonly IMakeAppxCli _makeAppxCli;
+        private readonly HashSet<string> _nuGetExtensions;
         private readonly HashSet<string> _zipExtensions;
 
         // Dependency injection requires a public constructor.
@@ -53,13 +54,17 @@ namespace Sign.Core
                 ".msix"
             };
 
+            _nuGetExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ".nupkg",
+                ".snupkg"
+            };
+
             _zipExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 ".appxupload",
                 ".clickonce",
                 ".msixupload",
-                ".nupkg",
-                ".snupkg",
                 ".vsix",
                 ".zip"
             };
@@ -77,6 +82,13 @@ namespace Sign.Core
             ArgumentNullException.ThrowIfNull(file, nameof(file));
 
             return _appxExtensions.Contains(file.Extension);
+        }
+
+        public bool IsNuGetContainer(FileInfo file)
+        {
+            ArgumentNullException.ThrowIfNull(file, nameof(file));
+
+            return _nuGetExtensions.Contains(file.Extension);
         }
 
         public bool IsZipContainer(FileInfo file)
@@ -103,6 +115,11 @@ namespace Sign.Core
             if (IsZipContainer(file))
             {
                 return new ZipContainer(file, _directoryService, _fileMatcher, _logger);
+            }
+
+            if (IsNuGetContainer(file))
+            {
+                return new NuGetContainer(file, _directoryService, _fileMatcher, _logger);
             }
 
             return null;

--- a/src/Sign.Core/Containers/IContainerProvider.cs
+++ b/src/Sign.Core/Containers/IContainerProvider.cs
@@ -8,6 +8,7 @@ namespace Sign.Core
     {
         bool IsAppxBundleContainer(FileInfo file);
         bool IsAppxContainer(FileInfo file);
+        bool IsNuGetContainer(FileInfo file);
         bool IsZipContainer(FileInfo file);
         IContainer? GetContainer(FileInfo file);
     }

--- a/src/Sign.Core/Containers/NuGetContainer.cs
+++ b/src/Sign.Core/Containers/NuGetContainer.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using NuGet.Packaging.Signing;
+
+namespace Sign.Core
+{
+    internal sealed class NuGetContainer : ZipContainer
+    {
+        internal NuGetContainer(
+            FileInfo zipFile,
+            IDirectoryService directoryService,
+            IFileMatcher fileMatcher, ILogger logger)
+            : base(zipFile, directoryService, fileMatcher, logger)
+        {
+        }
+
+        public override ValueTask SaveAsync()
+        {
+            if (TemporaryDirectory is null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            FileInfo signatureFile = new(
+                Path.Combine(
+                    TemporaryDirectory.Directory.FullName,
+                    SigningSpecifications.V1.SignaturePath));
+
+            if (signatureFile.Exists)
+            {
+                signatureFile.Delete();
+            }
+
+            return base.SaveAsync();
+        }
+    }
+}

--- a/src/Sign.Core/Containers/ZipContainer.cs
+++ b/src/Sign.Core/Containers/ZipContainer.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Sign.Core
 {
-    internal sealed class ZipContainer : Container
+    internal class ZipContainer : Container
     {
         private readonly IDirectoryService _directoryService;
         private readonly ILogger _logger;

--- a/src/Sign.Core/SignatureProviders/AggregatingSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/AggregatingSignatureProvider.cs
@@ -64,7 +64,7 @@ namespace Sign.Core
 
             // See if any of them are archives
             List<FileInfo> archives = (from file in files
-                                       where _containerProvider.IsZipContainer(file)
+                                       where _containerProvider.IsZipContainer(file) || _containerProvider.IsNuGetContainer(file)
                                        select file).ToList();
 
             // expand the archives and sign recursively first

--- a/test/Sign.Core.Test/Containers/ContainerProviderTests.cs
+++ b/test/Sign.Core.Test/Containers/ContainerProviderTests.cs
@@ -91,7 +91,6 @@ namespace Sign.Core.Test
             Assert.Equal("logger", exception.ParamName);
         }
 
-
         [Fact]
         public void IsAppxBundleContainer_WhenFileIsNull_Throws()
         {
@@ -159,6 +158,35 @@ namespace Sign.Core.Test
         }
 
         [Fact]
+        public void IsNuGetContainer_WhenFileIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => _provider.IsNuGetContainer(file: null!));
+
+            Assert.Equal("file", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(".zip")]
+        public void IsNuGetContainer_WhenFileExtensionDoesNotMatch_ReturnsFalse(string extension)
+        {
+            FileInfo file = new($"file{extension}");
+
+            Assert.False(_provider.IsNuGetContainer(file));
+        }
+
+        [Theory]
+        [InlineData(".nupkg")]
+        [InlineData(".snupkg")]
+        [InlineData(".NuPkg")] // test case insensitivity
+        public void IsNuGetContainer_WhenFileExtensionMatches_ReturnsTrue(string extension)
+        {
+            FileInfo file = new($"file{extension}");
+
+            Assert.True(_provider.IsNuGetContainer(file));
+        }
+
+        [Fact]
         public void IsZipContainer_WhenFileIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
@@ -182,8 +210,6 @@ namespace Sign.Core.Test
         [InlineData(".appxupload")]
         [InlineData(".clickonce")]
         [InlineData(".msixupload")]
-        [InlineData(".nupkg")]
-        [InlineData(".snupkg")]
         [InlineData(".vsix")]
         [InlineData(".zip")]
         [InlineData(".ZIP")] // test case insensitivity

--- a/test/Sign.Core.Test/TestInfrastructure/AggregatingSignatureProviderTest.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/AggregatingSignatureProviderTest.cs
@@ -130,6 +130,7 @@ namespace Sign.Core.Test
                     if (!isDirectory &&
                         (_containerProvider.IsAppxBundleContainer(file) ||
                         _containerProvider.IsAppxContainer(file) ||
+                        _containerProvider.IsNuGetContainer(file) ||
                         _containerProvider.IsZipContainer(file)))
                     {
                         files.Add(file);

--- a/test/Sign.Core.Test/TestInfrastructure/ContainerProviderStub.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/ContainerProviderStub.cs
@@ -33,6 +33,11 @@ namespace Sign.Core.Test
             return _containerProvider.IsAppxContainer(file);
         }
 
+        public bool IsNuGetContainer(FileInfo file)
+        {
+            return _containerProvider.IsNuGetContainer(file);
+        }
+
         public bool IsZipContainer(FileInfo file)
         {
             return _containerProvider.IsZipContainer(file);

--- a/test/Sign.Core.Test/TestInfrastructure/DirectoryServiceStub.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/DirectoryServiceStub.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.Core.Test
+{
+    internal sealed class DirectoryServiceStub : IDirectoryService
+    {
+        private readonly List<DirectoryInfo> _directories;
+
+        internal IReadOnlyList<DirectoryInfo> Directories { get; }
+
+        internal DirectoryServiceStub()
+        {
+            Directories = _directories = new List<DirectoryInfo>();
+        }
+
+        public DirectoryInfo CreateTemporaryDirectory()
+        {
+            DirectoryInfo directory = new(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+
+            directory.Create();
+
+            _directories.Add(directory);
+
+            return directory;
+        }
+
+        public void Delete(DirectoryInfo directory)
+        {
+            directory.Refresh();
+
+            if (directory.Exists)
+            {
+                directory.Delete(recursive: true);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (DirectoryInfo directory in _directories)
+            {
+                Delete(directory);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/547.

This change enables signing an already signed NuGet package.

CC @clairernovotny