### PR TITLE
Make ACS the default timestamping service

### DIFF
--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -64,8 +64,8 @@ namespace Sign.Cli
                 string? fileListFilePath = context.ParseResult.GetValueForOption(_codeCommand.FileListOption);
                 HashAlgorithmName fileHashAlgorithmName = context.ParseResult.GetValueForOption(_codeCommand.FileDigestOption);
                 HashAlgorithmName timestampHashAlgorithmName = context.ParseResult.GetValueForOption(_codeCommand.TimestampDigestOption);
-                // This option is required.  If its value fails to parse we won't have reached here,
-                // and after successful parsing its value will never be null.
+                // This option is optional but has a default value.  If its value fails to parse we won't have
+                // reached here, and after successful parsing its value will never be null.
                 // Non-null is already guaranteed; the null-forgiving operator (!) just simplifies code.
                 Uri timestampUrl = context.ParseResult.GetValueForOption(_codeCommand.TimestampUrlOption)!;
                 LogLevel verbosity = context.ParseResult.GetValueForOption(_codeCommand.VerbosityOption);

--- a/src/Sign.Cli/CodeCommand.cs
+++ b/src/Sign.Cli/CodeCommand.cs
@@ -30,11 +30,11 @@ namespace Sign.Cli
         {
             DescriptionOption.IsRequired = true;
             DescriptionUrlOption.IsRequired = true;
-            TimestampUrlOption.IsRequired = true;
 
             MaxConcurrencyOption.SetDefaultValue(4);
             FileDigestOption.SetDefaultValue(HashAlgorithmName.SHA256);
             TimestampDigestOption.SetDefaultValue(HashAlgorithmName.SHA256);
+            TimestampUrlOption.SetDefaultValue(new Uri("http://timestamp.acs.microsoft.com"));
             BaseDirectoryOption.SetDefaultValue(new DirectoryInfo(Environment.CurrentDirectory));
 
             // Global options are available on the adding command and all subcommands.

--- a/test/Sign.Cli.Test/CodeCommandTests.cs
+++ b/test/Sign.Cli.Test/CodeCommandTests.cs
@@ -125,9 +125,9 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
-        public void TimestampUrlOption_Always_IsRequired()
+        public void TimestampUrlOption_Always_IsNotRequired()
         {
-            Assert.True(_command.TimestampUrlOption.IsRequired);
+            Assert.False(_command.TimestampUrlOption.IsRequired);
         }
 
         [Fact]

--- a/test/Sign.Cli.Test/Options/TimestampUrlOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/TimestampUrlOptionTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
+using System.CommandLine.Parsing;
+
 namespace Sign.Cli.Test
 {
     public class TimestampUrlOptionTests : UriOptionTests
@@ -9,6 +11,16 @@ namespace Sign.Cli.Test
         public TimestampUrlOptionTests()
             : base(new CodeCommand().TimestampUrlOption, "-t", "--timestamp-url")
         {
+        }
+
+        [Fact]
+        public void Option_WhenOptionIsMissing_HasDefaultValue()
+        {
+            ParseResult result = Parse();
+            Uri? value = result.GetValueForOption(Option);
+
+            Assert.NotNull(value);
+            Assert.Equal("http://timestamp.acs.microsoft.com/", value.AbsoluteUri);
         }
     }
 }

--- a/test/Sign.Cli.Test/Options/UriOptionTests.cs
+++ b/test/Sign.Cli.Test/Options/UriOptionTests.cs
@@ -46,6 +46,7 @@ namespace Sign.Cli.Test
         }
 
         [Theory]
+        [InlineData("\"\"")]
         [InlineData("//domain.test")]
         [InlineData("/path")]
         [InlineData("file:///file.bin")]


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/597.

This change makes Azure Code Signing timestamping service the default.  The default can be overridden with the `-t` | `--timestamp-url` option.

Note that changing `IsRequired` from `true` to `false` means that a user isn't required to pass the option.  The new default value guarantees that there will be a value, so timestamping is still effectively required.

CC @clairernovotny