### PR TITLE
Update to System.Security.Cryptography.Pkcs 7.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,6 +24,7 @@
     <PackageVersion Include="OpenVsixSignTool.Core" Version="0.4.0" />
     <PackageVersion Include="RSAKeyVaultProvider" Version="2.1.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="7.0.1" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="7.0.1" />
     <PackageVersion Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>

--- a/src/Sign.Core/Sign.Core.csproj
+++ b/src/Sign.Core/Sign.Core.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="NuGetKeyVaultSignTool.Core" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="OpenVsixSignTool.Core" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="RSAKeyVaultProvider" PrivateAssets="analyzers;build;compile;contentfiles" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="System.Security.Cryptography.Xml" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="System.Text.Json" PrivateAssets="analyzers;build;compile;contentfiles" />
   </ItemGroup>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/539.

This change updates from System.Security.Cryptography.Pkcs 7.0 to 7.0.1, which brings in [this fix](https://github.com/dotnet/runtime/pull/80188).

I've manually verified that this works.  It's difficult to satisfactorily automate testing of this scenario, so I've created https://github.com/dotnet/sign/issues/595 as a separate task.

CC @clairernovotny