### PR TITLE
Update dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Azure.Identity" Version="1.8.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.8.1" />
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.4.0" />
     <PackageVersion Include="AzureSign.Core" Version="4.0.1" />
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
@@ -13,13 +13,13 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <!-- Only use release versions.  Pre-release versions are signed with an untrusted certificate. -->
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
-    <PackageVersion Include="Moq" Version="4.18.1" />
+    <PackageVersion Include="Moq" Version="4.18.4" />
     <!-- Lift this dependency from NuGetKeyVaultSignTool.Core to get the latest version. -->
     <PackageVersion Include="NuGet.Packaging" Version="6.4.0" />
     <!-- Lift this dependency from NuGetKeyVaultSignTool.Core to get the latest version. -->
     <PackageVersion Include="NuGet.Protocol" Version="6.4.0" />
     <PackageVersion Include="NuGetKeyVaultSignTool.Core" Version="3.2.3" />
-    <PackageVersion Include="OpenVsixSignTool.Core" Version="0.3.2" />
+    <PackageVersion Include="OpenVsixSignTool.Core" Version="0.4.0" />
     <PackageVersion Include="RSAKeyVaultProvider" Version="2.1.1" />
     <PackageVersion Include="System.CommandLine" Version="$(GenAPISystemCommandLineVersion)" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="7.0.1" />


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/574 and https://github.com/dotnet/sign/issues/536

This change updates dependencies:

* Azure.Identity 1.8.0 -> 1.8.1
* Moq 4.18.1 -> 4.18.4
* OpenVsixSignTool.Core 0.3.2 -> 0.4.0

CC @clairernovotny