### PR TITLE
Use explicit version instead of property for package version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="NuGetKeyVaultSignTool.Core" Version="3.2.3" />
     <PackageVersion Include="OpenVsixSignTool.Core" Version="0.4.0" />
     <PackageVersion Include="RSAKeyVaultProvider" Version="2.1.1" />
-    <PackageVersion Include="System.CommandLine" Version="$(GenAPISystemCommandLineVersion)" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="7.0.1" />
     <PackageVersion Include="System.Text.Json" Version="7.0.1" />
   </ItemGroup>


### PR DESCRIPTION
This change uses an explicit version instead of an Arcade property for the System.CommandLine package.

Note that the [package version isn't changing](https://github.com/dotnet/sign/blob/25b85a1dba230b6ed59d9cf66704a06ddbe430a1/eng/Versions.props#L36).