### PR TITLE
Fix verbosity option

### DIFF
--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -98,7 +98,7 @@ namespace Sign.Cli
                     return;
                 }
 
-                Core.ServiceProvider serviceProvider = Core.ServiceProvider.CreateDefault();
+                Core.ServiceProvider serviceProvider = Core.ServiceProvider.CreateDefault(verbosity);
 
                 List<FileInfo> inputFiles;
 

--- a/src/Sign.Core/ServiceProvider.cs
+++ b/src/Sign.Core/ServiceProvider.cs
@@ -26,7 +26,9 @@ namespace Sign.Core
             return _serviceProvider.GetService(serviceType);
         }
 
-        internal static ServiceProvider CreateDefault(LogLevel logLevel = LogLevel.Information)
+        internal static ServiceProvider CreateDefault(
+            LogLevel logLevel = LogLevel.Information,
+            ILoggerProvider? loggerProvider = null)
         {
             IServiceCollection services = new ServiceCollection();
             IConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
@@ -41,9 +43,14 @@ namespace Sign.Core
 
             services.AddLogging(builder =>
             {
-                builder.SetMinimumLevel(logLevel)
+                builder = builder.SetMinimumLevel(logLevel)
                     .AddConfiguration(loggingSection)
                     .AddConsole();
+
+                if (loggerProvider is not null)
+                {
+                    builder.AddProvider(loggerProvider);
+                }
             });
 
             services.AddSingleton<IAppRootDirectoryLocator, AppRootDirectoryLocator>();


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/579.

This change fixes the `-v` | `--verbosity` option once and for all and adds unit test coverage too.

CC @clairernovotny