### PR TITLE
Improve resource string comments

### DIFF
--- a/src/Sign.Cli/AzureKeyVaultResources.resx
+++ b/src/Sign.Cli/AzureKeyVaultResources.resx
@@ -134,11 +134,11 @@
   </data>
   <data name="InvalidBaseDirectoryValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be a fully rooted directory path.</value>
-    <comment>{0} is the option name (e.g.:  --base-directory)</comment>
+    <comment>{0} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
   </data>
   <data name="InvalidClientSecretCredential" xml:space="preserve">
     <value>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</value>
-    <comment>{0}, {1}, and {2} are option names</comment>
+    <comment>{0}, {1}, and {2} are option names and should not be localized.</comment>
   </data>
   <data name="InvalidFileValue" xml:space="preserve">
     <value>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</value>
@@ -154,7 +154,7 @@
   </data>
   <data name="SomeFilesDoNotExist" xml:space="preserve">
     <value>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</value>
-    <comment>{0} is an option name (e.g.:  --base-directory)</comment>
+    <comment>{0} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
   </data>
   <data name="TenantIdOptionDescription" xml:space="preserve">
     <value>Tenant ID to authenticate to Azure Key Vault.</value>

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -131,25 +131,26 @@
   </data>
   <data name="FileDigestOptionDescription" xml:space="preserve">
     <value>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</value>
+    <comment>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</comment>
   </data>
   <data name="FileListOptionDescription" xml:space="preserve">
     <value>Path to file containing paths of files to sign within an archive.</value>
   </data>
   <data name="InvalidBaseDirectoryValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be a fully rooted directory path.</value>
-    <comment>{0} is the option name (e.g.:  --base-directory)</comment>
+    <comment>{0} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
   </data>
   <data name="InvalidDigestValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be sha256, sha384, or sha512.</value>
-    <comment>{0} is the option name (e.g.:  --file-digest)</comment>
+    <comment>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</comment>
   </data>
   <data name="InvalidMaxConcurrencyValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be a number value greater than or equal to 1.</value>
-    <comment>{0} is the option name (e.g.:  --max-concurrency)</comment>
+    <comment>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</comment>
   </data>
   <data name="InvalidUrlValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</value>
-    <comment>{0} is the option name (e.g.:  --timestamp-url)</comment>
+    <comment>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</comment>
   </data>
   <data name="MaxConcurrencyOptionDescription" xml:space="preserve">
     <value>Maximum concurrency (default is 4).</value>
@@ -159,18 +160,22 @@
   </data>
   <data name="PublisherNameOptionDescription" xml:space="preserve">
     <value>Publisher name (ClickOnce).</value>
+    <comment>ClickOnce is a Microsoft deployment technology.</comment>
   </data>
   <data name="SignCommandDescription" xml:space="preserve">
     <value>Sign CLI</value>
   </data>
   <data name="TimestampDigestOptionDescription" xml:space="preserve">
     <value>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</value>
+    <comment>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</comment>
   </data>
   <data name="TimestampUrlOptionDescription" xml:space="preserve">
     <value>RFC 3161 timestamp server URL.</value>
+    <comment>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</comment>
   </data>
   <data name="VerbosityOptionDescription" xml:space="preserve">
     <value>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</value>
+    <comment>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</comment>
   </data>
   <data name="x86NotSupported" xml:space="preserve">
     <value>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</value>

--- a/src/Sign.Core/Resources.Designer.cs
+++ b/src/Sign.Core/Resources.Designer.cs
@@ -259,7 +259,7 @@ namespace Sign.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Performing attempt #{attempt} of {maxAttempts} attempts after {seconds}s..
+        ///   Looks up a localized string similar to Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s..
         /// </summary>
         internal static string SigningAttempt {
             get {

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -119,63 +119,64 @@
   </resheader>
   <data name="AzureSignToolSignatureProviderSigning" xml:space="preserve">
     <value>Signing SignTool job with {count} files.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="CertificateIsExpired" xml:space="preserve">
     <value>The certificate is expired.</value>
   </data>
   <data name="CertificateIsNotYetTimeValid" xml:space="preserve">
     <value>The certificate is not yet time valid.</value>
+    <comment>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</comment>
   </data>
   <data name="ClickOnceSignatureProviderSigning" xml:space="preserve">
     <value>Signing Mage job with {count} files.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="CliStandardError" xml:space="preserve">
     <value>{fileName} Err {error}</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="CliStandardOutput" xml:space="preserve">
     <value>{fileName} Out {output}</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="CreatingDirectory" xml:space="preserve">
     <value>Creating directory {path}.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{path} is a directory path.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="DeletedDirectory" xml:space="preserve">
     <value>Directory {path} deleted.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{path} is a directory path.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="DeletingDirectory" xml:space="preserve">
     <value>Deleting directory {path}.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{path} is a directory path.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="DirectoryNotDeleted" xml:space="preserve">
     <value>Directory {path} still exists.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{path} is a directory path.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="EditingAppInstaller" xml:space="preserve">
     <value>Editing AppInstaller job with {count} files.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="ErrorSigningVsix" xml:space="preserve">
     <value>An unspecified error occurred during VSIX signing.</value>
   </data>
   <data name="ExceptionWhileDeletingDirectory" xml:space="preserve">
     <value>An exception occurred while attempting to delete directory {path}.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{path} is a directory path.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="FetchedCertificate" xml:space="preserve">
     <value>Fetched certificate. [{milliseconds} ms]</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="FetchingCertificate" xml:space="preserve">
     <value>Fetching certificate from Azure Key Vault.</value>
   </data>
   <data name="OpeningContainer" xml:space="preserve">
     <value>Extracting container {ContainerFilePath} to {DirectoryPath}.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="ProcessCouldNotBeKilled" xml:space="preserve">
     <value>{0} timed out and could not be killed.</value>
@@ -183,7 +184,7 @@
   </data>
   <data name="ProcessDidNotExitInTime" xml:space="preserve">
     <value>{fileName} took too long to respond. The process exit code is {exitCode}.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="ProcessDidNotExitInTimeWithArguments" xml:space="preserve">
     <value>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</value>
@@ -191,19 +192,19 @@
   </data>
   <data name="RunningCli" xml:space="preserve">
     <value>Running {fileName} with parameters: '{args}'.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="SavingContainer" xml:space="preserve">
     <value>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="SignAsyncCalled" xml:space="preserve">
     <value>SignAsync called for {filePath}. Using {localFilePath} locally.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="SigningAttempt" xml:space="preserve">
-    <value>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds}s.</value>
-    <comment>Do not localize value inside {}.  The final "s" after "{seconds}" represents the unit for seconds not the plural for seconds.</comment>
+    <value>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</value>
+    <comment>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="SigningFailed" xml:space="preserve">
     <value>Could not sign {0}.</value>
@@ -214,28 +215,28 @@
   </data>
   <data name="SigningFailedWithError" xml:space="preserve">
     <value>Signing failed with error {errorCode}.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="SigningFile" xml:space="preserve">
     <value>Signing {filePath}.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{filePath} is a file path.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="SigningSucceeded" xml:space="preserve">
     <value>Signing succeeded.</value>
   </data>
   <data name="SigningSucceededWithTimeElapsed" xml:space="preserve">
     <value>Successfully signed {filePath} in {millseconds} ms</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="SubmittingFileForSigning" xml:space="preserve">
     <value>Submitting {filePath} for signing.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{filePath} is a file path.  The literal text inside the brackets should not be localized.</comment>
   </data>
   <data name="ValueCannotBeEmptyString" xml:space="preserve">
     <value>The value cannot be an empty string.</value>
   </data>
   <data name="VsixSignatureProviderSigning" xml:space="preserve">
     <value>Signing OpenVsixSignTool job with {count} files.</value>
-    <comment>Do not localize value inside {}.</comment>
+    <comment>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</comment>
   </data>
 </root>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/582.  Progress on https://github.com/dotnet/sign/issues/570.

This change updates resource string comments to be more useful during localization.

CC @clairernovotny