### PR TITLE
Enable Xliff-Tasks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
     <Deterministic>true</Deterministic>
+    <EnableXlfLocalization>true</EnableXlfLocalization>
     <Features>strict</Features>
     <ImplicitUsings>enable</ImplicitUsings>
     <!--
@@ -24,6 +25,7 @@
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <UpdateXlfOnBuild Condition="'$(CI)' != '1'">true</UpdateXlfOnBuild>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,9 +4,5 @@
     <!-- This repo version -->
     <VersionPrefix>0.9.0</VersionPrefix>
     <PreReleaseVersionLabel>beta</PreReleaseVersionLabel>
-    <!-- Opt-out repo features -->
-    <UsingToolXliff>false</UsingToolXliff>
-    <!-- Libs -->
-    <GenAPISystemCommandLineVersion>2.0.0-beta4.22272.1</GenAPISystemCommandLineVersion>
   </PropertyGroup>
 </Project>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../AzureKeyVaultResources.resx">
+    <body>
+      <trans-unit id="CertificateOptionDescription">
+        <source>Name of the certificate in Azure Key Vault.</source>
+        <target state="new">Name of the certificate in Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientIdOptionDescription">
+        <source>Client ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Client ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientSecretOptionDescription">
+        <source>Client secret to authenticate to Azure Key Vault.</source>
+        <target state="new">Client secret to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Use Azure Key Vault.</source>
+        <target state="new">Use Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="new">File(s) to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidClientSecretCredential">
+        <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
+        <target state="new">If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</target>
+        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityOptionDescription">
+        <source>Managed identity to authenticate to Azure Key Vault.</source>
+        <target state="new">Managed identity to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="new">A file or glob is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="new">No inputs found to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TenantIdOptionDescription">
+        <source>Tenant ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Tenant ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UrlOptionDescription">
+        <source>URL to an Azure Key Vault.</source>
+        <target state="new">URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../AzureKeyVaultResources.resx">
+    <body>
+      <trans-unit id="CertificateOptionDescription">
+        <source>Name of the certificate in Azure Key Vault.</source>
+        <target state="new">Name of the certificate in Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientIdOptionDescription">
+        <source>Client ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Client ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientSecretOptionDescription">
+        <source>Client secret to authenticate to Azure Key Vault.</source>
+        <target state="new">Client secret to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Use Azure Key Vault.</source>
+        <target state="new">Use Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="new">File(s) to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidClientSecretCredential">
+        <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
+        <target state="new">If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</target>
+        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityOptionDescription">
+        <source>Managed identity to authenticate to Azure Key Vault.</source>
+        <target state="new">Managed identity to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="new">A file or glob is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="new">No inputs found to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TenantIdOptionDescription">
+        <source>Tenant ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Tenant ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UrlOptionDescription">
+        <source>URL to an Azure Key Vault.</source>
+        <target state="new">URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../AzureKeyVaultResources.resx">
+    <body>
+      <trans-unit id="CertificateOptionDescription">
+        <source>Name of the certificate in Azure Key Vault.</source>
+        <target state="new">Name of the certificate in Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientIdOptionDescription">
+        <source>Client ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Client ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientSecretOptionDescription">
+        <source>Client secret to authenticate to Azure Key Vault.</source>
+        <target state="new">Client secret to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Use Azure Key Vault.</source>
+        <target state="new">Use Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="new">File(s) to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidClientSecretCredential">
+        <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
+        <target state="new">If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</target>
+        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityOptionDescription">
+        <source>Managed identity to authenticate to Azure Key Vault.</source>
+        <target state="new">Managed identity to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="new">A file or glob is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="new">No inputs found to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TenantIdOptionDescription">
+        <source>Tenant ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Tenant ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UrlOptionDescription">
+        <source>URL to an Azure Key Vault.</source>
+        <target state="new">URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../AzureKeyVaultResources.resx">
+    <body>
+      <trans-unit id="CertificateOptionDescription">
+        <source>Name of the certificate in Azure Key Vault.</source>
+        <target state="new">Name of the certificate in Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientIdOptionDescription">
+        <source>Client ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Client ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientSecretOptionDescription">
+        <source>Client secret to authenticate to Azure Key Vault.</source>
+        <target state="new">Client secret to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Use Azure Key Vault.</source>
+        <target state="new">Use Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="new">File(s) to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidClientSecretCredential">
+        <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
+        <target state="new">If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</target>
+        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityOptionDescription">
+        <source>Managed identity to authenticate to Azure Key Vault.</source>
+        <target state="new">Managed identity to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="new">A file or glob is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="new">No inputs found to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TenantIdOptionDescription">
+        <source>Tenant ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Tenant ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UrlOptionDescription">
+        <source>URL to an Azure Key Vault.</source>
+        <target state="new">URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../AzureKeyVaultResources.resx">
+    <body>
+      <trans-unit id="CertificateOptionDescription">
+        <source>Name of the certificate in Azure Key Vault.</source>
+        <target state="new">Name of the certificate in Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientIdOptionDescription">
+        <source>Client ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Client ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientSecretOptionDescription">
+        <source>Client secret to authenticate to Azure Key Vault.</source>
+        <target state="new">Client secret to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Use Azure Key Vault.</source>
+        <target state="new">Use Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="new">File(s) to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidClientSecretCredential">
+        <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
+        <target state="new">If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</target>
+        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityOptionDescription">
+        <source>Managed identity to authenticate to Azure Key Vault.</source>
+        <target state="new">Managed identity to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="new">A file or glob is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="new">No inputs found to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TenantIdOptionDescription">
+        <source>Tenant ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Tenant ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UrlOptionDescription">
+        <source>URL to an Azure Key Vault.</source>
+        <target state="new">URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../AzureKeyVaultResources.resx">
+    <body>
+      <trans-unit id="CertificateOptionDescription">
+        <source>Name of the certificate in Azure Key Vault.</source>
+        <target state="new">Name of the certificate in Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientIdOptionDescription">
+        <source>Client ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Client ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientSecretOptionDescription">
+        <source>Client secret to authenticate to Azure Key Vault.</source>
+        <target state="new">Client secret to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Use Azure Key Vault.</source>
+        <target state="new">Use Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="new">File(s) to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidClientSecretCredential">
+        <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
+        <target state="new">If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</target>
+        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityOptionDescription">
+        <source>Managed identity to authenticate to Azure Key Vault.</source>
+        <target state="new">Managed identity to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="new">A file or glob is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="new">No inputs found to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TenantIdOptionDescription">
+        <source>Tenant ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Tenant ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UrlOptionDescription">
+        <source>URL to an Azure Key Vault.</source>
+        <target state="new">URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../AzureKeyVaultResources.resx">
+    <body>
+      <trans-unit id="CertificateOptionDescription">
+        <source>Name of the certificate in Azure Key Vault.</source>
+        <target state="new">Name of the certificate in Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientIdOptionDescription">
+        <source>Client ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Client ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientSecretOptionDescription">
+        <source>Client secret to authenticate to Azure Key Vault.</source>
+        <target state="new">Client secret to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Use Azure Key Vault.</source>
+        <target state="new">Use Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="new">File(s) to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidClientSecretCredential">
+        <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
+        <target state="new">If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</target>
+        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityOptionDescription">
+        <source>Managed identity to authenticate to Azure Key Vault.</source>
+        <target state="new">Managed identity to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="new">A file or glob is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="new">No inputs found to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TenantIdOptionDescription">
+        <source>Tenant ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Tenant ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UrlOptionDescription">
+        <source>URL to an Azure Key Vault.</source>
+        <target state="new">URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../AzureKeyVaultResources.resx">
+    <body>
+      <trans-unit id="CertificateOptionDescription">
+        <source>Name of the certificate in Azure Key Vault.</source>
+        <target state="new">Name of the certificate in Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientIdOptionDescription">
+        <source>Client ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Client ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientSecretOptionDescription">
+        <source>Client secret to authenticate to Azure Key Vault.</source>
+        <target state="new">Client secret to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Use Azure Key Vault.</source>
+        <target state="new">Use Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="new">File(s) to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidClientSecretCredential">
+        <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
+        <target state="new">If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</target>
+        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityOptionDescription">
+        <source>Managed identity to authenticate to Azure Key Vault.</source>
+        <target state="new">Managed identity to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="new">A file or glob is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="new">No inputs found to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TenantIdOptionDescription">
+        <source>Tenant ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Tenant ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UrlOptionDescription">
+        <source>URL to an Azure Key Vault.</source>
+        <target state="new">URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../AzureKeyVaultResources.resx">
+    <body>
+      <trans-unit id="CertificateOptionDescription">
+        <source>Name of the certificate in Azure Key Vault.</source>
+        <target state="new">Name of the certificate in Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientIdOptionDescription">
+        <source>Client ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Client ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientSecretOptionDescription">
+        <source>Client secret to authenticate to Azure Key Vault.</source>
+        <target state="new">Client secret to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Use Azure Key Vault.</source>
+        <target state="new">Use Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="new">File(s) to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidClientSecretCredential">
+        <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
+        <target state="new">If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</target>
+        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityOptionDescription">
+        <source>Managed identity to authenticate to Azure Key Vault.</source>
+        <target state="new">Managed identity to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="new">A file or glob is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="new">No inputs found to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TenantIdOptionDescription">
+        <source>Tenant ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Tenant ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UrlOptionDescription">
+        <source>URL to an Azure Key Vault.</source>
+        <target state="new">URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../AzureKeyVaultResources.resx">
+    <body>
+      <trans-unit id="CertificateOptionDescription">
+        <source>Name of the certificate in Azure Key Vault.</source>
+        <target state="new">Name of the certificate in Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientIdOptionDescription">
+        <source>Client ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Client ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientSecretOptionDescription">
+        <source>Client secret to authenticate to Azure Key Vault.</source>
+        <target state="new">Client secret to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Use Azure Key Vault.</source>
+        <target state="new">Use Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="new">File(s) to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidClientSecretCredential">
+        <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
+        <target state="new">If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</target>
+        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityOptionDescription">
+        <source>Managed identity to authenticate to Azure Key Vault.</source>
+        <target state="new">Managed identity to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="new">A file or glob is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="new">No inputs found to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TenantIdOptionDescription">
+        <source>Tenant ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Tenant ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UrlOptionDescription">
+        <source>URL to an Azure Key Vault.</source>
+        <target state="new">URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../AzureKeyVaultResources.resx">
+    <body>
+      <trans-unit id="CertificateOptionDescription">
+        <source>Name of the certificate in Azure Key Vault.</source>
+        <target state="new">Name of the certificate in Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientIdOptionDescription">
+        <source>Client ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Client ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientSecretOptionDescription">
+        <source>Client secret to authenticate to Azure Key Vault.</source>
+        <target state="new">Client secret to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Use Azure Key Vault.</source>
+        <target state="new">Use Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="new">File(s) to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidClientSecretCredential">
+        <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
+        <target state="new">If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</target>
+        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityOptionDescription">
+        <source>Managed identity to authenticate to Azure Key Vault.</source>
+        <target state="new">Managed identity to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="new">A file or glob is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="new">No inputs found to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TenantIdOptionDescription">
+        <source>Tenant ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Tenant ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UrlOptionDescription">
+        <source>URL to an Azure Key Vault.</source>
+        <target state="new">URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../AzureKeyVaultResources.resx">
+    <body>
+      <trans-unit id="CertificateOptionDescription">
+        <source>Name of the certificate in Azure Key Vault.</source>
+        <target state="new">Name of the certificate in Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientIdOptionDescription">
+        <source>Client ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Client ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientSecretOptionDescription">
+        <source>Client secret to authenticate to Azure Key Vault.</source>
+        <target state="new">Client secret to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Use Azure Key Vault.</source>
+        <target state="new">Use Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="new">File(s) to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidClientSecretCredential">
+        <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
+        <target state="new">If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</target>
+        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityOptionDescription">
+        <source>Managed identity to authenticate to Azure Key Vault.</source>
+        <target state="new">Managed identity to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="new">A file or glob is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="new">No inputs found to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TenantIdOptionDescription">
+        <source>Tenant ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Tenant ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UrlOptionDescription">
+        <source>URL to an Azure Key Vault.</source>
+        <target state="new">URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../AzureKeyVaultResources.resx">
+    <body>
+      <trans-unit id="CertificateOptionDescription">
+        <source>Name of the certificate in Azure Key Vault.</source>
+        <target state="new">Name of the certificate in Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientIdOptionDescription">
+        <source>Client ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Client ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ClientSecretOptionDescription">
+        <source>Client secret to authenticate to Azure Key Vault.</source>
+        <target state="new">Client secret to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Use Azure Key Vault.</source>
+        <target state="new">Use Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="new">File(s) to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidClientSecretCredential">
+        <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
+        <target state="new">If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</target>
+        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityOptionDescription">
+        <source>Managed identity to authenticate to Azure Key Vault.</source>
+        <target state="new">Managed identity to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="new">A file or glob is required.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="new">No inputs found to sign.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TenantIdOptionDescription">
+        <source>Tenant ID to authenticate to Azure Key Vault.</source>
+        <target state="new">Tenant ID to authenticate to Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UrlOptionDescription">
+        <source>URL to an Azure Key Vault.</source>
+        <target state="new">URL to an Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
+    <body>
+      <trans-unit id="BaseDirectoryOptionDescription">
+        <source>Base directory for files.  Overrides the current working directory.</source>
+        <target state="new">Base directory for files.  Overrides the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeCommandDescription">
+        <source>Sign binaries and containers.</source>
+        <target state="new">Sign binaries and containers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionOptionDescription">
+        <source>Description of the signing certificate.</source>
+        <target state="new">Description of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionUrlOptionDescription">
+        <source>Description URL of the signing certificate.</source>
+        <target state="new">Description URL of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDigestOptionDescription">
+        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FileListOptionDescription">
+        <source>Path to file containing paths of files to sign within an archive.</source>
+        <target state="new">Path to file containing paths of files to sign within an archive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidDigestValue">
+        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
+        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxConcurrencyValue">
+        <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
+        <target state="new">Invalid value for {0}. The value must be a number value greater than or equal to 1.</target>
+        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
+        <target state="new">Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</target>
+        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MaxConcurrencyOptionDescription">
+        <source>Maximum concurrency (default is 4).</source>
+        <target state="new">Maximum concurrency (default is 4).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputOptionDescription">
+        <source>Output file or directory. If omitted, input files will be overwritten.</source>
+        <target state="new">Output file or directory. If omitted, input files will be overwritten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PublisherNameOptionDescription">
+        <source>Publisher name (ClickOnce).</source>
+        <target state="new">Publisher name (ClickOnce).</target>
+        <note>ClickOnce is a Microsoft deployment technology.</note>
+      </trans-unit>
+      <trans-unit id="SignCommandDescription">
+        <source>Sign CLI</source>
+        <target state="new">Sign CLI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampDigestOptionDescription">
+        <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TimestampUrlOptionDescription">
+        <source>RFC 3161 timestamp server URL.</source>
+        <target state="new">RFC 3161 timestamp server URL.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="x86NotSupported">
+        <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>
+        <target state="new">Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
+    <body>
+      <trans-unit id="BaseDirectoryOptionDescription">
+        <source>Base directory for files.  Overrides the current working directory.</source>
+        <target state="new">Base directory for files.  Overrides the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeCommandDescription">
+        <source>Sign binaries and containers.</source>
+        <target state="new">Sign binaries and containers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionOptionDescription">
+        <source>Description of the signing certificate.</source>
+        <target state="new">Description of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionUrlOptionDescription">
+        <source>Description URL of the signing certificate.</source>
+        <target state="new">Description URL of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDigestOptionDescription">
+        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FileListOptionDescription">
+        <source>Path to file containing paths of files to sign within an archive.</source>
+        <target state="new">Path to file containing paths of files to sign within an archive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidDigestValue">
+        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
+        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxConcurrencyValue">
+        <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
+        <target state="new">Invalid value for {0}. The value must be a number value greater than or equal to 1.</target>
+        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
+        <target state="new">Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</target>
+        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MaxConcurrencyOptionDescription">
+        <source>Maximum concurrency (default is 4).</source>
+        <target state="new">Maximum concurrency (default is 4).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputOptionDescription">
+        <source>Output file or directory. If omitted, input files will be overwritten.</source>
+        <target state="new">Output file or directory. If omitted, input files will be overwritten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PublisherNameOptionDescription">
+        <source>Publisher name (ClickOnce).</source>
+        <target state="new">Publisher name (ClickOnce).</target>
+        <note>ClickOnce is a Microsoft deployment technology.</note>
+      </trans-unit>
+      <trans-unit id="SignCommandDescription">
+        <source>Sign CLI</source>
+        <target state="new">Sign CLI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampDigestOptionDescription">
+        <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TimestampUrlOptionDescription">
+        <source>RFC 3161 timestamp server URL.</source>
+        <target state="new">RFC 3161 timestamp server URL.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="x86NotSupported">
+        <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>
+        <target state="new">Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
+    <body>
+      <trans-unit id="BaseDirectoryOptionDescription">
+        <source>Base directory for files.  Overrides the current working directory.</source>
+        <target state="new">Base directory for files.  Overrides the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeCommandDescription">
+        <source>Sign binaries and containers.</source>
+        <target state="new">Sign binaries and containers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionOptionDescription">
+        <source>Description of the signing certificate.</source>
+        <target state="new">Description of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionUrlOptionDescription">
+        <source>Description URL of the signing certificate.</source>
+        <target state="new">Description URL of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDigestOptionDescription">
+        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FileListOptionDescription">
+        <source>Path to file containing paths of files to sign within an archive.</source>
+        <target state="new">Path to file containing paths of files to sign within an archive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidDigestValue">
+        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
+        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxConcurrencyValue">
+        <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
+        <target state="new">Invalid value for {0}. The value must be a number value greater than or equal to 1.</target>
+        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
+        <target state="new">Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</target>
+        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MaxConcurrencyOptionDescription">
+        <source>Maximum concurrency (default is 4).</source>
+        <target state="new">Maximum concurrency (default is 4).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputOptionDescription">
+        <source>Output file or directory. If omitted, input files will be overwritten.</source>
+        <target state="new">Output file or directory. If omitted, input files will be overwritten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PublisherNameOptionDescription">
+        <source>Publisher name (ClickOnce).</source>
+        <target state="new">Publisher name (ClickOnce).</target>
+        <note>ClickOnce is a Microsoft deployment technology.</note>
+      </trans-unit>
+      <trans-unit id="SignCommandDescription">
+        <source>Sign CLI</source>
+        <target state="new">Sign CLI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampDigestOptionDescription">
+        <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TimestampUrlOptionDescription">
+        <source>RFC 3161 timestamp server URL.</source>
+        <target state="new">RFC 3161 timestamp server URL.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="x86NotSupported">
+        <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>
+        <target state="new">Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
+    <body>
+      <trans-unit id="BaseDirectoryOptionDescription">
+        <source>Base directory for files.  Overrides the current working directory.</source>
+        <target state="new">Base directory for files.  Overrides the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeCommandDescription">
+        <source>Sign binaries and containers.</source>
+        <target state="new">Sign binaries and containers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionOptionDescription">
+        <source>Description of the signing certificate.</source>
+        <target state="new">Description of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionUrlOptionDescription">
+        <source>Description URL of the signing certificate.</source>
+        <target state="new">Description URL of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDigestOptionDescription">
+        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FileListOptionDescription">
+        <source>Path to file containing paths of files to sign within an archive.</source>
+        <target state="new">Path to file containing paths of files to sign within an archive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidDigestValue">
+        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
+        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxConcurrencyValue">
+        <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
+        <target state="new">Invalid value for {0}. The value must be a number value greater than or equal to 1.</target>
+        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
+        <target state="new">Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</target>
+        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MaxConcurrencyOptionDescription">
+        <source>Maximum concurrency (default is 4).</source>
+        <target state="new">Maximum concurrency (default is 4).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputOptionDescription">
+        <source>Output file or directory. If omitted, input files will be overwritten.</source>
+        <target state="new">Output file or directory. If omitted, input files will be overwritten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PublisherNameOptionDescription">
+        <source>Publisher name (ClickOnce).</source>
+        <target state="new">Publisher name (ClickOnce).</target>
+        <note>ClickOnce is a Microsoft deployment technology.</note>
+      </trans-unit>
+      <trans-unit id="SignCommandDescription">
+        <source>Sign CLI</source>
+        <target state="new">Sign CLI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampDigestOptionDescription">
+        <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TimestampUrlOptionDescription">
+        <source>RFC 3161 timestamp server URL.</source>
+        <target state="new">RFC 3161 timestamp server URL.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="x86NotSupported">
+        <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>
+        <target state="new">Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
+    <body>
+      <trans-unit id="BaseDirectoryOptionDescription">
+        <source>Base directory for files.  Overrides the current working directory.</source>
+        <target state="new">Base directory for files.  Overrides the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeCommandDescription">
+        <source>Sign binaries and containers.</source>
+        <target state="new">Sign binaries and containers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionOptionDescription">
+        <source>Description of the signing certificate.</source>
+        <target state="new">Description of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionUrlOptionDescription">
+        <source>Description URL of the signing certificate.</source>
+        <target state="new">Description URL of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDigestOptionDescription">
+        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FileListOptionDescription">
+        <source>Path to file containing paths of files to sign within an archive.</source>
+        <target state="new">Path to file containing paths of files to sign within an archive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidDigestValue">
+        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
+        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxConcurrencyValue">
+        <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
+        <target state="new">Invalid value for {0}. The value must be a number value greater than or equal to 1.</target>
+        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
+        <target state="new">Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</target>
+        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MaxConcurrencyOptionDescription">
+        <source>Maximum concurrency (default is 4).</source>
+        <target state="new">Maximum concurrency (default is 4).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputOptionDescription">
+        <source>Output file or directory. If omitted, input files will be overwritten.</source>
+        <target state="new">Output file or directory. If omitted, input files will be overwritten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PublisherNameOptionDescription">
+        <source>Publisher name (ClickOnce).</source>
+        <target state="new">Publisher name (ClickOnce).</target>
+        <note>ClickOnce is a Microsoft deployment technology.</note>
+      </trans-unit>
+      <trans-unit id="SignCommandDescription">
+        <source>Sign CLI</source>
+        <target state="new">Sign CLI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampDigestOptionDescription">
+        <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TimestampUrlOptionDescription">
+        <source>RFC 3161 timestamp server URL.</source>
+        <target state="new">RFC 3161 timestamp server URL.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="x86NotSupported">
+        <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>
+        <target state="new">Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
+    <body>
+      <trans-unit id="BaseDirectoryOptionDescription">
+        <source>Base directory for files.  Overrides the current working directory.</source>
+        <target state="new">Base directory for files.  Overrides the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeCommandDescription">
+        <source>Sign binaries and containers.</source>
+        <target state="new">Sign binaries and containers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionOptionDescription">
+        <source>Description of the signing certificate.</source>
+        <target state="new">Description of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionUrlOptionDescription">
+        <source>Description URL of the signing certificate.</source>
+        <target state="new">Description URL of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDigestOptionDescription">
+        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FileListOptionDescription">
+        <source>Path to file containing paths of files to sign within an archive.</source>
+        <target state="new">Path to file containing paths of files to sign within an archive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidDigestValue">
+        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
+        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxConcurrencyValue">
+        <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
+        <target state="new">Invalid value for {0}. The value must be a number value greater than or equal to 1.</target>
+        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
+        <target state="new">Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</target>
+        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MaxConcurrencyOptionDescription">
+        <source>Maximum concurrency (default is 4).</source>
+        <target state="new">Maximum concurrency (default is 4).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputOptionDescription">
+        <source>Output file or directory. If omitted, input files will be overwritten.</source>
+        <target state="new">Output file or directory. If omitted, input files will be overwritten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PublisherNameOptionDescription">
+        <source>Publisher name (ClickOnce).</source>
+        <target state="new">Publisher name (ClickOnce).</target>
+        <note>ClickOnce is a Microsoft deployment technology.</note>
+      </trans-unit>
+      <trans-unit id="SignCommandDescription">
+        <source>Sign CLI</source>
+        <target state="new">Sign CLI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampDigestOptionDescription">
+        <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TimestampUrlOptionDescription">
+        <source>RFC 3161 timestamp server URL.</source>
+        <target state="new">RFC 3161 timestamp server URL.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="x86NotSupported">
+        <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>
+        <target state="new">Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
+    <body>
+      <trans-unit id="BaseDirectoryOptionDescription">
+        <source>Base directory for files.  Overrides the current working directory.</source>
+        <target state="new">Base directory for files.  Overrides the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeCommandDescription">
+        <source>Sign binaries and containers.</source>
+        <target state="new">Sign binaries and containers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionOptionDescription">
+        <source>Description of the signing certificate.</source>
+        <target state="new">Description of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionUrlOptionDescription">
+        <source>Description URL of the signing certificate.</source>
+        <target state="new">Description URL of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDigestOptionDescription">
+        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FileListOptionDescription">
+        <source>Path to file containing paths of files to sign within an archive.</source>
+        <target state="new">Path to file containing paths of files to sign within an archive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidDigestValue">
+        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
+        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxConcurrencyValue">
+        <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
+        <target state="new">Invalid value for {0}. The value must be a number value greater than or equal to 1.</target>
+        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
+        <target state="new">Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</target>
+        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MaxConcurrencyOptionDescription">
+        <source>Maximum concurrency (default is 4).</source>
+        <target state="new">Maximum concurrency (default is 4).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputOptionDescription">
+        <source>Output file or directory. If omitted, input files will be overwritten.</source>
+        <target state="new">Output file or directory. If omitted, input files will be overwritten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PublisherNameOptionDescription">
+        <source>Publisher name (ClickOnce).</source>
+        <target state="new">Publisher name (ClickOnce).</target>
+        <note>ClickOnce is a Microsoft deployment technology.</note>
+      </trans-unit>
+      <trans-unit id="SignCommandDescription">
+        <source>Sign CLI</source>
+        <target state="new">Sign CLI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampDigestOptionDescription">
+        <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TimestampUrlOptionDescription">
+        <source>RFC 3161 timestamp server URL.</source>
+        <target state="new">RFC 3161 timestamp server URL.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="x86NotSupported">
+        <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>
+        <target state="new">Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
+    <body>
+      <trans-unit id="BaseDirectoryOptionDescription">
+        <source>Base directory for files.  Overrides the current working directory.</source>
+        <target state="new">Base directory for files.  Overrides the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeCommandDescription">
+        <source>Sign binaries and containers.</source>
+        <target state="new">Sign binaries and containers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionOptionDescription">
+        <source>Description of the signing certificate.</source>
+        <target state="new">Description of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionUrlOptionDescription">
+        <source>Description URL of the signing certificate.</source>
+        <target state="new">Description URL of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDigestOptionDescription">
+        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FileListOptionDescription">
+        <source>Path to file containing paths of files to sign within an archive.</source>
+        <target state="new">Path to file containing paths of files to sign within an archive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidDigestValue">
+        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
+        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxConcurrencyValue">
+        <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
+        <target state="new">Invalid value for {0}. The value must be a number value greater than or equal to 1.</target>
+        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
+        <target state="new">Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</target>
+        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MaxConcurrencyOptionDescription">
+        <source>Maximum concurrency (default is 4).</source>
+        <target state="new">Maximum concurrency (default is 4).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputOptionDescription">
+        <source>Output file or directory. If omitted, input files will be overwritten.</source>
+        <target state="new">Output file or directory. If omitted, input files will be overwritten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PublisherNameOptionDescription">
+        <source>Publisher name (ClickOnce).</source>
+        <target state="new">Publisher name (ClickOnce).</target>
+        <note>ClickOnce is a Microsoft deployment technology.</note>
+      </trans-unit>
+      <trans-unit id="SignCommandDescription">
+        <source>Sign CLI</source>
+        <target state="new">Sign CLI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampDigestOptionDescription">
+        <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TimestampUrlOptionDescription">
+        <source>RFC 3161 timestamp server URL.</source>
+        <target state="new">RFC 3161 timestamp server URL.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="x86NotSupported">
+        <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>
+        <target state="new">Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
+    <body>
+      <trans-unit id="BaseDirectoryOptionDescription">
+        <source>Base directory for files.  Overrides the current working directory.</source>
+        <target state="new">Base directory for files.  Overrides the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeCommandDescription">
+        <source>Sign binaries and containers.</source>
+        <target state="new">Sign binaries and containers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionOptionDescription">
+        <source>Description of the signing certificate.</source>
+        <target state="new">Description of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionUrlOptionDescription">
+        <source>Description URL of the signing certificate.</source>
+        <target state="new">Description URL of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDigestOptionDescription">
+        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FileListOptionDescription">
+        <source>Path to file containing paths of files to sign within an archive.</source>
+        <target state="new">Path to file containing paths of files to sign within an archive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidDigestValue">
+        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
+        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxConcurrencyValue">
+        <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
+        <target state="new">Invalid value for {0}. The value must be a number value greater than or equal to 1.</target>
+        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
+        <target state="new">Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</target>
+        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MaxConcurrencyOptionDescription">
+        <source>Maximum concurrency (default is 4).</source>
+        <target state="new">Maximum concurrency (default is 4).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputOptionDescription">
+        <source>Output file or directory. If omitted, input files will be overwritten.</source>
+        <target state="new">Output file or directory. If omitted, input files will be overwritten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PublisherNameOptionDescription">
+        <source>Publisher name (ClickOnce).</source>
+        <target state="new">Publisher name (ClickOnce).</target>
+        <note>ClickOnce is a Microsoft deployment technology.</note>
+      </trans-unit>
+      <trans-unit id="SignCommandDescription">
+        <source>Sign CLI</source>
+        <target state="new">Sign CLI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampDigestOptionDescription">
+        <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TimestampUrlOptionDescription">
+        <source>RFC 3161 timestamp server URL.</source>
+        <target state="new">RFC 3161 timestamp server URL.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="x86NotSupported">
+        <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>
+        <target state="new">Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
+    <body>
+      <trans-unit id="BaseDirectoryOptionDescription">
+        <source>Base directory for files.  Overrides the current working directory.</source>
+        <target state="new">Base directory for files.  Overrides the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeCommandDescription">
+        <source>Sign binaries and containers.</source>
+        <target state="new">Sign binaries and containers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionOptionDescription">
+        <source>Description of the signing certificate.</source>
+        <target state="new">Description of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionUrlOptionDescription">
+        <source>Description URL of the signing certificate.</source>
+        <target state="new">Description URL of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDigestOptionDescription">
+        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FileListOptionDescription">
+        <source>Path to file containing paths of files to sign within an archive.</source>
+        <target state="new">Path to file containing paths of files to sign within an archive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidDigestValue">
+        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
+        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxConcurrencyValue">
+        <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
+        <target state="new">Invalid value for {0}. The value must be a number value greater than or equal to 1.</target>
+        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
+        <target state="new">Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</target>
+        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MaxConcurrencyOptionDescription">
+        <source>Maximum concurrency (default is 4).</source>
+        <target state="new">Maximum concurrency (default is 4).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputOptionDescription">
+        <source>Output file or directory. If omitted, input files will be overwritten.</source>
+        <target state="new">Output file or directory. If omitted, input files will be overwritten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PublisherNameOptionDescription">
+        <source>Publisher name (ClickOnce).</source>
+        <target state="new">Publisher name (ClickOnce).</target>
+        <note>ClickOnce is a Microsoft deployment technology.</note>
+      </trans-unit>
+      <trans-unit id="SignCommandDescription">
+        <source>Sign CLI</source>
+        <target state="new">Sign CLI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampDigestOptionDescription">
+        <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TimestampUrlOptionDescription">
+        <source>RFC 3161 timestamp server URL.</source>
+        <target state="new">RFC 3161 timestamp server URL.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="x86NotSupported">
+        <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>
+        <target state="new">Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
+    <body>
+      <trans-unit id="BaseDirectoryOptionDescription">
+        <source>Base directory for files.  Overrides the current working directory.</source>
+        <target state="new">Base directory for files.  Overrides the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeCommandDescription">
+        <source>Sign binaries and containers.</source>
+        <target state="new">Sign binaries and containers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionOptionDescription">
+        <source>Description of the signing certificate.</source>
+        <target state="new">Description of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionUrlOptionDescription">
+        <source>Description URL of the signing certificate.</source>
+        <target state="new">Description URL of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDigestOptionDescription">
+        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FileListOptionDescription">
+        <source>Path to file containing paths of files to sign within an archive.</source>
+        <target state="new">Path to file containing paths of files to sign within an archive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidDigestValue">
+        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
+        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxConcurrencyValue">
+        <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
+        <target state="new">Invalid value for {0}. The value must be a number value greater than or equal to 1.</target>
+        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
+        <target state="new">Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</target>
+        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MaxConcurrencyOptionDescription">
+        <source>Maximum concurrency (default is 4).</source>
+        <target state="new">Maximum concurrency (default is 4).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputOptionDescription">
+        <source>Output file or directory. If omitted, input files will be overwritten.</source>
+        <target state="new">Output file or directory. If omitted, input files will be overwritten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PublisherNameOptionDescription">
+        <source>Publisher name (ClickOnce).</source>
+        <target state="new">Publisher name (ClickOnce).</target>
+        <note>ClickOnce is a Microsoft deployment technology.</note>
+      </trans-unit>
+      <trans-unit id="SignCommandDescription">
+        <source>Sign CLI</source>
+        <target state="new">Sign CLI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampDigestOptionDescription">
+        <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TimestampUrlOptionDescription">
+        <source>RFC 3161 timestamp server URL.</source>
+        <target state="new">RFC 3161 timestamp server URL.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="x86NotSupported">
+        <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>
+        <target state="new">Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
+    <body>
+      <trans-unit id="BaseDirectoryOptionDescription">
+        <source>Base directory for files.  Overrides the current working directory.</source>
+        <target state="new">Base directory for files.  Overrides the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeCommandDescription">
+        <source>Sign binaries and containers.</source>
+        <target state="new">Sign binaries and containers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionOptionDescription">
+        <source>Description of the signing certificate.</source>
+        <target state="new">Description of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionUrlOptionDescription">
+        <source>Description URL of the signing certificate.</source>
+        <target state="new">Description URL of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDigestOptionDescription">
+        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FileListOptionDescription">
+        <source>Path to file containing paths of files to sign within an archive.</source>
+        <target state="new">Path to file containing paths of files to sign within an archive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidDigestValue">
+        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
+        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxConcurrencyValue">
+        <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
+        <target state="new">Invalid value for {0}. The value must be a number value greater than or equal to 1.</target>
+        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
+        <target state="new">Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</target>
+        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MaxConcurrencyOptionDescription">
+        <source>Maximum concurrency (default is 4).</source>
+        <target state="new">Maximum concurrency (default is 4).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputOptionDescription">
+        <source>Output file or directory. If omitted, input files will be overwritten.</source>
+        <target state="new">Output file or directory. If omitted, input files will be overwritten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PublisherNameOptionDescription">
+        <source>Publisher name (ClickOnce).</source>
+        <target state="new">Publisher name (ClickOnce).</target>
+        <note>ClickOnce is a Microsoft deployment technology.</note>
+      </trans-unit>
+      <trans-unit id="SignCommandDescription">
+        <source>Sign CLI</source>
+        <target state="new">Sign CLI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampDigestOptionDescription">
+        <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TimestampUrlOptionDescription">
+        <source>RFC 3161 timestamp server URL.</source>
+        <target state="new">RFC 3161 timestamp server URL.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="x86NotSupported">
+        <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>
+        <target state="new">Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
+    <body>
+      <trans-unit id="BaseDirectoryOptionDescription">
+        <source>Base directory for files.  Overrides the current working directory.</source>
+        <target state="new">Base directory for files.  Overrides the current working directory.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CodeCommandDescription">
+        <source>Sign binaries and containers.</source>
+        <target state="new">Sign binaries and containers.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionOptionDescription">
+        <source>Description of the signing certificate.</source>
+        <target state="new">Description of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DescriptionUrlOptionDescription">
+        <source>Description URL of the signing certificate.</source>
+        <target state="new">Description URL of the signing certificate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDigestOptionDescription">
+        <source>Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm to hash files with. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FileListOptionDescription">
+        <source>Path to file containing paths of files to sign within an archive.</source>
+        <target state="new">Path to file containing paths of files to sign within an archive.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidBaseDirectoryValue">
+        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
+        <target state="new">Invalid value for {0}. The value must be a fully rooted directory path.</target>
+        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidDigestValue">
+        <source>Invalid value for {0}. The value must be sha256, sha384, or sha512.</source>
+        <target state="new">Invalid value for {0}. The value must be sha256, sha384, or sha512.</target>
+        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidMaxConcurrencyValue">
+        <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
+        <target state="new">Invalid value for {0}. The value must be a number value greater than or equal to 1.</target>
+        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidUrlValue">
+        <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
+        <target state="new">Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</target>
+        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="MaxConcurrencyOptionDescription">
+        <source>Maximum concurrency (default is 4).</source>
+        <target state="new">Maximum concurrency (default is 4).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutputOptionDescription">
+        <source>Output file or directory. If omitted, input files will be overwritten.</source>
+        <target state="new">Output file or directory. If omitted, input files will be overwritten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PublisherNameOptionDescription">
+        <source>Publisher name (ClickOnce).</source>
+        <target state="new">Publisher name (ClickOnce).</target>
+        <note>ClickOnce is a Microsoft deployment technology.</note>
+      </trans-unit>
+      <trans-unit id="SignCommandDescription">
+        <source>Sign CLI</source>
+        <target state="new">Sign CLI</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TimestampDigestOptionDescription">
+        <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
+        <target state="new">Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</target>
+        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="TimestampUrlOptionDescription">
+        <source>RFC 3161 timestamp server URL.</source>
+        <target state="new">RFC 3161 timestamp server URL.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Sets the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note>{Locked="q[uiet]","m[inimal]","n[ormal]","d[etailed]","diag[nostic]"} are option values and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="x86NotSupported">
+        <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>
+        <target state="new">Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -1,0 +1,167 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
+    <body>
+      <trans-unit id="AzureSignToolSignatureProviderSigning">
+        <source>Signing SignTool job with {count} files.</source>
+        <target state="new">Signing SignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CertificateIsExpired">
+        <source>The certificate is expired.</source>
+        <target state="new">The certificate is expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CertificateIsNotYetTimeValid">
+        <source>The certificate is not yet time valid.</source>
+        <target state="new">The certificate is not yet time valid.</target>
+        <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardError">
+        <source>{fileName} Err {error}</source>
+        <target state="new">{fileName} Err {error}</target>
+        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardOutput">
+        <source>{fileName} Out {output}</source>
+        <target state="new">{fileName} Out {output}</target>
+        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceSignatureProviderSigning">
+        <source>Signing Mage job with {count} files.</source>
+        <target state="new">Signing Mage job with {count} files.</target>
+        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CreatingDirectory">
+        <source>Creating directory {path}.</source>
+        <target state="new">Creating directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletedDirectory">
+        <source>Directory {path} deleted.</source>
+        <target state="new">Directory {path} deleted.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletingDirectory">
+        <source>Deleting directory {path}.</source>
+        <target state="new">Deleting directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotDeleted">
+        <source>Directory {path} still exists.</source>
+        <target state="new">Directory {path} still exists.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="EditingAppInstaller">
+        <source>Editing AppInstaller job with {count} files.</source>
+        <target state="new">Editing AppInstaller job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ErrorSigningVsix">
+        <source>An unspecified error occurred during VSIX signing.</source>
+        <target state="new">An unspecified error occurred during VSIX signing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionWhileDeletingDirectory">
+        <source>An exception occurred while attempting to delete directory {path}.</source>
+        <target state="new">An exception occurred while attempting to delete directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchedCertificate">
+        <source>Fetched certificate. [{milliseconds} ms]</source>
+        <target state="new">Fetched certificate. [{milliseconds} ms]</target>
+        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchingCertificate">
+        <source>Fetching certificate from Azure Key Vault.</source>
+        <target state="new">Fetching certificate from Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpeningContainer">
+        <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
+        <target state="new">Extracting container {ContainerFilePath} to {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessCouldNotBeKilled">
+        <source>{0} timed out and could not be killed.</source>
+        <target state="new">{0} timed out and could not be killed.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTime">
+        <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
+        <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
+        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTimeWithArguments">
+        <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
+        <target state="new">{0} took too long to respond. The process exit code is {1}. Arguments: {2}</target>
+        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+      </trans-unit>
+      <trans-unit id="RunningCli">
+        <source>Running {fileName} with parameters: '{args}'.</source>
+        <target state="new">Running {fileName} with parameters: '{args}'.</target>
+        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SavingContainer">
+        <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
+        <target state="new">Rebuilding container {ContainerFilePath} from {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SignAsyncCalled">
+        <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
+        <target state="new">SignAsync called for {filePath}. Using {localFilePath} locally.</target>
+        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningAttempt">
+        <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
+        <target state="new">Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</target>
+        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailed">
+        <source>Could not sign {0}.</source>
+        <target state="new">Could not sign {0}.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailedAfterAllAttempts">
+        <source>Failed to sign. Attempts exceeded.</source>
+        <target state="new">Failed to sign. Attempts exceeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningFailedWithError">
+        <source>Signing failed with error {errorCode}.</source>
+        <target state="new">Signing failed with error {errorCode}.</target>
+        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFile">
+        <source>Signing {filePath}.</source>
+        <target state="new">Signing {filePath}.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningSucceeded">
+        <source>Signing succeeded.</source>
+        <target state="new">Signing succeeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningSucceededWithTimeElapsed">
+        <source>Successfully signed {filePath} in {millseconds} ms</source>
+        <target state="new">Successfully signed {filePath} in {millseconds} ms</target>
+        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SubmittingFileForSigning">
+        <source>Submitting {filePath} for signing.</source>
+        <target state="new">Submitting {filePath} for signing.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ValueCannotBeEmptyString">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsixSignatureProviderSigning">
+        <source>Signing OpenVsixSignTool job with {count} files.</source>
+        <target state="new">Signing OpenVsixSignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -1,0 +1,167 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
+    <body>
+      <trans-unit id="AzureSignToolSignatureProviderSigning">
+        <source>Signing SignTool job with {count} files.</source>
+        <target state="new">Signing SignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CertificateIsExpired">
+        <source>The certificate is expired.</source>
+        <target state="new">The certificate is expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CertificateIsNotYetTimeValid">
+        <source>The certificate is not yet time valid.</source>
+        <target state="new">The certificate is not yet time valid.</target>
+        <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardError">
+        <source>{fileName} Err {error}</source>
+        <target state="new">{fileName} Err {error}</target>
+        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardOutput">
+        <source>{fileName} Out {output}</source>
+        <target state="new">{fileName} Out {output}</target>
+        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceSignatureProviderSigning">
+        <source>Signing Mage job with {count} files.</source>
+        <target state="new">Signing Mage job with {count} files.</target>
+        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CreatingDirectory">
+        <source>Creating directory {path}.</source>
+        <target state="new">Creating directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletedDirectory">
+        <source>Directory {path} deleted.</source>
+        <target state="new">Directory {path} deleted.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletingDirectory">
+        <source>Deleting directory {path}.</source>
+        <target state="new">Deleting directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotDeleted">
+        <source>Directory {path} still exists.</source>
+        <target state="new">Directory {path} still exists.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="EditingAppInstaller">
+        <source>Editing AppInstaller job with {count} files.</source>
+        <target state="new">Editing AppInstaller job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ErrorSigningVsix">
+        <source>An unspecified error occurred during VSIX signing.</source>
+        <target state="new">An unspecified error occurred during VSIX signing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionWhileDeletingDirectory">
+        <source>An exception occurred while attempting to delete directory {path}.</source>
+        <target state="new">An exception occurred while attempting to delete directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchedCertificate">
+        <source>Fetched certificate. [{milliseconds} ms]</source>
+        <target state="new">Fetched certificate. [{milliseconds} ms]</target>
+        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchingCertificate">
+        <source>Fetching certificate from Azure Key Vault.</source>
+        <target state="new">Fetching certificate from Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpeningContainer">
+        <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
+        <target state="new">Extracting container {ContainerFilePath} to {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessCouldNotBeKilled">
+        <source>{0} timed out and could not be killed.</source>
+        <target state="new">{0} timed out and could not be killed.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTime">
+        <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
+        <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
+        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTimeWithArguments">
+        <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
+        <target state="new">{0} took too long to respond. The process exit code is {1}. Arguments: {2}</target>
+        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+      </trans-unit>
+      <trans-unit id="RunningCli">
+        <source>Running {fileName} with parameters: '{args}'.</source>
+        <target state="new">Running {fileName} with parameters: '{args}'.</target>
+        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SavingContainer">
+        <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
+        <target state="new">Rebuilding container {ContainerFilePath} from {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SignAsyncCalled">
+        <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
+        <target state="new">SignAsync called for {filePath}. Using {localFilePath} locally.</target>
+        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningAttempt">
+        <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
+        <target state="new">Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</target>
+        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailed">
+        <source>Could not sign {0}.</source>
+        <target state="new">Could not sign {0}.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailedAfterAllAttempts">
+        <source>Failed to sign. Attempts exceeded.</source>
+        <target state="new">Failed to sign. Attempts exceeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningFailedWithError">
+        <source>Signing failed with error {errorCode}.</source>
+        <target state="new">Signing failed with error {errorCode}.</target>
+        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFile">
+        <source>Signing {filePath}.</source>
+        <target state="new">Signing {filePath}.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningSucceeded">
+        <source>Signing succeeded.</source>
+        <target state="new">Signing succeeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningSucceededWithTimeElapsed">
+        <source>Successfully signed {filePath} in {millseconds} ms</source>
+        <target state="new">Successfully signed {filePath} in {millseconds} ms</target>
+        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SubmittingFileForSigning">
+        <source>Submitting {filePath} for signing.</source>
+        <target state="new">Submitting {filePath} for signing.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ValueCannotBeEmptyString">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsixSignatureProviderSigning">
+        <source>Signing OpenVsixSignTool job with {count} files.</source>
+        <target state="new">Signing OpenVsixSignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -1,0 +1,167 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
+    <body>
+      <trans-unit id="AzureSignToolSignatureProviderSigning">
+        <source>Signing SignTool job with {count} files.</source>
+        <target state="new">Signing SignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CertificateIsExpired">
+        <source>The certificate is expired.</source>
+        <target state="new">The certificate is expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CertificateIsNotYetTimeValid">
+        <source>The certificate is not yet time valid.</source>
+        <target state="new">The certificate is not yet time valid.</target>
+        <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardError">
+        <source>{fileName} Err {error}</source>
+        <target state="new">{fileName} Err {error}</target>
+        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardOutput">
+        <source>{fileName} Out {output}</source>
+        <target state="new">{fileName} Out {output}</target>
+        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceSignatureProviderSigning">
+        <source>Signing Mage job with {count} files.</source>
+        <target state="new">Signing Mage job with {count} files.</target>
+        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CreatingDirectory">
+        <source>Creating directory {path}.</source>
+        <target state="new">Creating directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletedDirectory">
+        <source>Directory {path} deleted.</source>
+        <target state="new">Directory {path} deleted.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletingDirectory">
+        <source>Deleting directory {path}.</source>
+        <target state="new">Deleting directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotDeleted">
+        <source>Directory {path} still exists.</source>
+        <target state="new">Directory {path} still exists.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="EditingAppInstaller">
+        <source>Editing AppInstaller job with {count} files.</source>
+        <target state="new">Editing AppInstaller job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ErrorSigningVsix">
+        <source>An unspecified error occurred during VSIX signing.</source>
+        <target state="new">An unspecified error occurred during VSIX signing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionWhileDeletingDirectory">
+        <source>An exception occurred while attempting to delete directory {path}.</source>
+        <target state="new">An exception occurred while attempting to delete directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchedCertificate">
+        <source>Fetched certificate. [{milliseconds} ms]</source>
+        <target state="new">Fetched certificate. [{milliseconds} ms]</target>
+        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchingCertificate">
+        <source>Fetching certificate from Azure Key Vault.</source>
+        <target state="new">Fetching certificate from Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpeningContainer">
+        <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
+        <target state="new">Extracting container {ContainerFilePath} to {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessCouldNotBeKilled">
+        <source>{0} timed out and could not be killed.</source>
+        <target state="new">{0} timed out and could not be killed.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTime">
+        <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
+        <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
+        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTimeWithArguments">
+        <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
+        <target state="new">{0} took too long to respond. The process exit code is {1}. Arguments: {2}</target>
+        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+      </trans-unit>
+      <trans-unit id="RunningCli">
+        <source>Running {fileName} with parameters: '{args}'.</source>
+        <target state="new">Running {fileName} with parameters: '{args}'.</target>
+        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SavingContainer">
+        <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
+        <target state="new">Rebuilding container {ContainerFilePath} from {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SignAsyncCalled">
+        <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
+        <target state="new">SignAsync called for {filePath}. Using {localFilePath} locally.</target>
+        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningAttempt">
+        <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
+        <target state="new">Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</target>
+        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailed">
+        <source>Could not sign {0}.</source>
+        <target state="new">Could not sign {0}.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailedAfterAllAttempts">
+        <source>Failed to sign. Attempts exceeded.</source>
+        <target state="new">Failed to sign. Attempts exceeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningFailedWithError">
+        <source>Signing failed with error {errorCode}.</source>
+        <target state="new">Signing failed with error {errorCode}.</target>
+        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFile">
+        <source>Signing {filePath}.</source>
+        <target state="new">Signing {filePath}.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningSucceeded">
+        <source>Signing succeeded.</source>
+        <target state="new">Signing succeeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningSucceededWithTimeElapsed">
+        <source>Successfully signed {filePath} in {millseconds} ms</source>
+        <target state="new">Successfully signed {filePath} in {millseconds} ms</target>
+        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SubmittingFileForSigning">
+        <source>Submitting {filePath} for signing.</source>
+        <target state="new">Submitting {filePath} for signing.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ValueCannotBeEmptyString">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsixSignatureProviderSigning">
+        <source>Signing OpenVsixSignTool job with {count} files.</source>
+        <target state="new">Signing OpenVsixSignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -1,0 +1,167 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
+    <body>
+      <trans-unit id="AzureSignToolSignatureProviderSigning">
+        <source>Signing SignTool job with {count} files.</source>
+        <target state="new">Signing SignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CertificateIsExpired">
+        <source>The certificate is expired.</source>
+        <target state="new">The certificate is expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CertificateIsNotYetTimeValid">
+        <source>The certificate is not yet time valid.</source>
+        <target state="new">The certificate is not yet time valid.</target>
+        <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardError">
+        <source>{fileName} Err {error}</source>
+        <target state="new">{fileName} Err {error}</target>
+        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardOutput">
+        <source>{fileName} Out {output}</source>
+        <target state="new">{fileName} Out {output}</target>
+        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceSignatureProviderSigning">
+        <source>Signing Mage job with {count} files.</source>
+        <target state="new">Signing Mage job with {count} files.</target>
+        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CreatingDirectory">
+        <source>Creating directory {path}.</source>
+        <target state="new">Creating directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletedDirectory">
+        <source>Directory {path} deleted.</source>
+        <target state="new">Directory {path} deleted.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletingDirectory">
+        <source>Deleting directory {path}.</source>
+        <target state="new">Deleting directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotDeleted">
+        <source>Directory {path} still exists.</source>
+        <target state="new">Directory {path} still exists.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="EditingAppInstaller">
+        <source>Editing AppInstaller job with {count} files.</source>
+        <target state="new">Editing AppInstaller job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ErrorSigningVsix">
+        <source>An unspecified error occurred during VSIX signing.</source>
+        <target state="new">An unspecified error occurred during VSIX signing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionWhileDeletingDirectory">
+        <source>An exception occurred while attempting to delete directory {path}.</source>
+        <target state="new">An exception occurred while attempting to delete directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchedCertificate">
+        <source>Fetched certificate. [{milliseconds} ms]</source>
+        <target state="new">Fetched certificate. [{milliseconds} ms]</target>
+        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchingCertificate">
+        <source>Fetching certificate from Azure Key Vault.</source>
+        <target state="new">Fetching certificate from Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpeningContainer">
+        <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
+        <target state="new">Extracting container {ContainerFilePath} to {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessCouldNotBeKilled">
+        <source>{0} timed out and could not be killed.</source>
+        <target state="new">{0} timed out and could not be killed.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTime">
+        <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
+        <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
+        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTimeWithArguments">
+        <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
+        <target state="new">{0} took too long to respond. The process exit code is {1}. Arguments: {2}</target>
+        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+      </trans-unit>
+      <trans-unit id="RunningCli">
+        <source>Running {fileName} with parameters: '{args}'.</source>
+        <target state="new">Running {fileName} with parameters: '{args}'.</target>
+        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SavingContainer">
+        <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
+        <target state="new">Rebuilding container {ContainerFilePath} from {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SignAsyncCalled">
+        <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
+        <target state="new">SignAsync called for {filePath}. Using {localFilePath} locally.</target>
+        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningAttempt">
+        <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
+        <target state="new">Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</target>
+        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailed">
+        <source>Could not sign {0}.</source>
+        <target state="new">Could not sign {0}.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailedAfterAllAttempts">
+        <source>Failed to sign. Attempts exceeded.</source>
+        <target state="new">Failed to sign. Attempts exceeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningFailedWithError">
+        <source>Signing failed with error {errorCode}.</source>
+        <target state="new">Signing failed with error {errorCode}.</target>
+        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFile">
+        <source>Signing {filePath}.</source>
+        <target state="new">Signing {filePath}.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningSucceeded">
+        <source>Signing succeeded.</source>
+        <target state="new">Signing succeeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningSucceededWithTimeElapsed">
+        <source>Successfully signed {filePath} in {millseconds} ms</source>
+        <target state="new">Successfully signed {filePath} in {millseconds} ms</target>
+        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SubmittingFileForSigning">
+        <source>Submitting {filePath} for signing.</source>
+        <target state="new">Submitting {filePath} for signing.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ValueCannotBeEmptyString">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsixSignatureProviderSigning">
+        <source>Signing OpenVsixSignTool job with {count} files.</source>
+        <target state="new">Signing OpenVsixSignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -1,0 +1,167 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
+    <body>
+      <trans-unit id="AzureSignToolSignatureProviderSigning">
+        <source>Signing SignTool job with {count} files.</source>
+        <target state="new">Signing SignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CertificateIsExpired">
+        <source>The certificate is expired.</source>
+        <target state="new">The certificate is expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CertificateIsNotYetTimeValid">
+        <source>The certificate is not yet time valid.</source>
+        <target state="new">The certificate is not yet time valid.</target>
+        <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardError">
+        <source>{fileName} Err {error}</source>
+        <target state="new">{fileName} Err {error}</target>
+        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardOutput">
+        <source>{fileName} Out {output}</source>
+        <target state="new">{fileName} Out {output}</target>
+        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceSignatureProviderSigning">
+        <source>Signing Mage job with {count} files.</source>
+        <target state="new">Signing Mage job with {count} files.</target>
+        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CreatingDirectory">
+        <source>Creating directory {path}.</source>
+        <target state="new">Creating directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletedDirectory">
+        <source>Directory {path} deleted.</source>
+        <target state="new">Directory {path} deleted.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletingDirectory">
+        <source>Deleting directory {path}.</source>
+        <target state="new">Deleting directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotDeleted">
+        <source>Directory {path} still exists.</source>
+        <target state="new">Directory {path} still exists.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="EditingAppInstaller">
+        <source>Editing AppInstaller job with {count} files.</source>
+        <target state="new">Editing AppInstaller job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ErrorSigningVsix">
+        <source>An unspecified error occurred during VSIX signing.</source>
+        <target state="new">An unspecified error occurred during VSIX signing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionWhileDeletingDirectory">
+        <source>An exception occurred while attempting to delete directory {path}.</source>
+        <target state="new">An exception occurred while attempting to delete directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchedCertificate">
+        <source>Fetched certificate. [{milliseconds} ms]</source>
+        <target state="new">Fetched certificate. [{milliseconds} ms]</target>
+        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchingCertificate">
+        <source>Fetching certificate from Azure Key Vault.</source>
+        <target state="new">Fetching certificate from Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpeningContainer">
+        <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
+        <target state="new">Extracting container {ContainerFilePath} to {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessCouldNotBeKilled">
+        <source>{0} timed out and could not be killed.</source>
+        <target state="new">{0} timed out and could not be killed.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTime">
+        <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
+        <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
+        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTimeWithArguments">
+        <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
+        <target state="new">{0} took too long to respond. The process exit code is {1}. Arguments: {2}</target>
+        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+      </trans-unit>
+      <trans-unit id="RunningCli">
+        <source>Running {fileName} with parameters: '{args}'.</source>
+        <target state="new">Running {fileName} with parameters: '{args}'.</target>
+        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SavingContainer">
+        <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
+        <target state="new">Rebuilding container {ContainerFilePath} from {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SignAsyncCalled">
+        <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
+        <target state="new">SignAsync called for {filePath}. Using {localFilePath} locally.</target>
+        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningAttempt">
+        <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
+        <target state="new">Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</target>
+        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailed">
+        <source>Could not sign {0}.</source>
+        <target state="new">Could not sign {0}.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailedAfterAllAttempts">
+        <source>Failed to sign. Attempts exceeded.</source>
+        <target state="new">Failed to sign. Attempts exceeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningFailedWithError">
+        <source>Signing failed with error {errorCode}.</source>
+        <target state="new">Signing failed with error {errorCode}.</target>
+        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFile">
+        <source>Signing {filePath}.</source>
+        <target state="new">Signing {filePath}.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningSucceeded">
+        <source>Signing succeeded.</source>
+        <target state="new">Signing succeeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningSucceededWithTimeElapsed">
+        <source>Successfully signed {filePath} in {millseconds} ms</source>
+        <target state="new">Successfully signed {filePath} in {millseconds} ms</target>
+        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SubmittingFileForSigning">
+        <source>Submitting {filePath} for signing.</source>
+        <target state="new">Submitting {filePath} for signing.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ValueCannotBeEmptyString">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsixSignatureProviderSigning">
+        <source>Signing OpenVsixSignTool job with {count} files.</source>
+        <target state="new">Signing OpenVsixSignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -1,0 +1,167 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
+    <body>
+      <trans-unit id="AzureSignToolSignatureProviderSigning">
+        <source>Signing SignTool job with {count} files.</source>
+        <target state="new">Signing SignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CertificateIsExpired">
+        <source>The certificate is expired.</source>
+        <target state="new">The certificate is expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CertificateIsNotYetTimeValid">
+        <source>The certificate is not yet time valid.</source>
+        <target state="new">The certificate is not yet time valid.</target>
+        <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardError">
+        <source>{fileName} Err {error}</source>
+        <target state="new">{fileName} Err {error}</target>
+        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardOutput">
+        <source>{fileName} Out {output}</source>
+        <target state="new">{fileName} Out {output}</target>
+        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceSignatureProviderSigning">
+        <source>Signing Mage job with {count} files.</source>
+        <target state="new">Signing Mage job with {count} files.</target>
+        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CreatingDirectory">
+        <source>Creating directory {path}.</source>
+        <target state="new">Creating directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletedDirectory">
+        <source>Directory {path} deleted.</source>
+        <target state="new">Directory {path} deleted.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletingDirectory">
+        <source>Deleting directory {path}.</source>
+        <target state="new">Deleting directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotDeleted">
+        <source>Directory {path} still exists.</source>
+        <target state="new">Directory {path} still exists.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="EditingAppInstaller">
+        <source>Editing AppInstaller job with {count} files.</source>
+        <target state="new">Editing AppInstaller job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ErrorSigningVsix">
+        <source>An unspecified error occurred during VSIX signing.</source>
+        <target state="new">An unspecified error occurred during VSIX signing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionWhileDeletingDirectory">
+        <source>An exception occurred while attempting to delete directory {path}.</source>
+        <target state="new">An exception occurred while attempting to delete directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchedCertificate">
+        <source>Fetched certificate. [{milliseconds} ms]</source>
+        <target state="new">Fetched certificate. [{milliseconds} ms]</target>
+        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchingCertificate">
+        <source>Fetching certificate from Azure Key Vault.</source>
+        <target state="new">Fetching certificate from Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpeningContainer">
+        <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
+        <target state="new">Extracting container {ContainerFilePath} to {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessCouldNotBeKilled">
+        <source>{0} timed out and could not be killed.</source>
+        <target state="new">{0} timed out and could not be killed.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTime">
+        <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
+        <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
+        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTimeWithArguments">
+        <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
+        <target state="new">{0} took too long to respond. The process exit code is {1}. Arguments: {2}</target>
+        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+      </trans-unit>
+      <trans-unit id="RunningCli">
+        <source>Running {fileName} with parameters: '{args}'.</source>
+        <target state="new">Running {fileName} with parameters: '{args}'.</target>
+        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SavingContainer">
+        <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
+        <target state="new">Rebuilding container {ContainerFilePath} from {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SignAsyncCalled">
+        <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
+        <target state="new">SignAsync called for {filePath}. Using {localFilePath} locally.</target>
+        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningAttempt">
+        <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
+        <target state="new">Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</target>
+        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailed">
+        <source>Could not sign {0}.</source>
+        <target state="new">Could not sign {0}.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailedAfterAllAttempts">
+        <source>Failed to sign. Attempts exceeded.</source>
+        <target state="new">Failed to sign. Attempts exceeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningFailedWithError">
+        <source>Signing failed with error {errorCode}.</source>
+        <target state="new">Signing failed with error {errorCode}.</target>
+        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFile">
+        <source>Signing {filePath}.</source>
+        <target state="new">Signing {filePath}.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningSucceeded">
+        <source>Signing succeeded.</source>
+        <target state="new">Signing succeeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningSucceededWithTimeElapsed">
+        <source>Successfully signed {filePath} in {millseconds} ms</source>
+        <target state="new">Successfully signed {filePath} in {millseconds} ms</target>
+        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SubmittingFileForSigning">
+        <source>Submitting {filePath} for signing.</source>
+        <target state="new">Submitting {filePath} for signing.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ValueCannotBeEmptyString">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsixSignatureProviderSigning">
+        <source>Signing OpenVsixSignTool job with {count} files.</source>
+        <target state="new">Signing OpenVsixSignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -1,0 +1,167 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
+    <body>
+      <trans-unit id="AzureSignToolSignatureProviderSigning">
+        <source>Signing SignTool job with {count} files.</source>
+        <target state="new">Signing SignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CertificateIsExpired">
+        <source>The certificate is expired.</source>
+        <target state="new">The certificate is expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CertificateIsNotYetTimeValid">
+        <source>The certificate is not yet time valid.</source>
+        <target state="new">The certificate is not yet time valid.</target>
+        <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardError">
+        <source>{fileName} Err {error}</source>
+        <target state="new">{fileName} Err {error}</target>
+        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardOutput">
+        <source>{fileName} Out {output}</source>
+        <target state="new">{fileName} Out {output}</target>
+        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceSignatureProviderSigning">
+        <source>Signing Mage job with {count} files.</source>
+        <target state="new">Signing Mage job with {count} files.</target>
+        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CreatingDirectory">
+        <source>Creating directory {path}.</source>
+        <target state="new">Creating directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletedDirectory">
+        <source>Directory {path} deleted.</source>
+        <target state="new">Directory {path} deleted.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletingDirectory">
+        <source>Deleting directory {path}.</source>
+        <target state="new">Deleting directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotDeleted">
+        <source>Directory {path} still exists.</source>
+        <target state="new">Directory {path} still exists.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="EditingAppInstaller">
+        <source>Editing AppInstaller job with {count} files.</source>
+        <target state="new">Editing AppInstaller job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ErrorSigningVsix">
+        <source>An unspecified error occurred during VSIX signing.</source>
+        <target state="new">An unspecified error occurred during VSIX signing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionWhileDeletingDirectory">
+        <source>An exception occurred while attempting to delete directory {path}.</source>
+        <target state="new">An exception occurred while attempting to delete directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchedCertificate">
+        <source>Fetched certificate. [{milliseconds} ms]</source>
+        <target state="new">Fetched certificate. [{milliseconds} ms]</target>
+        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchingCertificate">
+        <source>Fetching certificate from Azure Key Vault.</source>
+        <target state="new">Fetching certificate from Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpeningContainer">
+        <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
+        <target state="new">Extracting container {ContainerFilePath} to {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessCouldNotBeKilled">
+        <source>{0} timed out and could not be killed.</source>
+        <target state="new">{0} timed out and could not be killed.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTime">
+        <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
+        <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
+        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTimeWithArguments">
+        <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
+        <target state="new">{0} took too long to respond. The process exit code is {1}. Arguments: {2}</target>
+        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+      </trans-unit>
+      <trans-unit id="RunningCli">
+        <source>Running {fileName} with parameters: '{args}'.</source>
+        <target state="new">Running {fileName} with parameters: '{args}'.</target>
+        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SavingContainer">
+        <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
+        <target state="new">Rebuilding container {ContainerFilePath} from {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SignAsyncCalled">
+        <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
+        <target state="new">SignAsync called for {filePath}. Using {localFilePath} locally.</target>
+        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningAttempt">
+        <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
+        <target state="new">Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</target>
+        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailed">
+        <source>Could not sign {0}.</source>
+        <target state="new">Could not sign {0}.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailedAfterAllAttempts">
+        <source>Failed to sign. Attempts exceeded.</source>
+        <target state="new">Failed to sign. Attempts exceeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningFailedWithError">
+        <source>Signing failed with error {errorCode}.</source>
+        <target state="new">Signing failed with error {errorCode}.</target>
+        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFile">
+        <source>Signing {filePath}.</source>
+        <target state="new">Signing {filePath}.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningSucceeded">
+        <source>Signing succeeded.</source>
+        <target state="new">Signing succeeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningSucceededWithTimeElapsed">
+        <source>Successfully signed {filePath} in {millseconds} ms</source>
+        <target state="new">Successfully signed {filePath} in {millseconds} ms</target>
+        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SubmittingFileForSigning">
+        <source>Submitting {filePath} for signing.</source>
+        <target state="new">Submitting {filePath} for signing.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ValueCannotBeEmptyString">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsixSignatureProviderSigning">
+        <source>Signing OpenVsixSignTool job with {count} files.</source>
+        <target state="new">Signing OpenVsixSignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -1,0 +1,167 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
+    <body>
+      <trans-unit id="AzureSignToolSignatureProviderSigning">
+        <source>Signing SignTool job with {count} files.</source>
+        <target state="new">Signing SignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CertificateIsExpired">
+        <source>The certificate is expired.</source>
+        <target state="new">The certificate is expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CertificateIsNotYetTimeValid">
+        <source>The certificate is not yet time valid.</source>
+        <target state="new">The certificate is not yet time valid.</target>
+        <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardError">
+        <source>{fileName} Err {error}</source>
+        <target state="new">{fileName} Err {error}</target>
+        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardOutput">
+        <source>{fileName} Out {output}</source>
+        <target state="new">{fileName} Out {output}</target>
+        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceSignatureProviderSigning">
+        <source>Signing Mage job with {count} files.</source>
+        <target state="new">Signing Mage job with {count} files.</target>
+        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CreatingDirectory">
+        <source>Creating directory {path}.</source>
+        <target state="new">Creating directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletedDirectory">
+        <source>Directory {path} deleted.</source>
+        <target state="new">Directory {path} deleted.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletingDirectory">
+        <source>Deleting directory {path}.</source>
+        <target state="new">Deleting directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotDeleted">
+        <source>Directory {path} still exists.</source>
+        <target state="new">Directory {path} still exists.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="EditingAppInstaller">
+        <source>Editing AppInstaller job with {count} files.</source>
+        <target state="new">Editing AppInstaller job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ErrorSigningVsix">
+        <source>An unspecified error occurred during VSIX signing.</source>
+        <target state="new">An unspecified error occurred during VSIX signing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionWhileDeletingDirectory">
+        <source>An exception occurred while attempting to delete directory {path}.</source>
+        <target state="new">An exception occurred while attempting to delete directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchedCertificate">
+        <source>Fetched certificate. [{milliseconds} ms]</source>
+        <target state="new">Fetched certificate. [{milliseconds} ms]</target>
+        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchingCertificate">
+        <source>Fetching certificate from Azure Key Vault.</source>
+        <target state="new">Fetching certificate from Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpeningContainer">
+        <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
+        <target state="new">Extracting container {ContainerFilePath} to {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessCouldNotBeKilled">
+        <source>{0} timed out and could not be killed.</source>
+        <target state="new">{0} timed out and could not be killed.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTime">
+        <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
+        <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
+        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTimeWithArguments">
+        <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
+        <target state="new">{0} took too long to respond. The process exit code is {1}. Arguments: {2}</target>
+        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+      </trans-unit>
+      <trans-unit id="RunningCli">
+        <source>Running {fileName} with parameters: '{args}'.</source>
+        <target state="new">Running {fileName} with parameters: '{args}'.</target>
+        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SavingContainer">
+        <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
+        <target state="new">Rebuilding container {ContainerFilePath} from {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SignAsyncCalled">
+        <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
+        <target state="new">SignAsync called for {filePath}. Using {localFilePath} locally.</target>
+        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningAttempt">
+        <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
+        <target state="new">Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</target>
+        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailed">
+        <source>Could not sign {0}.</source>
+        <target state="new">Could not sign {0}.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailedAfterAllAttempts">
+        <source>Failed to sign. Attempts exceeded.</source>
+        <target state="new">Failed to sign. Attempts exceeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningFailedWithError">
+        <source>Signing failed with error {errorCode}.</source>
+        <target state="new">Signing failed with error {errorCode}.</target>
+        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFile">
+        <source>Signing {filePath}.</source>
+        <target state="new">Signing {filePath}.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningSucceeded">
+        <source>Signing succeeded.</source>
+        <target state="new">Signing succeeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningSucceededWithTimeElapsed">
+        <source>Successfully signed {filePath} in {millseconds} ms</source>
+        <target state="new">Successfully signed {filePath} in {millseconds} ms</target>
+        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SubmittingFileForSigning">
+        <source>Submitting {filePath} for signing.</source>
+        <target state="new">Submitting {filePath} for signing.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ValueCannotBeEmptyString">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsixSignatureProviderSigning">
+        <source>Signing OpenVsixSignTool job with {count} files.</source>
+        <target state="new">Signing OpenVsixSignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -1,0 +1,167 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
+    <body>
+      <trans-unit id="AzureSignToolSignatureProviderSigning">
+        <source>Signing SignTool job with {count} files.</source>
+        <target state="new">Signing SignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CertificateIsExpired">
+        <source>The certificate is expired.</source>
+        <target state="new">The certificate is expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CertificateIsNotYetTimeValid">
+        <source>The certificate is not yet time valid.</source>
+        <target state="new">The certificate is not yet time valid.</target>
+        <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardError">
+        <source>{fileName} Err {error}</source>
+        <target state="new">{fileName} Err {error}</target>
+        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardOutput">
+        <source>{fileName} Out {output}</source>
+        <target state="new">{fileName} Out {output}</target>
+        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceSignatureProviderSigning">
+        <source>Signing Mage job with {count} files.</source>
+        <target state="new">Signing Mage job with {count} files.</target>
+        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CreatingDirectory">
+        <source>Creating directory {path}.</source>
+        <target state="new">Creating directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletedDirectory">
+        <source>Directory {path} deleted.</source>
+        <target state="new">Directory {path} deleted.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletingDirectory">
+        <source>Deleting directory {path}.</source>
+        <target state="new">Deleting directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotDeleted">
+        <source>Directory {path} still exists.</source>
+        <target state="new">Directory {path} still exists.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="EditingAppInstaller">
+        <source>Editing AppInstaller job with {count} files.</source>
+        <target state="new">Editing AppInstaller job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ErrorSigningVsix">
+        <source>An unspecified error occurred during VSIX signing.</source>
+        <target state="new">An unspecified error occurred during VSIX signing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionWhileDeletingDirectory">
+        <source>An exception occurred while attempting to delete directory {path}.</source>
+        <target state="new">An exception occurred while attempting to delete directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchedCertificate">
+        <source>Fetched certificate. [{milliseconds} ms]</source>
+        <target state="new">Fetched certificate. [{milliseconds} ms]</target>
+        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchingCertificate">
+        <source>Fetching certificate from Azure Key Vault.</source>
+        <target state="new">Fetching certificate from Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpeningContainer">
+        <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
+        <target state="new">Extracting container {ContainerFilePath} to {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessCouldNotBeKilled">
+        <source>{0} timed out and could not be killed.</source>
+        <target state="new">{0} timed out and could not be killed.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTime">
+        <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
+        <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
+        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTimeWithArguments">
+        <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
+        <target state="new">{0} took too long to respond. The process exit code is {1}. Arguments: {2}</target>
+        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+      </trans-unit>
+      <trans-unit id="RunningCli">
+        <source>Running {fileName} with parameters: '{args}'.</source>
+        <target state="new">Running {fileName} with parameters: '{args}'.</target>
+        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SavingContainer">
+        <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
+        <target state="new">Rebuilding container {ContainerFilePath} from {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SignAsyncCalled">
+        <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
+        <target state="new">SignAsync called for {filePath}. Using {localFilePath} locally.</target>
+        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningAttempt">
+        <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
+        <target state="new">Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</target>
+        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailed">
+        <source>Could not sign {0}.</source>
+        <target state="new">Could not sign {0}.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailedAfterAllAttempts">
+        <source>Failed to sign. Attempts exceeded.</source>
+        <target state="new">Failed to sign. Attempts exceeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningFailedWithError">
+        <source>Signing failed with error {errorCode}.</source>
+        <target state="new">Signing failed with error {errorCode}.</target>
+        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFile">
+        <source>Signing {filePath}.</source>
+        <target state="new">Signing {filePath}.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningSucceeded">
+        <source>Signing succeeded.</source>
+        <target state="new">Signing succeeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningSucceededWithTimeElapsed">
+        <source>Successfully signed {filePath} in {millseconds} ms</source>
+        <target state="new">Successfully signed {filePath} in {millseconds} ms</target>
+        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SubmittingFileForSigning">
+        <source>Submitting {filePath} for signing.</source>
+        <target state="new">Submitting {filePath} for signing.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ValueCannotBeEmptyString">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsixSignatureProviderSigning">
+        <source>Signing OpenVsixSignTool job with {count} files.</source>
+        <target state="new">Signing OpenVsixSignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -1,0 +1,167 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
+    <body>
+      <trans-unit id="AzureSignToolSignatureProviderSigning">
+        <source>Signing SignTool job with {count} files.</source>
+        <target state="new">Signing SignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CertificateIsExpired">
+        <source>The certificate is expired.</source>
+        <target state="new">The certificate is expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CertificateIsNotYetTimeValid">
+        <source>The certificate is not yet time valid.</source>
+        <target state="new">The certificate is not yet time valid.</target>
+        <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardError">
+        <source>{fileName} Err {error}</source>
+        <target state="new">{fileName} Err {error}</target>
+        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardOutput">
+        <source>{fileName} Out {output}</source>
+        <target state="new">{fileName} Out {output}</target>
+        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceSignatureProviderSigning">
+        <source>Signing Mage job with {count} files.</source>
+        <target state="new">Signing Mage job with {count} files.</target>
+        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CreatingDirectory">
+        <source>Creating directory {path}.</source>
+        <target state="new">Creating directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletedDirectory">
+        <source>Directory {path} deleted.</source>
+        <target state="new">Directory {path} deleted.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletingDirectory">
+        <source>Deleting directory {path}.</source>
+        <target state="new">Deleting directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotDeleted">
+        <source>Directory {path} still exists.</source>
+        <target state="new">Directory {path} still exists.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="EditingAppInstaller">
+        <source>Editing AppInstaller job with {count} files.</source>
+        <target state="new">Editing AppInstaller job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ErrorSigningVsix">
+        <source>An unspecified error occurred during VSIX signing.</source>
+        <target state="new">An unspecified error occurred during VSIX signing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionWhileDeletingDirectory">
+        <source>An exception occurred while attempting to delete directory {path}.</source>
+        <target state="new">An exception occurred while attempting to delete directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchedCertificate">
+        <source>Fetched certificate. [{milliseconds} ms]</source>
+        <target state="new">Fetched certificate. [{milliseconds} ms]</target>
+        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchingCertificate">
+        <source>Fetching certificate from Azure Key Vault.</source>
+        <target state="new">Fetching certificate from Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpeningContainer">
+        <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
+        <target state="new">Extracting container {ContainerFilePath} to {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessCouldNotBeKilled">
+        <source>{0} timed out and could not be killed.</source>
+        <target state="new">{0} timed out and could not be killed.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTime">
+        <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
+        <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
+        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTimeWithArguments">
+        <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
+        <target state="new">{0} took too long to respond. The process exit code is {1}. Arguments: {2}</target>
+        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+      </trans-unit>
+      <trans-unit id="RunningCli">
+        <source>Running {fileName} with parameters: '{args}'.</source>
+        <target state="new">Running {fileName} with parameters: '{args}'.</target>
+        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SavingContainer">
+        <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
+        <target state="new">Rebuilding container {ContainerFilePath} from {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SignAsyncCalled">
+        <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
+        <target state="new">SignAsync called for {filePath}. Using {localFilePath} locally.</target>
+        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningAttempt">
+        <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
+        <target state="new">Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</target>
+        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailed">
+        <source>Could not sign {0}.</source>
+        <target state="new">Could not sign {0}.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailedAfterAllAttempts">
+        <source>Failed to sign. Attempts exceeded.</source>
+        <target state="new">Failed to sign. Attempts exceeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningFailedWithError">
+        <source>Signing failed with error {errorCode}.</source>
+        <target state="new">Signing failed with error {errorCode}.</target>
+        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFile">
+        <source>Signing {filePath}.</source>
+        <target state="new">Signing {filePath}.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningSucceeded">
+        <source>Signing succeeded.</source>
+        <target state="new">Signing succeeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningSucceededWithTimeElapsed">
+        <source>Successfully signed {filePath} in {millseconds} ms</source>
+        <target state="new">Successfully signed {filePath} in {millseconds} ms</target>
+        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SubmittingFileForSigning">
+        <source>Submitting {filePath} for signing.</source>
+        <target state="new">Submitting {filePath} for signing.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ValueCannotBeEmptyString">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsixSignatureProviderSigning">
+        <source>Signing OpenVsixSignTool job with {count} files.</source>
+        <target state="new">Signing OpenVsixSignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -1,0 +1,167 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
+    <body>
+      <trans-unit id="AzureSignToolSignatureProviderSigning">
+        <source>Signing SignTool job with {count} files.</source>
+        <target state="new">Signing SignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CertificateIsExpired">
+        <source>The certificate is expired.</source>
+        <target state="new">The certificate is expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CertificateIsNotYetTimeValid">
+        <source>The certificate is not yet time valid.</source>
+        <target state="new">The certificate is not yet time valid.</target>
+        <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardError">
+        <source>{fileName} Err {error}</source>
+        <target state="new">{fileName} Err {error}</target>
+        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardOutput">
+        <source>{fileName} Out {output}</source>
+        <target state="new">{fileName} Out {output}</target>
+        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceSignatureProviderSigning">
+        <source>Signing Mage job with {count} files.</source>
+        <target state="new">Signing Mage job with {count} files.</target>
+        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CreatingDirectory">
+        <source>Creating directory {path}.</source>
+        <target state="new">Creating directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletedDirectory">
+        <source>Directory {path} deleted.</source>
+        <target state="new">Directory {path} deleted.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletingDirectory">
+        <source>Deleting directory {path}.</source>
+        <target state="new">Deleting directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotDeleted">
+        <source>Directory {path} still exists.</source>
+        <target state="new">Directory {path} still exists.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="EditingAppInstaller">
+        <source>Editing AppInstaller job with {count} files.</source>
+        <target state="new">Editing AppInstaller job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ErrorSigningVsix">
+        <source>An unspecified error occurred during VSIX signing.</source>
+        <target state="new">An unspecified error occurred during VSIX signing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionWhileDeletingDirectory">
+        <source>An exception occurred while attempting to delete directory {path}.</source>
+        <target state="new">An exception occurred while attempting to delete directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchedCertificate">
+        <source>Fetched certificate. [{milliseconds} ms]</source>
+        <target state="new">Fetched certificate. [{milliseconds} ms]</target>
+        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchingCertificate">
+        <source>Fetching certificate from Azure Key Vault.</source>
+        <target state="new">Fetching certificate from Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpeningContainer">
+        <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
+        <target state="new">Extracting container {ContainerFilePath} to {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessCouldNotBeKilled">
+        <source>{0} timed out and could not be killed.</source>
+        <target state="new">{0} timed out and could not be killed.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTime">
+        <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
+        <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
+        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTimeWithArguments">
+        <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
+        <target state="new">{0} took too long to respond. The process exit code is {1}. Arguments: {2}</target>
+        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+      </trans-unit>
+      <trans-unit id="RunningCli">
+        <source>Running {fileName} with parameters: '{args}'.</source>
+        <target state="new">Running {fileName} with parameters: '{args}'.</target>
+        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SavingContainer">
+        <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
+        <target state="new">Rebuilding container {ContainerFilePath} from {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SignAsyncCalled">
+        <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
+        <target state="new">SignAsync called for {filePath}. Using {localFilePath} locally.</target>
+        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningAttempt">
+        <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
+        <target state="new">Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</target>
+        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailed">
+        <source>Could not sign {0}.</source>
+        <target state="new">Could not sign {0}.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailedAfterAllAttempts">
+        <source>Failed to sign. Attempts exceeded.</source>
+        <target state="new">Failed to sign. Attempts exceeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningFailedWithError">
+        <source>Signing failed with error {errorCode}.</source>
+        <target state="new">Signing failed with error {errorCode}.</target>
+        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFile">
+        <source>Signing {filePath}.</source>
+        <target state="new">Signing {filePath}.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningSucceeded">
+        <source>Signing succeeded.</source>
+        <target state="new">Signing succeeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningSucceededWithTimeElapsed">
+        <source>Successfully signed {filePath} in {millseconds} ms</source>
+        <target state="new">Successfully signed {filePath} in {millseconds} ms</target>
+        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SubmittingFileForSigning">
+        <source>Submitting {filePath} for signing.</source>
+        <target state="new">Submitting {filePath} for signing.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ValueCannotBeEmptyString">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsixSignatureProviderSigning">
+        <source>Signing OpenVsixSignTool job with {count} files.</source>
+        <target state="new">Signing OpenVsixSignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -1,0 +1,167 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
+    <body>
+      <trans-unit id="AzureSignToolSignatureProviderSigning">
+        <source>Signing SignTool job with {count} files.</source>
+        <target state="new">Signing SignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CertificateIsExpired">
+        <source>The certificate is expired.</source>
+        <target state="new">The certificate is expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CertificateIsNotYetTimeValid">
+        <source>The certificate is not yet time valid.</source>
+        <target state="new">The certificate is not yet time valid.</target>
+        <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardError">
+        <source>{fileName} Err {error}</source>
+        <target state="new">{fileName} Err {error}</target>
+        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardOutput">
+        <source>{fileName} Out {output}</source>
+        <target state="new">{fileName} Out {output}</target>
+        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceSignatureProviderSigning">
+        <source>Signing Mage job with {count} files.</source>
+        <target state="new">Signing Mage job with {count} files.</target>
+        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CreatingDirectory">
+        <source>Creating directory {path}.</source>
+        <target state="new">Creating directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletedDirectory">
+        <source>Directory {path} deleted.</source>
+        <target state="new">Directory {path} deleted.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletingDirectory">
+        <source>Deleting directory {path}.</source>
+        <target state="new">Deleting directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotDeleted">
+        <source>Directory {path} still exists.</source>
+        <target state="new">Directory {path} still exists.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="EditingAppInstaller">
+        <source>Editing AppInstaller job with {count} files.</source>
+        <target state="new">Editing AppInstaller job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ErrorSigningVsix">
+        <source>An unspecified error occurred during VSIX signing.</source>
+        <target state="new">An unspecified error occurred during VSIX signing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionWhileDeletingDirectory">
+        <source>An exception occurred while attempting to delete directory {path}.</source>
+        <target state="new">An exception occurred while attempting to delete directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchedCertificate">
+        <source>Fetched certificate. [{milliseconds} ms]</source>
+        <target state="new">Fetched certificate. [{milliseconds} ms]</target>
+        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchingCertificate">
+        <source>Fetching certificate from Azure Key Vault.</source>
+        <target state="new">Fetching certificate from Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpeningContainer">
+        <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
+        <target state="new">Extracting container {ContainerFilePath} to {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessCouldNotBeKilled">
+        <source>{0} timed out and could not be killed.</source>
+        <target state="new">{0} timed out and could not be killed.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTime">
+        <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
+        <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
+        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTimeWithArguments">
+        <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
+        <target state="new">{0} took too long to respond. The process exit code is {1}. Arguments: {2}</target>
+        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+      </trans-unit>
+      <trans-unit id="RunningCli">
+        <source>Running {fileName} with parameters: '{args}'.</source>
+        <target state="new">Running {fileName} with parameters: '{args}'.</target>
+        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SavingContainer">
+        <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
+        <target state="new">Rebuilding container {ContainerFilePath} from {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SignAsyncCalled">
+        <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
+        <target state="new">SignAsync called for {filePath}. Using {localFilePath} locally.</target>
+        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningAttempt">
+        <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
+        <target state="new">Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</target>
+        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailed">
+        <source>Could not sign {0}.</source>
+        <target state="new">Could not sign {0}.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailedAfterAllAttempts">
+        <source>Failed to sign. Attempts exceeded.</source>
+        <target state="new">Failed to sign. Attempts exceeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningFailedWithError">
+        <source>Signing failed with error {errorCode}.</source>
+        <target state="new">Signing failed with error {errorCode}.</target>
+        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFile">
+        <source>Signing {filePath}.</source>
+        <target state="new">Signing {filePath}.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningSucceeded">
+        <source>Signing succeeded.</source>
+        <target state="new">Signing succeeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningSucceededWithTimeElapsed">
+        <source>Successfully signed {filePath} in {millseconds} ms</source>
+        <target state="new">Successfully signed {filePath} in {millseconds} ms</target>
+        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SubmittingFileForSigning">
+        <source>Submitting {filePath} for signing.</source>
+        <target state="new">Submitting {filePath} for signing.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ValueCannotBeEmptyString">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsixSignatureProviderSigning">
+        <source>Signing OpenVsixSignTool job with {count} files.</source>
+        <target state="new">Signing OpenVsixSignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -1,0 +1,167 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
+    <body>
+      <trans-unit id="AzureSignToolSignatureProviderSigning">
+        <source>Signing SignTool job with {count} files.</source>
+        <target state="new">Signing SignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CertificateIsExpired">
+        <source>The certificate is expired.</source>
+        <target state="new">The certificate is expired.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CertificateIsNotYetTimeValid">
+        <source>The certificate is not yet time valid.</source>
+        <target state="new">The certificate is not yet time valid.</target>
+        <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardError">
+        <source>{fileName} Err {error}</source>
+        <target state="new">{fileName} Err {error}</target>
+        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CliStandardOutput">
+        <source>{fileName} Out {output}</source>
+        <target state="new">{fileName} Out {output}</target>
+        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceSignatureProviderSigning">
+        <source>Signing Mage job with {count} files.</source>
+        <target state="new">Signing Mage job with {count} files.</target>
+        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="CreatingDirectory">
+        <source>Creating directory {path}.</source>
+        <target state="new">Creating directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletedDirectory">
+        <source>Directory {path} deleted.</source>
+        <target state="new">Directory {path} deleted.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DeletingDirectory">
+        <source>Deleting directory {path}.</source>
+        <target state="new">Deleting directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="DirectoryNotDeleted">
+        <source>Directory {path} still exists.</source>
+        <target state="new">Directory {path} still exists.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="EditingAppInstaller">
+        <source>Editing AppInstaller job with {count} files.</source>
+        <target state="new">Editing AppInstaller job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ErrorSigningVsix">
+        <source>An unspecified error occurred during VSIX signing.</source>
+        <target state="new">An unspecified error occurred during VSIX signing.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExceptionWhileDeletingDirectory">
+        <source>An exception occurred while attempting to delete directory {path}.</source>
+        <target state="new">An exception occurred while attempting to delete directory {path}.</target>
+        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchedCertificate">
+        <source>Fetched certificate. [{milliseconds} ms]</source>
+        <target state="new">Fetched certificate. [{milliseconds} ms]</target>
+        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="FetchingCertificate">
+        <source>Fetching certificate from Azure Key Vault.</source>
+        <target state="new">Fetching certificate from Azure Key Vault.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpeningContainer">
+        <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
+        <target state="new">Extracting container {ContainerFilePath} to {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessCouldNotBeKilled">
+        <source>{0} timed out and could not be killed.</source>
+        <target state="new">{0} timed out and could not be killed.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTime">
+        <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
+        <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
+        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ProcessDidNotExitInTimeWithArguments">
+        <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
+        <target state="new">{0} took too long to respond. The process exit code is {1}. Arguments: {2}</target>
+        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+      </trans-unit>
+      <trans-unit id="RunningCli">
+        <source>Running {fileName} with parameters: '{args}'.</source>
+        <target state="new">Running {fileName} with parameters: '{args}'.</target>
+        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SavingContainer">
+        <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
+        <target state="new">Rebuilding container {ContainerFilePath} from {DirectoryPath}.</target>
+        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SignAsyncCalled">
+        <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
+        <target state="new">SignAsync called for {filePath}. Using {localFilePath} locally.</target>
+        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningAttempt">
+        <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
+        <target state="new">Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</target>
+        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailed">
+        <source>Could not sign {0}.</source>
+        <target state="new">Could not sign {0}.</target>
+        <note>{0} is a file path.</note>
+      </trans-unit>
+      <trans-unit id="SigningFailedAfterAllAttempts">
+        <source>Failed to sign. Attempts exceeded.</source>
+        <target state="new">Failed to sign. Attempts exceeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningFailedWithError">
+        <source>Signing failed with error {errorCode}.</source>
+        <target state="new">Signing failed with error {errorCode}.</target>
+        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningFile">
+        <source>Signing {filePath}.</source>
+        <target state="new">Signing {filePath}.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SigningSucceeded">
+        <source>Signing succeeded.</source>
+        <target state="new">Signing succeeded.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SigningSucceededWithTimeElapsed">
+        <source>Successfully signed {filePath} in {millseconds} ms</source>
+        <target state="new">Successfully signed {filePath} in {millseconds} ms</target>
+        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="SubmittingFileForSigning">
+        <source>Submitting {filePath} for signing.</source>
+        <target state="new">Submitting {filePath} for signing.</target>
+        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="ValueCannotBeEmptyString">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VsixSignatureProviderSigning">
+        <source>Signing OpenVsixSignTool job with {count} files.</source>
+        <target state="new">Signing OpenVsixSignTool job with {count} files.</target>
+        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
Progress on https://github.com/dotnet/sign/issues/570.

A prerequisite for localization is enabling Xliff-Tasks.  It's briefly mentioned [here](https://github.com/dotnet/arcade/blob/b40fa37a9086f204fea57539ee19a47b45062295/Documentation/OneLocBuild.md) but with no pointers on how to do it.  The [dotnet/xliff-tasks](https://github.com/dotnet/xliff-tasks/#readme) repo has directions.

This change opts in to Xliff-Tasks and generates initial .xlf files required for localization.

Additionally, following guidance [here](https://github.com/dotnet/xliff-tasks/tree/4be0854629b831ad6565ad05c5e25b278613e4d3#updating-xlf-files), `UpdateXlfOnBuild` is enabled by default in local developer (non-CI) builds.