### PR TITLE
Remove duplicate default value from help

### DIFF
--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -160,7 +160,7 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Maximum concurrency (default is 4)..
+        ///   Looks up a localized string similar to Maximum concurrency..
         /// </summary>
         internal static string MaxConcurrencyOptionDescription {
             get {

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -156,7 +156,7 @@
     <comment>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</comment>
   </data>
   <data name="MaxConcurrencyOptionDescription" xml:space="preserve">
-    <value>Maximum concurrency (default is 4).</value>
+    <value>Maximum concurrency.</value>
   </data>
   <data name="OutputOptionDescription" xml:space="preserve">
     <value>Output file or directory. If omitted, input files will be overwritten.</value>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/599.

This change removes a duplicate message about the default value for the `-m` | `--max-concurrency` option.

```
  -m, --max-concurrency <max-concurrency>                Maximum concurrency. [default: 4]
```

CC @clairernovotny