### PR TITLE
Fix and improve logging

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,8 @@
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.4.0" />
     <PackageVersion Include="AzureSign.Core" Version="4.0.1" />
     <PackageVersion Include="coverlet.collector" Version="3.1.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />

--- a/src/Sign.Core/Resources.Designer.cs
+++ b/src/Sign.Core/Resources.Designer.cs
@@ -178,6 +178,24 @@ namespace Sign.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Fetched certificate. [{milliseconds} ms].
+        /// </summary>
+        internal static string FetchedCertificate {
+            get {
+                return ResourceManager.GetString("FetchedCertificate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fetching certificate from Azure Key Vault..
+        /// </summary>
+        internal static string FetchingCertificate {
+            get {
+                return ResourceManager.GetString("FetchingCertificate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Extracting container {ContainerFilePath} to {DirectoryPath}..
         /// </summary>
         internal static string OpeningContainer {

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -166,6 +166,13 @@
     <value>An exception occurred while attempting to delete directory {path}.</value>
     <comment>Do not localize value inside {}.</comment>
   </data>
+  <data name="FetchedCertificate" xml:space="preserve">
+    <value>Fetched certificate. [{milliseconds} ms]</value>
+    <comment>Do not localize value inside {}.</comment>
+  </data>
+  <data name="FetchingCertificate" xml:space="preserve">
+    <value>Fetching certificate from Azure Key Vault.</value>
+  </data>
   <data name="OpeningContainer" xml:space="preserve">
     <value>Extracting container {ContainerFilePath} to {DirectoryPath}.</value>
     <comment>Do not localize value inside {}.</comment>

--- a/src/Sign.Core/Sign.Core.csproj
+++ b/src/Sign.Core/Sign.Core.csproj
@@ -9,6 +9,8 @@
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="AzureSign.Core" PrivateAssets="analyzers;build;compile;contentfiles" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" PrivateAssets="analyzers;build;compile;contentfiles" />

--- a/test/Sign.Core.Test/SignerTests.cs
+++ b/test/Sign.Core.Test/SignerTests.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Sign.Core.Test
+{
+    public class SignerTests
+    {
+        [Fact]
+        public void Constructor_WhenServiceProviderIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new Signer(serviceProvider: null!, Mock.Of<ILogger<ISigner>>()));
+
+            Assert.Equal("serviceProvider", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenLoggerIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new Signer(Mock.Of<IServiceProvider>(), logger: null!));
+
+            Assert.Equal("logger", exception.ParamName);
+        }
+    }
+}


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/579.

This change:

* wires up the `-v` | `--verbosity` option to enable logging verbosity
* taps into Microsoft.Extensions.Logging's configuration options to enable setting logging options (e.g.:  verbosity, format, etc.) via environment variables or appsettings.json file
* cleans up some code to use dependency injection
* adds logging for certificate retrieval
* adds some unit tests

CC @clairernovotny