### PR TITLE
Update resource strings and comments

### DIFF
--- a/src/Sign.Cli/AzureKeyVaultResources.resx
+++ b/src/Sign.Cli/AzureKeyVaultResources.resx
@@ -134,11 +134,11 @@
   </data>
   <data name="InvalidBaseDirectoryValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be a fully rooted directory path.</value>
-    <comment>{0} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
+    <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
   </data>
   <data name="InvalidClientSecretCredential" xml:space="preserve">
     <value>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</value>
-    <comment>{0}, {1}, and {2} are option names and should not be localized.</comment>
+    <comment>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</comment>
   </data>
   <data name="InvalidFileValue" xml:space="preserve">
     <value>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</value>
@@ -154,7 +154,7 @@
   </data>
   <data name="SomeFilesDoNotExist" xml:space="preserve">
     <value>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</value>
-    <comment>{0} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
+    <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
   </data>
   <data name="TenantIdOptionDescription" xml:space="preserve">
     <value>Tenant ID to authenticate to Azure Key Vault.</value>

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -134,26 +134,26 @@
   </data>
   <data name="FileDigestOptionDescription" xml:space="preserve">
     <value>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</value>
-    <comment>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</comment>
+    <comment>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</comment>
   </data>
   <data name="FileListOptionDescription" xml:space="preserve">
     <value>Path to file containing paths of files to sign within an archive.</value>
   </data>
   <data name="InvalidBaseDirectoryValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be a fully rooted directory path.</value>
-    <comment>{0} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
+    <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
   </data>
   <data name="InvalidDigestValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</value>
-    <comment>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</comment>
+    <comment>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</comment>
   </data>
   <data name="InvalidMaxConcurrencyValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be a number value greater than or equal to 1.</value>
-    <comment>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</comment>
+    <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</comment>
   </data>
   <data name="InvalidUrlValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</value>
-    <comment>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</comment>
+    <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</comment>
   </data>
   <data name="MaxConcurrencyOptionDescription" xml:space="preserve">
     <value>Maximum concurrency.</value>
@@ -170,7 +170,7 @@
   </data>
   <data name="TimestampDigestOptionDescription" xml:space="preserve">
     <value>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</value>
-    <comment>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</comment>
+    <comment>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161), and {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names should not be localized.</comment>
   </data>
   <data name="TimestampUrlOptionDescription" xml:space="preserve">
     <value>RFC 3161 timestamp server URL.</value>
@@ -178,7 +178,7 @@
   </data>
   <data name="VerbosityOptionDescription" xml:space="preserve">
     <value>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</value>
-    <comment>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</comment>
+    <comment>{Locked="none", "critical", "error", "warning", "information", "debug", "trace"} are option values and should not be localized.</comment>
   </data>
   <data name="x86NotSupported" xml:space="preserve">
     <value>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</value>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
@@ -29,13 +29,13 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být plně kořenová cesta k adresáři.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Neplatná hodnota pro {0}. Hodnota musí být plně kořenová cesta k adresáři.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
-        <target state="translated">Pokud se nepoužívá spravovaná identita, vyžadují se všechny tyto možnosti: {0}, {1}a {2}.</target>
-        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+        <target state="needs-review-translation">Pokud se nepoužívá spravovaná identita, vyžadují se všechny tyto možnosti: {0}, {1}a {2}.</target>
+        <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
@@ -59,8 +59,8 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Některé soubory neexistují.  Zkuste použít jinou hodnotu {0} nebo plně kvalifikovanou cestu k souboru.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Některé soubory neexistují.  Zkuste použít jinou hodnotu {0} nebo plně kvalifikovanou cestu k souboru.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
@@ -29,13 +29,13 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Ungültiger Wert für {0}. Der Wert muss ein vollständiger Stammverzeichnispfad sein.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Ungültiger Wert für {0}. Der Wert muss ein vollständiger Stammverzeichnispfad sein.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
-        <target state="translated">Wenn Sie keine verwaltete Identität verwenden, sind alle diese Optionen erforderlich: {0}, {1} und {2}.</target>
-        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+        <target state="needs-review-translation">Wenn Sie keine verwaltete Identität verwenden, sind alle diese Optionen erforderlich: {0}, {1} und {2}.</target>
+        <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
@@ -59,8 +59,8 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Einige Dateien sind nicht vorhanden.  Versuchen Sie, einen anderen {0}-Wert oder einen vollqualifizierten Dateipfad zu verwenden.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Einige Dateien sind nicht vorhanden.  Versuchen Sie, einen anderen {0}-Wert oder einen vollqualifizierten Dateipfad zu verwenden.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
@@ -29,13 +29,13 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valor no válido para {0}. El valor debe ser una ruta de acceso de directorio totalmente raíz.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Valor no válido para {0}. El valor debe ser una ruta de acceso de directorio totalmente raíz.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
-        <target state="translated">Si no usa una identidad administrada, se requieren todas estas opciones: {0}, {1} y {2}.</target>
-        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+        <target state="needs-review-translation">Si no usa una identidad administrada, se requieren todas estas opciones: {0}, {1} y {2}.</target>
+        <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
@@ -59,8 +59,8 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Algunos archivos no existen.  Pruebe a usar otro valor {0} o una ruta de acceso de archivo completa.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Algunos archivos no existen.  Pruebe a usar otro valor {0} o una ruta de acceso de archivo completa.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
@@ -29,13 +29,13 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valeur non valide pour {0}. La valeur doit être un chemin d’accès de répertoire entièrement rooté.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Valeur non valide pour {0}. La valeur doit être un chemin d’accès de répertoire entièrement rooté.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
-        <target state="translated">Si vous n’utilisez pas d’identité managée, toutes ces options sont requises : {0}, {1} et {2}.</target>
-        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+        <target state="needs-review-translation">Si vous n’utilisez pas d’identité managée, toutes ces options sont requises : {0}, {1} et {2}.</target>
+        <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
@@ -59,8 +59,8 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Certains fichiers n’existent pas. Essayez d’utiliser une autre valeur {0} ou un chemin de fichier complet.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Certains fichiers n’existent pas. Essayez d’utiliser une autre valeur {0} ou un chemin de fichier complet.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
@@ -29,13 +29,13 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valore non valido per {0}. Il valore deve essere un percorso di directory completo.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Valore non valido per {0}. Il valore deve essere un percorso di directory completo.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
-        <target state="translated">Se non si usa un'identità gestita, saranno necessarie tutte le opzioni seguenti: {0}, {1} e {2}.</target>
-        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+        <target state="needs-review-translation">Se non si usa un'identità gestita, saranno necessarie tutte le opzioni seguenti: {0}, {1} e {2}.</target>
+        <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
@@ -59,8 +59,8 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Alcuni file non esistono.  Provare a usare un valore di {0} diverso o un percorso di file completo.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Alcuni file non esistono.  Provare a usare un valore di {0} diverso o un percorso di file completo.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
@@ -29,13 +29,13 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} の値が無効です。値は、完全にルート化されたディレクトリ パスである必要があります。</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">{0} の値が無効です。値は、完全にルート化されたディレクトリ パスである必要があります。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
-        <target state="translated">マネージド ID を使用しない場合は、{0}、{1}、{2} のオプションがすべて必要です。</target>
-        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+        <target state="needs-review-translation">マネージド ID を使用しない場合は、{0}、{1}、{2} のオプションがすべて必要です。</target>
+        <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
@@ -59,8 +59,8 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">一部のファイルが存在しません。別の {0} 値または完全修飾ファイル パスを使用してみてください。</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">一部のファイルが存在しません。別の {0} 値または完全修飾ファイル パスを使用してみてください。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
@@ -29,13 +29,13 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 완전한 루트 디렉터리 경로여야 합니다.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">{0}에 대한 값이 잘못되었습니다. 값은 완전한 루트 디렉터리 경로여야 합니다.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
-        <target state="translated">관리 ID를 사용하고 있지 않은 경우 {0}, {1} 및 {2} 옵션이 모두 필요합니다.</target>
-        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+        <target state="needs-review-translation">관리 ID를 사용하고 있지 않은 경우 {0}, {1} 및 {2} 옵션이 모두 필요합니다.</target>
+        <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
@@ -59,8 +59,8 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">일부 파일이 존재하지 않습니다.  다른 {0} 값 또는 정규화된 파일 경로를 사용해 보세요.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">일부 파일이 존재하지 않습니다.  다른 {0} 값 또는 정규화된 파일 경로를 사용해 보세요.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
@@ -29,13 +29,13 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Nieprawidłowa wartość dla {0}. Wartość musi być w pełni główną ścieżką katalogu.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Nieprawidłowa wartość dla {0}. Wartość musi być w pełni główną ścieżką katalogu.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
-        <target state="translated">Jeśli tożsamość zarządzana nie jest używana, wymagane są wszystkie następujące opcje: {0}, {1} i {2}.</target>
-        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+        <target state="needs-review-translation">Jeśli tożsamość zarządzana nie jest używana, wymagane są wszystkie następujące opcje: {0}, {1} i {2}.</target>
+        <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
@@ -59,8 +59,8 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Niektóre pliki nie istnieją.  Spróbuj użyć innej wartości {0} lub w pełni kwalifikowanej ścieżki pliku.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Niektóre pliki nie istnieją.  Spróbuj użyć innej wartości {0} lub w pełni kwalifikowanej ścieżki pliku.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
@@ -29,13 +29,13 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valor inválido para {0}. O valor deve ser um caminho de diretório totalmente desbloqueado por rooting.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Valor inválido para {0}. O valor deve ser um caminho de diretório totalmente desbloqueado por rooting.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
-        <target state="translated">Se não estiver usando uma identidade gerenciada, todas essas opções serão necessárias: {0}, {1} e {2}.</target>
-        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+        <target state="needs-review-translation">Se não estiver usando uma identidade gerenciada, todas essas opções serão necessárias: {0}, {1} e {2}.</target>
+        <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
@@ -59,8 +59,8 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Alguns arquivos não existem.  Tente usar um valor diferente de {0} ou um caminho de arquivo totalmente qualificado.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Alguns arquivos não existem.  Tente usar um valor diferente de {0} ou um caminho de arquivo totalmente qualificado.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
@@ -29,13 +29,13 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Недопустимое значение для {0}. Значение должно быть полным корневым путем к каталогу.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Недопустимое значение для {0}. Значение должно быть полным корневым путем к каталогу.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
-        <target state="translated">Если управляемое удостоверение не используется, требуются все следующие параметры: {0}, {1} и {2}.</target>
-        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+        <target state="needs-review-translation">Если управляемое удостоверение не используется, требуются все следующие параметры: {0}, {1} и {2}.</target>
+        <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
@@ -59,8 +59,8 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Некоторые файлы не существуют.  Попробуйте использовать другое значение {0} или полный путь к файлу.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Некоторые файлы не существуют.  Попробуйте использовать другое значение {0} или полный путь к файлу.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
@@ -29,13 +29,13 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} için geçersiz değer. Değer, tam olarak kök erişim izni verilmiş bir dizin yolu olmalıdır.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">{0} için geçersiz değer. Değer, tam olarak kök erişim izni verilmiş bir dizin yolu olmalıdır.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
-        <target state="translated">Bir yönetilen kimlik kullanılmıyorsa bu seçeneklerin tümü gereklidir: {0}, {1} ve {2}.</target>
-        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+        <target state="needs-review-translation">Bir yönetilen kimlik kullanılmıyorsa bu seçeneklerin tümü gereklidir: {0}, {1} ve {2}.</target>
+        <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
@@ -59,8 +59,8 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Bazı dosyalar mevcut değil. Farklı bir {0} değeri veya tam bir dosya yolu kullanmayı deneyin.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Bazı dosyalar mevcut değil. Farklı bir {0} değeri veya tam bir dosya yolu kullanmayı deneyin.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
@@ -29,13 +29,13 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} 的值无效。该值必须是完整的根目录路径。</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">{0} 的值无效。该值必须是完整的根目录路径。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
-        <target state="translated">如果不使用托管标识，则需要以下所有选项: {0}、{1} 和 {2}。</target>
-        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+        <target state="needs-review-translation">如果不使用托管标识，则需要以下所有选项: {0}、{1} 和 {2}。</target>
+        <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
@@ -59,8 +59,8 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">某些文件不存在。请尝试使用其他 {0} 值或完全限定的文件路径。</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">某些文件不存在。请尝试使用其他 {0} 值或完全限定的文件路径。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
@@ -29,13 +29,13 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} 的值無效。值必須是完整的根目錄路徑。</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">{0} 的值無效。值必須是完整的根目錄路徑。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
-        <target state="translated">如果未使用受控識別，則需要下列所有選項: {0}、{1} 和 {2}。</target>
-        <note>{0}, {1}, and {2} are option names and should not be localized.</note>
+        <target state="needs-review-translation">如果未使用受控識別，則需要下列所有選項: {0}、{1} 和 {2}。</target>
+        <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
@@ -59,8 +59,8 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">某些檔案不存在。請嘗試使用不同的 {0} 值或完整檔案路徑。</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">某些檔案不存在。請嘗試使用不同的 {0} 值或完整檔案路徑。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -29,8 +29,8 @@
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
         <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Algoritmus hodnoty hash pro hash souborů. Povolené hodnoty jsou sha256, sha384 a sha512.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+        <target state="needs-review-translation">Algoritmus hodnoty hash pro hash souborů. Povolené hodnoty jsou sha256, sha384 a sha512.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign within an archive.</source>
@@ -39,23 +39,23 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být plně kořenová cesta k adresáři.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Neplatná hodnota pro {0}. Hodnota musí být plně kořenová cesta k adresáři.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být sha256, sha384 nebo sha512.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+        <target state="needs-review-translation">Neplatná hodnota pro {0}. Hodnota musí být sha256, sha384 nebo sha512.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
-        <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být číselná hodnota větší nebo rovna 1.</target>
-        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+        <target state="needs-review-translation">Neplatná hodnota pro {0}. Hodnota musí být číselná hodnota větší nebo rovna 1.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
-        <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být absolutní adresa URL protokolu HTTP nebo HTTPS.</target>
-        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+        <target state="needs-review-translation">Neplatná hodnota pro {0}. Hodnota musí být absolutní adresa URL protokolu HTTP nebo HTTPS.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">
         <source>Maximum concurrency.</source>
@@ -79,8 +79,8 @@
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">Algoritmus hodnoty hash pro server časového razítka RFC 3161. Povolené hodnoty jsou sha256, sha384 a sha512.</target>
-        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+        <target state="needs-review-translation">Algoritmus hodnoty hash pro server časového razítka RFC 3161. Povolené hodnoty jsou sha256, sha384 a sha512.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161), and {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampUrlOptionDescription">
         <source>RFC 3161 timestamp server URL.</source>
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
         <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
-        <target state="translated">Nastaví úroveň podrobností. Povolené hodnoty jsou none, critical, error, warning, information, debug a trace.</target>
-        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
+        <target state="needs-review-translation">Nastaví úroveň podrobností. Povolené hodnoty jsou none, critical, error, warning, information, debug a trace.</target>
+        <note>{Locked="none", "critical", "error", "warning", "information", "debug", "trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -29,8 +29,8 @@
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
         <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Digestalgorithmus zum Hashen von Dateien. Zulässige Werte sind "sha256", "sha384" und "sha512".</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+        <target state="needs-review-translation">Digestalgorithmus zum Hashen von Dateien. Zulässige Werte sind "sha256", "sha384" und "sha512".</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign within an archive.</source>
@@ -39,23 +39,23 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Ungültiger Wert für {0}. Der Wert muss ein vollständiger Stammverzeichnispfad sein.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Ungültiger Wert für {0}. Der Wert muss ein vollständiger Stammverzeichnispfad sein.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Ungültiger Wert für {0}. Der Wert muss "sha256", "sha384" oder "sha512" sein.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+        <target state="needs-review-translation">Ungültiger Wert für {0}. Der Wert muss "sha256", "sha384" oder "sha512" sein.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
-        <target state="translated">Ungültiger Wert für {0}. Der Wert muss ein Zahlenwert größer oder gleich 1 sein.</target>
-        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+        <target state="needs-review-translation">Ungültiger Wert für {0}. Der Wert muss ein Zahlenwert größer oder gleich 1 sein.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
-        <target state="translated">Ungültiger Wert für {0}. Der Wert muss eine absolute HTTP- oder HTTPS-URL sein.</target>
-        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+        <target state="needs-review-translation">Ungültiger Wert für {0}. Der Wert muss eine absolute HTTP- oder HTTPS-URL sein.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">
         <source>Maximum concurrency.</source>
@@ -79,8 +79,8 @@
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">Digest-Algorithmus für den RFC 3161-Zeitstempelserver. Zulässige Werte sind sha256, sha384 und sha512.</target>
-        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+        <target state="needs-review-translation">Digest-Algorithmus für den RFC 3161-Zeitstempelserver. Zulässige Werte sind sha256, sha384 und sha512.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161), and {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampUrlOptionDescription">
         <source>RFC 3161 timestamp server URL.</source>
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
         <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
-        <target state="translated">Legt den Ausführlichkeitsgrad fest. Zulässige Werte sind "none", "critical", "error", "warning", "information", "debug" und "trace".</target>
-        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
+        <target state="needs-review-translation">Legt den Ausführlichkeitsgrad fest. Zulässige Werte sind "none", "critical", "error", "warning", "information", "debug" und "trace".</target>
+        <note>{Locked="none", "critical", "error", "warning", "information", "debug", "trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -29,8 +29,8 @@
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
         <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Algoritmo de resumen con el que se van a aplicar algoritmos hash a los archivos. Los valores permitidos son 'sha256', 'sha384', y 'sha512'.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+        <target state="needs-review-translation">Algoritmo de resumen con el que se van a aplicar algoritmos hash a los archivos. Los valores permitidos son 'sha256', 'sha384', y 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign within an archive.</source>
@@ -39,23 +39,23 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valor no válido para {0}. El valor debe ser una ruta de acceso de directorio totalmente raíz.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Valor no válido para {0}. El valor debe ser una ruta de acceso de directorio totalmente raíz.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Valor no válido para {0}. El valor debe ser 'sha256', 'sha384' o 'sha512'.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+        <target state="needs-review-translation">Valor no válido para {0}. El valor debe ser 'sha256', 'sha384' o 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
-        <target state="translated">Valor no válido para {0}. El valor debe ser un valor numérico mayor o igual que 1.</target>
-        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+        <target state="needs-review-translation">Valor no válido para {0}. El valor debe ser un valor numérico mayor o igual que 1.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
-        <target state="translated">Valor no válido para {0}. El valor debe ser una dirección URL HTTP o HTTPS absoluta.</target>
-        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+        <target state="needs-review-translation">Valor no válido para {0}. El valor debe ser una dirección URL HTTP o HTTPS absoluta.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">
         <source>Maximum concurrency.</source>
@@ -79,8 +79,8 @@
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">Algoritmo de resumen para el servidor de marca de tiempo RFC 3161. Los valores permitidos son sha256, sha384 y sha512.</target>
-        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+        <target state="needs-review-translation">Algoritmo de resumen para el servidor de marca de tiempo RFC 3161. Los valores permitidos son sha256, sha384 y sha512.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161), and {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampUrlOptionDescription">
         <source>RFC 3161 timestamp server URL.</source>
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
         <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
-        <target state="translated">Establece el nivel de detalle. Los valores permitidos son "none", "critical", "error", "warning", "information", "debug" y "trace".</target>
-        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
+        <target state="needs-review-translation">Establece el nivel de detalle. Los valores permitidos son "none", "critical", "error", "warning", "information", "debug" y "trace".</target>
+        <note>{Locked="none", "critical", "error", "warning", "information", "debug", "trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -29,8 +29,8 @@
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
         <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Algorithme Digest pour hacher les fichiers avec. Les valeurs autorisées sont 'sha256', 'sha384' et 'sha512'.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+        <target state="needs-review-translation">Algorithme Digest pour hacher les fichiers avec. Les valeurs autorisées sont 'sha256', 'sha384' et 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign within an archive.</source>
@@ -39,23 +39,23 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valeur non valide pour {0}. La valeur doit être un chemin d’accès de répertoire entièrement rooté.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Valeur non valide pour {0}. La valeur doit être un chemin d’accès de répertoire entièrement rooté.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Valeur invalide pour {0}. La valeur doit être 'sha256', 'sha384' ou 'sha512'.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+        <target state="needs-review-translation">Valeur invalide pour {0}. La valeur doit être 'sha256', 'sha384' ou 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
-        <target state="translated">Valeur non valide pour {0}. La valeur doit être une valeur numérique supérieure ou égale à 1.</target>
-        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+        <target state="needs-review-translation">Valeur non valide pour {0}. La valeur doit être une valeur numérique supérieure ou égale à 1.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
-        <target state="translated">Valeur non valide pour {0}. La valeur doit être une URL HTTP ou HTTPS absolue.</target>
-        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+        <target state="needs-review-translation">Valeur non valide pour {0}. La valeur doit être une URL HTTP ou HTTPS absolue.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">
         <source>Maximum concurrency.</source>
@@ -79,8 +79,8 @@
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">Algorithme de hachage pour le serveur d’horodatage RFC 3161. Les valeurs autorisées sont sha256, sha384 et sha512.</target>
-        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+        <target state="needs-review-translation">Algorithme de hachage pour le serveur d’horodatage RFC 3161. Les valeurs autorisées sont sha256, sha384 et sha512.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161), and {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampUrlOptionDescription">
         <source>RFC 3161 timestamp server URL.</source>
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
         <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
-        <target state="translated">Définit le niveau de verbosité. Les valeurs autorisées sont 'none', 'critical', 'error', 'warning', 'information', 'debug', et 'trace'</target>
-        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
+        <target state="needs-review-translation">Définit le niveau de verbosité. Les valeurs autorisées sont 'none', 'critical', 'error', 'warning', 'information', 'debug', et 'trace'</target>
+        <note>{Locked="none", "critical", "error", "warning", "information", "debug", "trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -29,8 +29,8 @@
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
         <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Algoritmo di digest con cui eseguire l'hashing dei file. I valori consentiti sono 'sha256', 'sha384' e 'sha512'.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+        <target state="needs-review-translation">Algoritmo di digest con cui eseguire l'hashing dei file. I valori consentiti sono 'sha256', 'sha384' e 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign within an archive.</source>
@@ -39,23 +39,23 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valore non valido per {0}. Il valore deve essere un percorso di directory completo.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Valore non valido per {0}. Il valore deve essere un percorso di directory completo.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Valore non valido per {0}. Il valore deve essere 'sha256', 'sha384' o 'sha512'.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+        <target state="needs-review-translation">Valore non valido per {0}. Il valore deve essere 'sha256', 'sha384' o 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
-        <target state="translated">Valore non valido per {0}. Il valore deve essere un numero maggiore o uguale a 1.</target>
-        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+        <target state="needs-review-translation">Valore non valido per {0}. Il valore deve essere un numero maggiore o uguale a 1.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
-        <target state="translated">Valore non valido per {0}. Il valore deve essere un URL HTTP o HTTPS assoluto.</target>
-        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+        <target state="needs-review-translation">Valore non valido per {0}. Il valore deve essere un URL HTTP o HTTPS assoluto.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">
         <source>Maximum concurrency.</source>
@@ -79,8 +79,8 @@
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">Algoritmo di digest per il server di timestamp RFC 3161. I valori consentiti sono sha256, sha384 e sha512.</target>
-        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+        <target state="needs-review-translation">Algoritmo di digest per il server di timestamp RFC 3161. I valori consentiti sono sha256, sha384 e sha512.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161), and {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampUrlOptionDescription">
         <source>RFC 3161 timestamp server URL.</source>
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
         <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
-        <target state="translated">Imposta il livello di dettaglio. I valori consentiti sono 'none', 'critical', 'error', 'warning', 'information', 'debug' e 'trace'.</target>
-        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
+        <target state="needs-review-translation">Imposta il livello di dettaglio. I valori consentiti sono 'none', 'critical', 'error', 'warning', 'information', 'debug' e 'trace'.</target>
+        <note>{Locked="none", "critical", "error", "warning", "information", "debug", "trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -29,8 +29,8 @@
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
         <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">ファイルのハッシュに使用するダイジェスト アルゴリズム。使用できる値は、'sha256'、'sha384'、および 'sha512' です。</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+        <target state="needs-review-translation">ファイルのハッシュに使用するダイジェスト アルゴリズム。使用できる値は、'sha256'、'sha384'、および 'sha512' です。</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign within an archive.</source>
@@ -39,23 +39,23 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} の値が無効です。値は、完全にルート化されたディレクトリ パスである必要があります。</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">{0} の値が無効です。値は、完全にルート化されたディレクトリ パスである必要があります。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">{0} の値が無効です。値は 'sha256'、'sha384'、または 'sha512' である必要があります。</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+        <target state="needs-review-translation">{0} の値が無効です。値は 'sha256'、'sha384'、または 'sha512' である必要があります。</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
-        <target state="translated">{0} の値が無効です。値は、1 以上の数値である必要があります。</target>
-        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+        <target state="needs-review-translation">{0} の値が無効です。値は、1 以上の数値である必要があります。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
-        <target state="translated">{0}の値が無効です。値は HTTP または HTTPS の絶対 URL である必要があります。</target>
-        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+        <target state="needs-review-translation">{0}の値が無効です。値は HTTP または HTTPS の絶対 URL である必要があります。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">
         <source>Maximum concurrency.</source>
@@ -79,8 +79,8 @@
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">RFC 3161 タイムスタンプ サーバーのダイジェスト アルゴリズム。使用できる値は、sha256、sha384、および sha512 です。</target>
-        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+        <target state="needs-review-translation">RFC 3161 タイムスタンプ サーバーのダイジェスト アルゴリズム。使用できる値は、sha256、sha384、および sha512 です。</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161), and {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampUrlOptionDescription">
         <source>RFC 3161 timestamp server URL.</source>
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
         <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
-        <target state="translated">詳細レベルを設定します。指定できる値は、'none'、'critical'、'error'、'warning'、'information'、'debug'、'trace' です。</target>
-        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
+        <target state="needs-review-translation">詳細レベルを設定します。指定できる値は、'none'、'critical'、'error'、'warning'、'information'、'debug'、'trace' です。</target>
+        <note>{Locked="none", "critical", "error", "warning", "information", "debug", "trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -29,8 +29,8 @@
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
         <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">파일을 해시하는 다이제스트 알고리즘입니다. 허용되는 값은 'sha256', 'sha384' 및 'sha512'입니다.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+        <target state="needs-review-translation">파일을 해시하는 다이제스트 알고리즘입니다. 허용되는 값은 'sha256', 'sha384' 및 'sha512'입니다.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign within an archive.</source>
@@ -39,23 +39,23 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 완전한 루트 디렉터리 경로여야 합니다.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">{0}에 대한 값이 잘못되었습니다. 값은 완전한 루트 디렉터리 경로여야 합니다.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 'sha256', 'sha384' 또는 'sha512'.여야 합니다.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+        <target state="needs-review-translation">{0}에 대한 값이 잘못되었습니다. 값은 'sha256', 'sha384' 또는 'sha512'.여야 합니다.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
-        <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 1보다 크거나 같은 숫자 값이어야 합니다.</target>
-        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+        <target state="needs-review-translation">{0}에 대한 값이 잘못되었습니다. 값은 1보다 크거나 같은 숫자 값이어야 합니다.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
-        <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 절대 HTTP 또는 HTTPS URL이어야 합니다.</target>
-        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+        <target state="needs-review-translation">{0}에 대한 값이 잘못되었습니다. 값은 절대 HTTP 또는 HTTPS URL이어야 합니다.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">
         <source>Maximum concurrency.</source>
@@ -79,8 +79,8 @@
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">RFC 3161 타임스탬프 서버용 다이제스트 알고리즘입니다. 허용되는 값은 sha256, sha384 및 sha512입니다.</target>
-        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+        <target state="needs-review-translation">RFC 3161 타임스탬프 서버용 다이제스트 알고리즘입니다. 허용되는 값은 sha256, sha384 및 sha512입니다.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161), and {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampUrlOptionDescription">
         <source>RFC 3161 timestamp server URL.</source>
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
         <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
-        <target state="translated">세부 정보 표시 수준을 설정합니다. 허용되는 값은 'none', 'critical', 'error', 'warning', 'information', 'debug' 및 'trace'입니다.</target>
-        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
+        <target state="needs-review-translation">세부 정보 표시 수준을 설정합니다. 허용되는 값은 'none', 'critical', 'error', 'warning', 'information', 'debug' 및 'trace'입니다.</target>
+        <note>{Locked="none", "critical", "error", "warning", "information", "debug", "trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -29,8 +29,8 @@
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
         <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Algorytm skrótu, za pomocą którego jest tworzony skrót plików. Dozwolonymi wartościami są: „sha256”, „sha384”, lub „sha512”.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+        <target state="needs-review-translation">Algorytm skrótu, za pomocą którego jest tworzony skrót plików. Dozwolonymi wartościami są: „sha256”, „sha384”, lub „sha512”.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign within an archive.</source>
@@ -39,23 +39,23 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Nieprawidłowa wartość dla {0}. Wartość musi być w pełni główną ścieżką katalogu.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Nieprawidłowa wartość dla {0}. Wartość musi być w pełni główną ścieżką katalogu.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Nieprawidłowa wartość dla {0}. Wartością musi być „sha256”, „sha384”, lub „sha512”.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+        <target state="needs-review-translation">Nieprawidłowa wartość dla {0}. Wartością musi być „sha256”, „sha384”, lub „sha512”.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
-        <target state="translated">Nieprawidłowa wartość dla {0}. Wartość musi być większa lub równa 1.</target>
-        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+        <target state="needs-review-translation">Nieprawidłowa wartość dla {0}. Wartość musi być większa lub równa 1.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
-        <target state="translated">Nieprawidłowa wartość dla {0}. Wartość musi być bezwzględnym adresem URL protokołu HTTP lub HTTPS.</target>
-        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+        <target state="needs-review-translation">Nieprawidłowa wartość dla {0}. Wartość musi być bezwzględnym adresem URL protokołu HTTP lub HTTPS.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">
         <source>Maximum concurrency.</source>
@@ -79,8 +79,8 @@
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">Algorytm skrótu dla serwera znacznika czasu RFC 3161. Dozwolonymi wartościami są: sha256, sha384 i sha512.</target>
-        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+        <target state="needs-review-translation">Algorytm skrótu dla serwera znacznika czasu RFC 3161. Dozwolonymi wartościami są: sha256, sha384 i sha512.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161), and {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampUrlOptionDescription">
         <source>RFC 3161 timestamp server URL.</source>
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
         <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
-        <target state="translated">Ustawia poziom szczegółowości. Dozwolone wartości to „none”, „critical”, „error”, „warning”, „information”, „debug” i „trace”.</target>
-        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
+        <target state="needs-review-translation">Ustawia poziom szczegółowości. Dozwolone wartości to „none”, „critical”, „error”, „warning”, „information”, „debug” i „trace”.</target>
+        <note>{Locked="none", "critical", "error", "warning", "information", "debug", "trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -29,8 +29,8 @@
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
         <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Algoritmo de código hash para arquivos de hash. Os valores permitidos são 'sha256', 'sha384' e 'sha512'.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+        <target state="needs-review-translation">Algoritmo de código hash para arquivos de hash. Os valores permitidos são 'sha256', 'sha384' e 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign within an archive.</source>
@@ -39,23 +39,23 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valor inválido para {0}. O valor deve ser um caminho de diretório totalmente desbloqueado por rooting.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Valor inválido para {0}. O valor deve ser um caminho de diretório totalmente desbloqueado por rooting.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Valor inválido para {0}. O valor deve ser 'sha256', 'sha384' ou 'sha512'.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+        <target state="needs-review-translation">Valor inválido para {0}. O valor deve ser 'sha256', 'sha384' ou 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
-        <target state="translated">Valor inválido para {0}. O valor deve ser um valor numérico maior ou igual a 1.</target>
-        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+        <target state="needs-review-translation">Valor inválido para {0}. O valor deve ser um valor numérico maior ou igual a 1.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
-        <target state="translated">Valor inválido para {0}. O valor deve ser uma URL HTTP ou HTTPS absoluta.</target>
-        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+        <target state="needs-review-translation">Valor inválido para {0}. O valor deve ser uma URL HTTP ou HTTPS absoluta.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">
         <source>Maximum concurrency.</source>
@@ -79,8 +79,8 @@
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">Resumo do algoritmo para o servidor de carimbo de data/hora RFC 3161. Os valores permitidos são sha256, sha384 e sha512.</target>
-        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+        <target state="needs-review-translation">Resumo do algoritmo para o servidor de carimbo de data/hora RFC 3161. Os valores permitidos são sha256, sha384 e sha512.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161), and {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampUrlOptionDescription">
         <source>RFC 3161 timestamp server URL.</source>
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
         <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
-        <target state="translated">Define o nível de detalhamento. Os valores permitidos são 'none', 'critical', 'error', 'warning', 'information', 'debug' e 'trace'.</target>
-        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
+        <target state="needs-review-translation">Define o nível de detalhamento. Os valores permitidos são 'none', 'critical', 'error', 'warning', 'information', 'debug' e 'trace'.</target>
+        <note>{Locked="none", "critical", "error", "warning", "information", "debug", "trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -29,8 +29,8 @@
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
         <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Алгоритм дайджеста для хэширования файлов. Допустимые значения: "sha256", "sha384" и "sha512".</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+        <target state="needs-review-translation">Алгоритм дайджеста для хэширования файлов. Допустимые значения: "sha256", "sha384" и "sha512".</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign within an archive.</source>
@@ -39,23 +39,23 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Недопустимое значение для {0}. Значение должно быть полным корневым путем к каталогу.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">Недопустимое значение для {0}. Значение должно быть полным корневым путем к каталогу.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Недопустимое значение для {0}. Необходимо использовать "sha256", "sha384" или "sha512".</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+        <target state="needs-review-translation">Недопустимое значение для {0}. Необходимо использовать "sha256", "sha384" или "sha512".</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
-        <target state="translated">Недопустимое значение для "{0}". Значение должно быть числом, большим или равным 1.</target>
-        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+        <target state="needs-review-translation">Недопустимое значение для "{0}". Значение должно быть числом, большим или равным 1.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
-        <target state="translated">Недопустимое значение для {0}. Значение должно быть абсолютным URL-адресом HTTP или HTTPS.</target>
-        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+        <target state="needs-review-translation">Недопустимое значение для {0}. Значение должно быть абсолютным URL-адресом HTTP или HTTPS.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">
         <source>Maximum concurrency.</source>
@@ -79,8 +79,8 @@
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">Алгоритм дайджеста для сервера меток времени RFC 3161. Допустимые значения: sha256, sha384 и sha512.</target>
-        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+        <target state="needs-review-translation">Алгоритм дайджеста для сервера меток времени RFC 3161. Допустимые значения: sha256, sha384 и sha512.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161), and {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampUrlOptionDescription">
         <source>RFC 3161 timestamp server URL.</source>
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
         <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
-        <target state="translated">Задает уровень детализации. Допустимые значения: "none" (нет), "critical" (критическое), "error" (ошибки), "warning" (предупреждения), "information" (информация), "debug" (отладка) и "trace" (трассировка).</target>
-        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
+        <target state="needs-review-translation">Задает уровень детализации. Допустимые значения: "none" (нет), "critical" (критическое), "error" (ошибки), "warning" (предупреждения), "information" (информация), "debug" (отладка) и "trace" (трассировка).</target>
+        <note>{Locked="none", "critical", "error", "warning", "information", "debug", "trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -29,8 +29,8 @@
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
         <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Dosyaların karmasını oluşturmak için kullanılan karma algoritması. İzin verilen değerler şunlardır: 'sha256', 'sha384' ve 'sha512'.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+        <target state="needs-review-translation">Dosyaların karmasını oluşturmak için kullanılan karma algoritması. İzin verilen değerler şunlardır: 'sha256', 'sha384' ve 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign within an archive.</source>
@@ -39,23 +39,23 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} için geçersiz değer. Değer, tam olarak kök erişim izni verilmiş bir dizin yolu olmalıdır.</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">{0} için geçersiz değer. Değer, tam olarak kök erişim izni verilmiş bir dizin yolu olmalıdır.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">{0} için geçersiz değer. Değer 'sha256', 'sha384' veya 'sha512' olmalıdır.</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+        <target state="needs-review-translation">{0} için geçersiz değer. Değer 'sha256', 'sha384' veya 'sha512' olmalıdır.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
-        <target state="translated">{0} için geçersiz değer. Değer, 1’den büyük veya buna eşit bir sayı değeri olmalıdır.</target>
-        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+        <target state="needs-review-translation">{0} için geçersiz değer. Değer, 1’den büyük veya buna eşit bir sayı değeri olmalıdır.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
-        <target state="translated">{0} için geçersiz değer. Değer mutlak bir HTTP veya HTTPS URL’si olmalıdır.</target>
-        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+        <target state="needs-review-translation">{0} için geçersiz değer. Değer mutlak bir HTTP veya HTTPS URL’si olmalıdır.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">
         <source>Maximum concurrency.</source>
@@ -79,8 +79,8 @@
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">RFC 3161 zaman damgası sunucusu için karma algoritması. İzin verilen değerler şunlardır. sha256, sha384 ve sha512.</target>
-        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+        <target state="needs-review-translation">RFC 3161 zaman damgası sunucusu için karma algoritması. İzin verilen değerler şunlardır. sha256, sha384 ve sha512.</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161), and {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampUrlOptionDescription">
         <source>RFC 3161 timestamp server URL.</source>
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
         <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
-        <target state="translated">Ayrıntı düzeyini ayarlar. İzin verilen değerler: 'none', 'critical', 'error', 'warning', 'information', 'debug' ve 'trace'.</target>
-        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
+        <target state="needs-review-translation">Ayrıntı düzeyini ayarlar. İzin verilen değerler: 'none', 'critical', 'error', 'warning', 'information', 'debug' ve 'trace'.</target>
+        <note>{Locked="none", "critical", "error", "warning", "information", "debug", "trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -29,8 +29,8 @@
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
         <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">用于对文件进行哈希处理的摘要算法。允许的值为 "sha256"、"sha384" 和 "sha512"。</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+        <target state="needs-review-translation">用于对文件进行哈希处理的摘要算法。允许的值为 "sha256"、"sha384" 和 "sha512"。</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign within an archive.</source>
@@ -39,23 +39,23 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} 的值无效。该值必须是完整的根目录路径。</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">{0} 的值无效。该值必须是完整的根目录路径。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">{0} 的值无效。值必须为 "sha256"、"sha384" 或 "sha512"。</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+        <target state="needs-review-translation">{0} 的值无效。值必须为 "sha256"、"sha384" 或 "sha512"。</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
-        <target state="translated">{0} 的值无效。该值必须是大于或等于 1 的数值。</target>
-        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+        <target state="needs-review-translation">{0} 的值无效。该值必须是大于或等于 1 的数值。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
-        <target state="translated">{0} 的值无效。值必须是绝对 HTTP 或 HTTPS URL。</target>
-        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+        <target state="needs-review-translation">{0} 的值无效。值必须是绝对 HTTP 或 HTTPS URL。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">
         <source>Maximum concurrency.</source>
@@ -79,8 +79,8 @@
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">RFC 3161 时间戳服务器的摘要算法。允许的值为 sha256、sha384 和 sha512。</target>
-        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+        <target state="needs-review-translation">RFC 3161 时间戳服务器的摘要算法。允许的值为 sha256、sha384 和 sha512。</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161), and {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampUrlOptionDescription">
         <source>RFC 3161 timestamp server URL.</source>
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
         <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
-        <target state="translated">设置详细级别。允许的值为 "none"、"critical"、"error"、"warning"、"information"、"debug" 和 "trace"。</target>
-        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
+        <target state="needs-review-translation">设置详细级别。允许的值为 "none"、"critical"、"error"、"warning"、"information"、"debug" 和 "trace"。</target>
+        <note>{Locked="none", "critical", "error", "warning", "information", "debug", "trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -29,8 +29,8 @@
       </trans-unit>
       <trans-unit id="FileDigestOptionDescription">
         <source>Digest algorithm to hash files with. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">用於雜湊檔案的摘要演算法。允許的值為 'sha256'、'sha384' 和 'sha512'。</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.</note>
+        <target state="needs-review-translation">用於雜湊檔案的摘要演算法。允許的值為 'sha256'、'sha384' 和 'sha512'。</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign within an archive.</source>
@@ -39,23 +39,23 @@
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} 的值無效。值必須是完整的根目錄路徑。</target>
-        <note>{0} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+        <target state="needs-review-translation">{0} 的值無效。值必須是完整的根目錄路徑。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">{0} 的值無效。值必須是 'sha256'、'sha384' 或 'sha512'。</target>
-        <note>{Locked="sha256","sha384","sha512"} are cryptographic hash algorithm names and should not be localized.  {0} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+        <target state="needs-review-translation">{0} 的值無效。值必須是 'sha256'、'sha384' 或 'sha512'。</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
-        <target state="translated">{0} 的值無效。值必須是大或等於 1 的數值。</target>
-        <note>{0} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
+        <target state="needs-review-translation">{0} 的值無效。值必須是大或等於 1 的數值。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>
-        <target state="translated">{0} 的值無效。值必須是絕對 HTTP 或 HTTPS URL。</target>
-        <note>{0} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
+        <target state="needs-review-translation">{0} 的值無效。值必須是絕對 HTTP 或 HTTPS URL。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">
         <source>Maximum concurrency.</source>
@@ -79,8 +79,8 @@
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>
-        <target state="translated">RFC 3161 時間戳記伺服器的摘要演算法。允許的值為 sha256、sha384 和 sha512。</target>
-        <note>{Locked="RFC 3161","sha256","sha384","sha512"} RFC 3161 is an Internet standard (https://www.rfc-editor.org/info/rfc3161) and the others are cryptographic hash algorithm names should not be localized.</note>
+        <target state="needs-review-translation">RFC 3161 時間戳記伺服器的摘要演算法。允許的值為 sha256、sha384 和 sha512。</target>
+        <note>{Locked="RFC 3161"} is an Internet standard (https://www.rfc-editor.org/info/rfc3161), and {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampUrlOptionDescription">
         <source>RFC 3161 timestamp server URL.</source>
@@ -89,8 +89,8 @@
       </trans-unit>
       <trans-unit id="VerbosityOptionDescription">
         <source>Sets the verbosity level. Allowed values are 'none', 'critical', 'error', 'warning', 'information', 'debug', and 'trace'.</source>
-        <target state="translated">設定詳細資訊層級。允許的值為 'none'、'critical'、'error'、'warning'、'information'、'debug' 和 'trace'。</target>
-        <note>{Locked="none","critical","error","warning","information","debug","trace"} are option values and should not be localized.</note>
+        <target state="needs-review-translation">設定詳細資訊層級。允許的值為 'none'、'critical'、'error'、'warning'、'information'、'debug' 和 'trace'。</target>
+        <note>{Locked="none", "critical", "error", "warning", "information", "debug", "trace"} are option values and should not be localized.</note>
       </trans-unit>
       <trans-unit id="x86NotSupported">
         <source>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</source>

--- a/src/Sign.Core/Resources.Designer.cs
+++ b/src/Sign.Core/Resources.Designer.cs
@@ -97,7 +97,7 @@ namespace Sign.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {fileName} Err {error}.
+        ///   Looks up a localized string similar to {fileName} returned the error {error}.
         /// </summary>
         internal static string CliStandardError {
             get {
@@ -106,7 +106,7 @@ namespace Sign.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {fileName} Out {output}.
+        ///   Looks up a localized string similar to {fileName} returned the output {output}.
         /// </summary>
         internal static string CliStandardOutput {
             get {

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -119,7 +119,7 @@
   </resheader>
   <data name="AzureSignToolSignatureProviderSigning" xml:space="preserve">
     <value>Signing SignTool job with {count} files.</value>
-    <comment>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{count}"} is the number of files to be signed.</comment>
   </data>
   <data name="CertificateIsExpired" xml:space="preserve">
     <value>The certificate is expired.</value>
@@ -130,113 +130,113 @@
   </data>
   <data name="ClickOnceSignatureProviderSigning" xml:space="preserve">
     <value>Signing Mage job with {count} files.</value>
-    <comment>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</comment>
   </data>
   <data name="CliStandardError" xml:space="preserve">
-    <value>{fileName} Err {error}</value>
-    <comment>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</comment>
+    <value>{fileName} returned the error {error}</value>
+    <comment>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</comment>
   </data>
   <data name="CliStandardOutput" xml:space="preserve">
-    <value>{fileName} Out {output}</value>
-    <comment>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</comment>
+    <value>{fileName} returned the output {output}</value>
+    <comment>{Placeholder="{fileName}"} is a file name, and {Placeholder="{output}"} is verbose output from a tool.</comment>
   </data>
   <data name="CreatingDirectory" xml:space="preserve">
     <value>Creating directory {path}.</value>
-    <comment>{path} is a directory path.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{path}"} is a directory path.</comment>
   </data>
   <data name="DeletedDirectory" xml:space="preserve">
     <value>Directory {path} deleted.</value>
-    <comment>{path} is a directory path.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{path}"} is a directory path.</comment>
   </data>
   <data name="DeletingDirectory" xml:space="preserve">
     <value>Deleting directory {path}.</value>
-    <comment>{path} is a directory path.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{path}"} is a directory path.</comment>
   </data>
   <data name="DirectoryNotDeleted" xml:space="preserve">
     <value>Directory {path} still exists.</value>
-    <comment>{path} is a directory path.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{path}"} is a directory path.</comment>
   </data>
   <data name="EditingAppInstaller" xml:space="preserve">
     <value>Editing AppInstaller job with {count} files.</value>
-    <comment>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{count}"} is the number of files to be signed.</comment>
   </data>
   <data name="ErrorSigningVsix" xml:space="preserve">
     <value>An unspecified error occurred during VSIX signing.</value>
   </data>
   <data name="ExceptionWhileDeletingDirectory" xml:space="preserve">
     <value>An exception occurred while attempting to delete directory {path}.</value>
-    <comment>{path} is a directory path.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{path}"} is a directory path.</comment>
   </data>
   <data name="FetchedCertificate" xml:space="preserve">
     <value>Fetched certificate. [{milliseconds} ms]</value>
-    <comment>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</comment>
   </data>
   <data name="FetchingCertificate" xml:space="preserve">
     <value>Fetching certificate from Azure Key Vault.</value>
   </data>
   <data name="OpeningContainer" xml:space="preserve">
     <value>Extracting container {ContainerFilePath} to {DirectoryPath}.</value>
-    <comment>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</comment>
   </data>
   <data name="ProcessCouldNotBeKilled" xml:space="preserve">
     <value>{0} timed out and could not be killed.</value>
-    <comment>{0} is a file path.</comment>
+    <comment>{NumberedPlaceholder="{0}"} is a file path.</comment>
   </data>
   <data name="ProcessDidNotExitInTime" xml:space="preserve">
     <value>{fileName} took too long to respond. The process exit code is {exitCode}.</value>
-    <comment>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{fileName}"} is a file name, and {Placeholder="{exitCode}"} is a number representing the error code returned from a process.</comment>
   </data>
   <data name="ProcessDidNotExitInTimeWithArguments" xml:space="preserve">
     <value>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</value>
-    <comment>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</comment>
+    <comment>{NumberedPlaceholder="{0}"} is a file name.  {NumberedPlaceholder="{1}"} is a process exit code.  {NumberedPlaceholder="{2}"} is process arguments.</comment>
   </data>
   <data name="RunningCli" xml:space="preserve">
     <value>Running {fileName} with parameters: '{args}'.</value>
-    <comment>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{fileName}"} is a file name, and {Placeholder="{args}"} is process arguments.</comment>
   </data>
   <data name="SavingContainer" xml:space="preserve">
     <value>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</value>
-    <comment>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</comment>
   </data>
   <data name="SignAsyncCalled" xml:space="preserve">
     <value>SignAsync called for {filePath}. Using {localFilePath} locally.</value>
-    <comment>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{filePath}", "{localFilePath}"} are both file paths.</comment>
   </data>
   <data name="SigningAttempt" xml:space="preserve">
     <value>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</value>
-    <comment>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{attempt}", "{maxAttempts}"} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  {Placeholder="{seconds}"} is a decimal number representing the number of seconds elapsed, and "s" is the unit abbreviation for seconds.</comment>
   </data>
   <data name="SigningFailed" xml:space="preserve">
     <value>Could not sign {0}.</value>
-    <comment>{0} is a file path.</comment>
+    <comment>{NumberedPlaceholder="{0}"} is a file path.</comment>
   </data>
   <data name="SigningFailedAfterAllAttempts" xml:space="preserve">
     <value>Failed to sign. Attempts exceeded.</value>
   </data>
   <data name="SigningFailedWithError" xml:space="preserve">
     <value>Signing failed with error {errorCode}.</value>
-    <comment>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{errorCode}"} is an error code.</comment>
   </data>
   <data name="SigningFile" xml:space="preserve">
     <value>Signing {filePath}.</value>
-    <comment>{filePath} is a file path.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{filePath}"} is a file path.</comment>
   </data>
   <data name="SigningSucceeded" xml:space="preserve">
     <value>Signing succeeded.</value>
   </data>
   <data name="SigningSucceededWithTimeElapsed" xml:space="preserve">
     <value>Successfully signed {filePath} in {millseconds} ms</value>
-    <comment>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</comment>
   </data>
   <data name="SubmittingFileForSigning" xml:space="preserve">
     <value>Submitting {filePath} for signing.</value>
-    <comment>{filePath} is a file path.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{filePath}"} is a file path.</comment>
   </data>
   <data name="ValueCannotBeEmptyString" xml:space="preserve">
     <value>The value cannot be an empty string.</value>
   </data>
   <data name="VsixSignatureProviderSigning" xml:space="preserve">
     <value>Signing OpenVsixSignTool job with {count} files.</value>
-    <comment>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</comment>
+    <comment>{Placeholder="{count}"} is the number of files to be signed.</comment>
   </data>
 </root>

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -4,8 +4,8 @@
     <body>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
-        <target state="translated">Podepisování úlohy SignTool s tímto počtem souborů: {count}.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Podepisování úlohy SignTool s tímto počtem souborů: {count}.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CertificateIsExpired">
         <source>The certificate is expired.</source>
@@ -18,44 +18,44 @@
         <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
       </trans-unit>
       <trans-unit id="CliStandardError">
-        <source>{fileName} Err {error}</source>
-        <target state="translated">{fileName} Err {error}</target>
-        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the error {error}</source>
+        <target state="needs-review-translation">{fileName} Err {error}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="CliStandardOutput">
-        <source>{fileName} Out {output}</source>
-        <target state="new">{fileName} Out {output}</target>
-        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the output {output}</source>
+        <target state="new">{fileName} returned the output {output}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{output}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="ClickOnceSignatureProviderSigning">
         <source>Signing Mage job with {count} files.</source>
-        <target state="translated">Podepisování úlohy Mage pomocí {count} souborů.</target>
-        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Podepisování úlohy Mage pomocí {count} souborů.</target>
+        <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
-        <target state="translated">Vytváří se adresář {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Vytváří se adresář {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletedDirectory">
         <source>Directory {path} deleted.</source>
-        <target state="translated">Adresář {path} se odstranil.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Adresář {path} se odstranil.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletingDirectory">
         <source>Deleting directory {path}.</source>
-        <target state="translated">Odstraňuje se adresář {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Odstraňuje se adresář {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DirectoryNotDeleted">
         <source>Directory {path} still exists.</source>
-        <target state="translated">Adresář {path} stále existuje.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Adresář {path} stále existuje.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="EditingAppInstaller">
         <source>Editing AppInstaller job with {count} files.</source>
-        <target state="translated">Upravuje se úloha AppInstaller s tímto počtem souborů: {count}.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Upravuje se úloha AppInstaller s tímto počtem souborů: {count}.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="ErrorSigningVsix">
         <source>An unspecified error occurred during VSIX signing.</source>
@@ -64,13 +64,13 @@
       </trans-unit>
       <trans-unit id="ExceptionWhileDeletingDirectory">
         <source>An exception occurred while attempting to delete directory {path}.</source>
-        <target state="translated">Při pokusu o odstranění adresáře {path} došlo k výjimce.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Při pokusu o odstranění adresáře {path} došlo k výjimce.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="FetchedCertificate">
         <source>Fetched certificate. [{milliseconds} ms]</source>
-        <target state="translated">Načetl se certifikát. [{milisekund} ms]</target>
-        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Načetl se certifikát. [{milisekund} ms]</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="FetchingCertificate">
         <source>Fetching certificate from Azure Key Vault.</source>
@@ -79,48 +79,48 @@
       </trans-unit>
       <trans-unit id="OpeningContainer">
         <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
-        <target state="translated">Extrahuje se kontejner {ContainerFilePath} do adresáře {DirectoryPath}.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Extrahuje se kontejner {ContainerFilePath} do adresáře {DirectoryPath}.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="ProcessCouldNotBeKilled">
         <source>{0} timed out and could not be killed.</source>
-        <target state="translated">Vypršel časový limit cesty k {0} a nelze ji ukončit.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">Vypršel časový limit cesty k {0} a nelze ji ukončit.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTime">
         <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
         <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
-        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{exitCode}"} is a number representing the error code returned from a process.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTimeWithArguments">
         <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
-        <target state="translated">Odpověď souboru {0} trvala příliš dlouho,. Ukončovací kód procesu je {1}. Argumenty: {2}</target>
-        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+        <target state="needs-review-translation">Odpověď souboru {0} trvala příliš dlouho,. Ukončovací kód procesu je {1}. Argumenty: {2}</target>
+        <note>{NumberedPlaceholder="{0}"} is a file name.  {NumberedPlaceholder="{1}"} is a process exit code.  {NumberedPlaceholder="{2}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="RunningCli">
         <source>Running {fileName} with parameters: '{args}'.</source>
         <target state="new">Running {fileName} with parameters: '{args}'.</target>
-        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{args}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="SavingContainer">
         <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
-        <target state="translated">Kontejner {ContainerFilePath} se znovu sestavuje z adresáře {DirectoryPath}.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Kontejner {ContainerFilePath} se znovu sestavuje z adresáře {DirectoryPath}.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="SignAsyncCalled">
         <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
-        <target state="translated">Byla volána metoda SignAsync pro soubor {filePath}. Používá se {localFilePath} místně.</target>
-        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Byla volána metoda SignAsync pro soubor {filePath}. Používá se {localFilePath} místně.</target>
+        <note>{Placeholder="{filePath}", "{localFilePath}"} are both file paths.</note>
       </trans-unit>
       <trans-unit id="SigningAttempt">
         <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
-        <target state="translated">Probíhá pokus #{attempt} z {maxAttempts} pokusů po {seconds} s.</target>
-        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Probíhá pokus #{attempt} z {maxAttempts} pokusů po {seconds} s.</target>
+        <note>{Placeholder="{attempt}", "{maxAttempts}"} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  {Placeholder="{seconds}"} is a decimal number representing the number of seconds elapsed, and "s" is the unit abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="SigningFailed">
         <source>Could not sign {0}.</source>
-        <target state="translated">Nelze podepsat {0}{0}.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">Nelze podepsat {0}{0}.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningFailedAfterAllAttempts">
         <source>Failed to sign. Attempts exceeded.</source>
@@ -129,13 +129,13 @@
       </trans-unit>
       <trans-unit id="SigningFailedWithError">
         <source>Signing failed with error {errorCode}.</source>
-        <target state="translated">Podepisování selhalo s chybou {errorCode}.</target>
-        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Podepisování selhalo s chybou {errorCode}.</target>
+        <note>{Placeholder="{errorCode}"} is an error code.</note>
       </trans-unit>
       <trans-unit id="SigningFile">
         <source>Signing {filePath}.</source>
-        <target state="translated">Podepisování souboru {filePath}</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Podepisování souboru {filePath}</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing succeeded.</source>
@@ -144,13 +144,13 @@
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
         <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">Soubor {filePath} se úspěšně podepsal za {millseconds} ms.</target>
-        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Soubor {filePath} se úspěšně podepsal za {millseconds} ms.</target>
+        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
-        <target state="translated">Odesílá se soubor {filePath} pro podepisování.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Odesílá se soubor {filePath} pro podepisování.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
         <source>The value cannot be an empty string.</source>
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing OpenVsixSignTool job with {count} files.</source>
-        <target state="translated">Podepisování úlohy OpenVsixSignTool pomocí tohoto počtu souborů: {count}.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Podepisování úlohy OpenVsixSignTool pomocí tohoto počtu souborů: {count}.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -4,8 +4,8 @@
     <body>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
-        <target state="translated">Der SignTool-Auftrag wird mit {count} Dateien signiert.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Der SignTool-Auftrag wird mit {count} Dateien signiert.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CertificateIsExpired">
         <source>The certificate is expired.</source>
@@ -18,44 +18,44 @@
         <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
       </trans-unit>
       <trans-unit id="CliStandardError">
-        <source>{fileName} Err {error}</source>
-        <target state="new">{fileName} Err {error}</target>
-        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the error {error}</source>
+        <target state="new">{fileName} returned the error {error}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="CliStandardOutput">
-        <source>{fileName} Out {output}</source>
-        <target state="new">{fileName} Out {output}</target>
-        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the output {output}</source>
+        <target state="new">{fileName} returned the output {output}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{output}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="ClickOnceSignatureProviderSigning">
         <source>Signing Mage job with {count} files.</source>
-        <target state="translated">Der Mage-Auftrag wird mit {count} Dateien signiert.</target>
-        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Der Mage-Auftrag wird mit {count} Dateien signiert.</target>
+        <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
-        <target state="translated">Das Verzeichnis {path} wird erstellt.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Das Verzeichnis {path} wird erstellt.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletedDirectory">
         <source>Directory {path} deleted.</source>
-        <target state="translated">Das Verzeichnis {path} wurde gelöscht.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Das Verzeichnis {path} wurde gelöscht.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletingDirectory">
         <source>Deleting directory {path}.</source>
-        <target state="translated">Das Verzeichnis {path} wird gelöscht.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Das Verzeichnis {path} wird gelöscht.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DirectoryNotDeleted">
         <source>Directory {path} still exists.</source>
-        <target state="translated">Das Verzeichnis {path} ist noch vorhanden.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Das Verzeichnis {path} ist noch vorhanden.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="EditingAppInstaller">
         <source>Editing AppInstaller job with {count} files.</source>
-        <target state="translated">AppInstaller-Auftrag wird mit {count} Dateien bearbeitet.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">AppInstaller-Auftrag wird mit {count} Dateien bearbeitet.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="ErrorSigningVsix">
         <source>An unspecified error occurred during VSIX signing.</source>
@@ -64,13 +64,13 @@
       </trans-unit>
       <trans-unit id="ExceptionWhileDeletingDirectory">
         <source>An exception occurred while attempting to delete directory {path}.</source>
-        <target state="translated">Beim Versuch, das Verzeichnis {path} zu löschen, ist eine Ausnahme aufgetreten.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Beim Versuch, das Verzeichnis {path} zu löschen, ist eine Ausnahme aufgetreten.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="FetchedCertificate">
         <source>Fetched certificate. [{milliseconds} ms]</source>
-        <target state="translated">Zertifikat abgerufen. [{milliseconds} ms]</target>
-        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Zertifikat abgerufen. [{milliseconds} ms]</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="FetchingCertificate">
         <source>Fetching certificate from Azure Key Vault.</source>
@@ -79,48 +79,48 @@
       </trans-unit>
       <trans-unit id="OpeningContainer">
         <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
-        <target state="translated">Der Container {ContainerFilePath} wird in {DirectoryPath} extrahiert.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Der Container {ContainerFilePath} wird in {DirectoryPath} extrahiert.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="ProcessCouldNotBeKilled">
         <source>{0} timed out and could not be killed.</source>
-        <target state="translated">{0} hat ein Timeout und konnte nicht abgebrochen werden.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">{0} hat ein Timeout und konnte nicht abgebrochen werden.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTime">
         <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
         <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
-        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{exitCode}"} is a number representing the error code returned from a process.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTimeWithArguments">
         <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
-        <target state="translated">{0} hat zu lange gebraucht, um zu antworten. Der Prozessexitcode ist {1}. Argumente: {2}</target>
-        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+        <target state="needs-review-translation">{0} hat zu lange gebraucht, um zu antworten. Der Prozessexitcode ist {1}. Argumente: {2}</target>
+        <note>{NumberedPlaceholder="{0}"} is a file name.  {NumberedPlaceholder="{1}"} is a process exit code.  {NumberedPlaceholder="{2}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="RunningCli">
         <source>Running {fileName} with parameters: '{args}'.</source>
         <target state="new">Running {fileName} with parameters: '{args}'.</target>
-        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{args}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="SavingContainer">
         <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
-        <target state="translated">Der Container {ContainerFilePath} wird aus {DirectoryPath} neu erstellt.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Der Container {ContainerFilePath} wird aus {DirectoryPath} neu erstellt.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="SignAsyncCalled">
         <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
-        <target state="translated">SignAsync wurde für {filePath} aufgerufen. {localFilePath} wird lokal verwendet.</target>
-        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">SignAsync wurde für {filePath} aufgerufen. {localFilePath} wird lokal verwendet.</target>
+        <note>{Placeholder="{filePath}", "{localFilePath}"} are both file paths.</note>
       </trans-unit>
       <trans-unit id="SigningAttempt">
         <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
-        <target state="translated">Der Versuch #{attempt} von {maxAttempts} Versuchen wird nach {seconds} Sek. ausgeführt.</target>
-        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Der Versuch #{attempt} von {maxAttempts} Versuchen wird nach {seconds} Sek. ausgeführt.</target>
+        <note>{Placeholder="{attempt}", "{maxAttempts}"} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  {Placeholder="{seconds}"} is a decimal number representing the number of seconds elapsed, and "s" is the unit abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="SigningFailed">
         <source>Could not sign {0}.</source>
-        <target state="translated">{0} konnte nicht signiert werden.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">{0} konnte nicht signiert werden.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningFailedAfterAllAttempts">
         <source>Failed to sign. Attempts exceeded.</source>
@@ -129,13 +129,13 @@
       </trans-unit>
       <trans-unit id="SigningFailedWithError">
         <source>Signing failed with error {errorCode}.</source>
-        <target state="translated">Das Signieren ist mit Fehler {errorCode} fehlgeschlagen.</target>
-        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Das Signieren ist mit Fehler {errorCode} fehlgeschlagen.</target>
+        <note>{Placeholder="{errorCode}"} is an error code.</note>
       </trans-unit>
       <trans-unit id="SigningFile">
         <source>Signing {filePath}.</source>
-        <target state="translated">{filePath} wird signiert.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath} wird signiert.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing succeeded.</source>
@@ -144,13 +144,13 @@
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
         <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{filePath} wurde in {millseconds} ms erfolgreich signiert.</target>
-        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath} wurde in {millseconds} ms erfolgreich signiert.</target>
+        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
-        <target state="translated">{filePath} wird zum Signieren übermittelt.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath} wird zum Signieren übermittelt.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
         <source>The value cannot be an empty string.</source>
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing OpenVsixSignTool job with {count} files.</source>
-        <target state="translated">OpenVsixSignTool-Auftrag wird mit {count} Dateien signiert.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">OpenVsixSignTool-Auftrag wird mit {count} Dateien signiert.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -4,8 +4,8 @@
     <body>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
-        <target state="translated">Firmando el trabajo de SignTool con {count} archivos.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Firmando el trabajo de SignTool con {count} archivos.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CertificateIsExpired">
         <source>The certificate is expired.</source>
@@ -18,44 +18,44 @@
         <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
       </trans-unit>
       <trans-unit id="CliStandardError">
-        <source>{fileName} Err {error}</source>
-        <target state="translated">{fileName} Err {error}</target>
-        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the error {error}</source>
+        <target state="needs-review-translation">{fileName} Err {error}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="CliStandardOutput">
-        <source>{fileName} Out {output}</source>
-        <target state="translated">{fileName} Out {output}</target>
-        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the output {output}</source>
+        <target state="needs-review-translation">{fileName} Out {output}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{output}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="ClickOnceSignatureProviderSigning">
         <source>Signing Mage job with {count} files.</source>
-        <target state="translated">Firmando el trabajo de Mage con {count} archivos.</target>
-        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Firmando el trabajo de Mage con {count} archivos.</target>
+        <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
-        <target state="translated">Creando directorio {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Creando directorio {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletedDirectory">
         <source>Directory {path} deleted.</source>
-        <target state="translated">Directorio {path} eliminado.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Directorio {path} eliminado.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletingDirectory">
         <source>Deleting directory {path}.</source>
-        <target state="translated">Eliminando el directorio {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Eliminando el directorio {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DirectoryNotDeleted">
         <source>Directory {path} still exists.</source>
-        <target state="translated">El directorio {path} todavía existe.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">El directorio {path} todavía existe.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="EditingAppInstaller">
         <source>Editing AppInstaller job with {count} files.</source>
-        <target state="translated">Editando el trabajo AppInstaller con {count} archivos.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Editando el trabajo AppInstaller con {count} archivos.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="ErrorSigningVsix">
         <source>An unspecified error occurred during VSIX signing.</source>
@@ -64,13 +64,13 @@
       </trans-unit>
       <trans-unit id="ExceptionWhileDeletingDirectory">
         <source>An exception occurred while attempting to delete directory {path}.</source>
-        <target state="translated">Se produjo una excepción al intentar eliminar el directorio {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Se produjo una excepción al intentar eliminar el directorio {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="FetchedCertificate">
         <source>Fetched certificate. [{milliseconds} ms]</source>
-        <target state="translated">Certificado capturado. [{milliseconds} ms]</target>
-        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Certificado capturado. [{milliseconds} ms]</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="FetchingCertificate">
         <source>Fetching certificate from Azure Key Vault.</source>
@@ -79,48 +79,48 @@
       </trans-unit>
       <trans-unit id="OpeningContainer">
         <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
-        <target state="translated">Extrayendo el contenedor {ContainerFilePath} en {DirectoryPath}.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Extrayendo el contenedor {ContainerFilePath} en {DirectoryPath}.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="ProcessCouldNotBeKilled">
         <source>{0} timed out and could not be killed.</source>
-        <target state="translated">{0} agotó el tiempo de espera y no se pudo terminar.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">{0} agotó el tiempo de espera y no se pudo terminar.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTime">
         <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
         <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
-        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{exitCode}"} is a number representing the error code returned from a process.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTimeWithArguments">
         <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
-        <target state="translated">{0} tardó demasiado en responder. El código de salida del proceso es {1}. Argumentos: {2}</target>
-        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+        <target state="needs-review-translation">{0} tardó demasiado en responder. El código de salida del proceso es {1}. Argumentos: {2}</target>
+        <note>{NumberedPlaceholder="{0}"} is a file name.  {NumberedPlaceholder="{1}"} is a process exit code.  {NumberedPlaceholder="{2}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="RunningCli">
         <source>Running {fileName} with parameters: '{args}'.</source>
         <target state="new">Running {fileName} with parameters: '{args}'.</target>
-        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{args}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="SavingContainer">
         <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
-        <target state="translated">Recompilando el contenedor {ContainerFilePath} desde {DirectoryPath}.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Recompilando el contenedor {ContainerFilePath} desde {DirectoryPath}.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="SignAsyncCalled">
         <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
-        <target state="translated">Se llamó a SignAsync para {filePath}. Usando {localFilePath} localmente.</target>
-        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Se llamó a SignAsync para {filePath}. Usando {localFilePath} localmente.</target>
+        <note>{Placeholder="{filePath}", "{localFilePath}"} are both file paths.</note>
       </trans-unit>
       <trans-unit id="SigningAttempt">
         <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
-        <target state="translated">Realizando el intento #{attempt} de {maxAttempts} intentos después de {seconds} s.</target>
-        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Realizando el intento #{attempt} de {maxAttempts} intentos después de {seconds} s.</target>
+        <note>{Placeholder="{attempt}", "{maxAttempts}"} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  {Placeholder="{seconds}"} is a decimal number representing the number of seconds elapsed, and "s" is the unit abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="SigningFailed">
         <source>Could not sign {0}.</source>
-        <target state="translated">No se pudo firmar {0}.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">No se pudo firmar {0}.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningFailedAfterAllAttempts">
         <source>Failed to sign. Attempts exceeded.</source>
@@ -129,13 +129,13 @@
       </trans-unit>
       <trans-unit id="SigningFailedWithError">
         <source>Signing failed with error {errorCode}.</source>
-        <target state="translated">Error al firmar: {errorCode}.</target>
-        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Error al firmar: {errorCode}.</target>
+        <note>{Placeholder="{errorCode}"} is an error code.</note>
       </trans-unit>
       <trans-unit id="SigningFile">
         <source>Signing {filePath}.</source>
-        <target state="translated">Firmando {filePath}.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Firmando {filePath}.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing succeeded.</source>
@@ -144,13 +144,13 @@
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
         <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{filePath} se firmó correctamente en {millseconds} ms</target>
-        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath} se firmó correctamente en {millseconds} ms</target>
+        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
-        <target state="translated">Enviando {filePath} para la firma.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Enviando {filePath} para la firma.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
         <source>The value cannot be an empty string.</source>
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing OpenVsixSignTool job with {count} files.</source>
-        <target state="translated">Firmando trabajo de OpenVsixSignTool con {count} archivos.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Firmando trabajo de OpenVsixSignTool con {count} archivos.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -4,8 +4,8 @@
     <body>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
-        <target state="translated">Signature du travail SignTool avec {count} fichiers.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Signature du travail SignTool avec {count} fichiers.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CertificateIsExpired">
         <source>The certificate is expired.</source>
@@ -18,44 +18,44 @@
         <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
       </trans-unit>
       <trans-unit id="CliStandardError">
-        <source>{fileName} Err {error}</source>
-        <target state="translated">{fileName} Err {error}</target>
-        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the error {error}</source>
+        <target state="needs-review-translation">{fileName} Err {error}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="CliStandardOutput">
-        <source>{fileName} Out {output}</source>
-        <target state="new">{fileName} Out {output}</target>
-        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the output {output}</source>
+        <target state="new">{fileName} returned the output {output}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{output}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="ClickOnceSignatureProviderSigning">
         <source>Signing Mage job with {count} files.</source>
-        <target state="translated">Signature du travail Mage avec {count} fichiers.</target>
-        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Signature du travail Mage avec {count} fichiers.</target>
+        <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
-        <target state="translated">Création du répertoire {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Création du répertoire {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletedDirectory">
         <source>Directory {path} deleted.</source>
-        <target state="translated">Répertoire {path} supprimé.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Répertoire {path} supprimé.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletingDirectory">
         <source>Deleting directory {path}.</source>
-        <target state="translated">Suppression du répertoire {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Suppression du répertoire {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DirectoryNotDeleted">
         <source>Directory {path} still exists.</source>
-        <target state="translated">Le répertoire {path} existe toujours.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Le répertoire {path} existe toujours.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="EditingAppInstaller">
         <source>Editing AppInstaller job with {count} files.</source>
-        <target state="translated">Modification du travail AppInstaller avec {count} fichiers.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Modification du travail AppInstaller avec {count} fichiers.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="ErrorSigningVsix">
         <source>An unspecified error occurred during VSIX signing.</source>
@@ -64,13 +64,13 @@
       </trans-unit>
       <trans-unit id="ExceptionWhileDeletingDirectory">
         <source>An exception occurred while attempting to delete directory {path}.</source>
-        <target state="translated">Une exception s’est produite lors de la tentative de suppression du répertoire {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Une exception s’est produite lors de la tentative de suppression du répertoire {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="FetchedCertificate">
         <source>Fetched certificate. [{milliseconds} ms]</source>
-        <target state="translated">Certificat récupéré. [{milliseconds} ms]</target>
-        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Certificat récupéré. [{milliseconds} ms]</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="FetchingCertificate">
         <source>Fetching certificate from Azure Key Vault.</source>
@@ -79,48 +79,48 @@
       </trans-unit>
       <trans-unit id="OpeningContainer">
         <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
-        <target state="translated">Extraction du conteneur {ContainerFilePath} vers {DirectoryPath}.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Extraction du conteneur {ContainerFilePath} vers {DirectoryPath}.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="ProcessCouldNotBeKilled">
         <source>{0} timed out and could not be killed.</source>
-        <target state="translated">{0} a expiré et n’a pas pu être arrêté.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">{0} a expiré et n’a pas pu être arrêté.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTime">
         <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
         <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
-        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{exitCode}"} is a number representing the error code returned from a process.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTimeWithArguments">
         <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
-        <target state="translated">{0} a mis trop de temps à répondre. Le code de sortie du processus est {1}. Arguments : {2}</target>
-        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+        <target state="needs-review-translation">{0} a mis trop de temps à répondre. Le code de sortie du processus est {1}. Arguments : {2}</target>
+        <note>{NumberedPlaceholder="{0}"} is a file name.  {NumberedPlaceholder="{1}"} is a process exit code.  {NumberedPlaceholder="{2}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="RunningCli">
         <source>Running {fileName} with parameters: '{args}'.</source>
         <target state="new">Running {fileName} with parameters: '{args}'.</target>
-        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{args}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="SavingContainer">
         <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
-        <target state="translated">Reconstruction du conteneur {ContainerFilePath} à partir de {DirectoryPath}.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Reconstruction du conteneur {ContainerFilePath} à partir de {DirectoryPath}.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="SignAsyncCalled">
         <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
-        <target state="translated">SignAsync appelé pour {filePath}. Utilisation locale de {localFilePath}.</target>
-        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">SignAsync appelé pour {filePath}. Utilisation locale de {localFilePath}.</target>
+        <note>{Placeholder="{filePath}", "{localFilePath}"} are both file paths.</note>
       </trans-unit>
       <trans-unit id="SigningAttempt">
         <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
-        <target state="translated">Exécution de la tentative n° {attempt} sur {maxAttempts} après {seconds} s.</target>
-        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Exécution de la tentative n° {attempt} sur {maxAttempts} après {seconds} s.</target>
+        <note>{Placeholder="{attempt}", "{maxAttempts}"} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  {Placeholder="{seconds}"} is a decimal number representing the number of seconds elapsed, and "s" is the unit abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="SigningFailed">
         <source>Could not sign {0}.</source>
-        <target state="translated">Impossible de signer {0}.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">Impossible de signer {0}.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningFailedAfterAllAttempts">
         <source>Failed to sign. Attempts exceeded.</source>
@@ -129,13 +129,13 @@
       </trans-unit>
       <trans-unit id="SigningFailedWithError">
         <source>Signing failed with error {errorCode}.</source>
-        <target state="translated">Échec de la signature avec l’erreur {errorCode}.</target>
-        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Échec de la signature avec l’erreur {errorCode}.</target>
+        <note>{Placeholder="{errorCode}"} is an error code.</note>
       </trans-unit>
       <trans-unit id="SigningFile">
         <source>Signing {filePath}.</source>
-        <target state="translated">Signature de {filePath}.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Signature de {filePath}.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing succeeded.</source>
@@ -144,13 +144,13 @@
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
         <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{filePath} signé en {millseconds} ms</target>
-        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath} signé en {millseconds} ms</target>
+        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
-        <target state="translated">Envoi de {filePath} pour signature.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Envoi de {filePath} pour signature.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
         <source>The value cannot be an empty string.</source>
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing OpenVsixSignTool job with {count} files.</source>
-        <target state="translated">Signature du travail OpenVsixSignTool avec {count} fichiers.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Signature du travail OpenVsixSignTool avec {count} fichiers.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -4,8 +4,8 @@
     <body>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
-        <target state="translated">Firma del processo SignTool con {count} file.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Firma del processo SignTool con {count} file.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CertificateIsExpired">
         <source>The certificate is expired.</source>
@@ -18,44 +18,44 @@
         <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
       </trans-unit>
       <trans-unit id="CliStandardError">
-        <source>{fileName} Err {error}</source>
-        <target state="new">{fileName} Err {error}</target>
-        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the error {error}</source>
+        <target state="new">{fileName} returned the error {error}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="CliStandardOutput">
-        <source>{fileName} Out {output}</source>
-        <target state="new">{fileName} Out {output}</target>
-        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the output {output}</source>
+        <target state="new">{fileName} returned the output {output}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{output}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="ClickOnceSignatureProviderSigning">
         <source>Signing Mage job with {count} files.</source>
-        <target state="translated">Firma del processo Mage con {count} file.</target>
-        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Firma del processo Mage con {count} file.</target>
+        <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
-        <target state="translated">Creazione della directory {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Creazione della directory {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletedDirectory">
         <source>Directory {path} deleted.</source>
-        <target state="translated">{path} directory eliminato.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{path} directory eliminato.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletingDirectory">
         <source>Deleting directory {path}.</source>
-        <target state="translated">Eliminazione della directory {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Eliminazione della directory {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DirectoryNotDeleted">
         <source>Directory {path} still exists.</source>
-        <target state="translated">{path} della directory esiste ancora.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{path} della directory esiste ancora.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="EditingAppInstaller">
         <source>Editing AppInstaller job with {count} files.</source>
-        <target state="translated">Modifica del processo AppInstaller con {count} file.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Modifica del processo AppInstaller con {count} file.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="ErrorSigningVsix">
         <source>An unspecified error occurred during VSIX signing.</source>
@@ -64,13 +64,13 @@
       </trans-unit>
       <trans-unit id="ExceptionWhileDeletingDirectory">
         <source>An exception occurred while attempting to delete directory {path}.</source>
-        <target state="translated">Si è verificata un'eccezione durante il tentativo di eliminare la directory {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Si è verificata un'eccezione durante il tentativo di eliminare la directory {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="FetchedCertificate">
         <source>Fetched certificate. [{milliseconds} ms]</source>
-        <target state="translated">Il certificato è stato recuperato. [{milliseconds} ms]</target>
-        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Il certificato è stato recuperato. [{milliseconds} ms]</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="FetchingCertificate">
         <source>Fetching certificate from Azure Key Vault.</source>
@@ -79,48 +79,48 @@
       </trans-unit>
       <trans-unit id="OpeningContainer">
         <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
-        <target state="translated">Estrazione del contenitore {ContainerFilePath} in {DirectoryPath}.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Estrazione del contenitore {ContainerFilePath} in {DirectoryPath}.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="ProcessCouldNotBeKilled">
         <source>{0} timed out and could not be killed.</source>
-        <target state="translated">Si è verificato il timeout di {0} e non è stato possibile terminarlo.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">Si è verificato il timeout di {0} e non è stato possibile terminarlo.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTime">
         <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
         <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
-        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{exitCode}"} is a number representing the error code returned from a process.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTimeWithArguments">
         <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
-        <target state="translated">{0} ha impiegato troppo tempo per rispondere. Codice di uscita del processo {1}. Argomenti: {2}</target>
-        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+        <target state="needs-review-translation">{0} ha impiegato troppo tempo per rispondere. Codice di uscita del processo {1}. Argomenti: {2}</target>
+        <note>{NumberedPlaceholder="{0}"} is a file name.  {NumberedPlaceholder="{1}"} is a process exit code.  {NumberedPlaceholder="{2}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="RunningCli">
         <source>Running {fileName} with parameters: '{args}'.</source>
         <target state="new">Running {fileName} with parameters: '{args}'.</target>
-        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{args}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="SavingContainer">
         <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
-        <target state="translated">Ricompilazione del contenitore {ContainerFilePath} da {DirectoryPath}.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Ricompilazione del contenitore {ContainerFilePath} da {DirectoryPath}.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="SignAsyncCalled">
         <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
-        <target state="translated">SignAsync chiamato per {filePath}. Utilizzo di {localFilePath} in locale.</target>
-        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">SignAsync chiamato per {filePath}. Utilizzo di {localFilePath} in locale.</target>
+        <note>{Placeholder="{filePath}", "{localFilePath}"} are both file paths.</note>
       </trans-unit>
       <trans-unit id="SigningAttempt">
         <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
-        <target state="translated">Esecuzione del tentativo #{attempt} di {maxAttempts} tentativi dopo {seconds} s.</target>
-        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Esecuzione del tentativo #{attempt} di {maxAttempts} tentativi dopo {seconds} s.</target>
+        <note>{Placeholder="{attempt}", "{maxAttempts}"} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  {Placeholder="{seconds}"} is a decimal number representing the number of seconds elapsed, and "s" is the unit abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="SigningFailed">
         <source>Could not sign {0}.</source>
-        <target state="translated">Non è stato possibile accedere a {0}.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">Non è stato possibile accedere a {0}.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningFailedAfterAllAttempts">
         <source>Failed to sign. Attempts exceeded.</source>
@@ -129,13 +129,13 @@
       </trans-unit>
       <trans-unit id="SigningFailedWithError">
         <source>Signing failed with error {errorCode}.</source>
-        <target state="translated">Firma non riuscita con errore {errorCode}.</target>
-        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Firma non riuscita con errore {errorCode}.</target>
+        <note>{Placeholder="{errorCode}"} is an error code.</note>
       </trans-unit>
       <trans-unit id="SigningFile">
         <source>Signing {filePath}.</source>
-        <target state="translated">Firma di {filePath} in corso.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Firma di {filePath} in corso.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing succeeded.</source>
@@ -144,13 +144,13 @@
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
         <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{filePath} è stato firmato in {millseconds} ms</target>
-        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath} è stato firmato in {millseconds} ms</target>
+        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
-        <target state="translated">Invio {filePath} per la firma.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Invio {filePath} per la firma.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
         <source>The value cannot be an empty string.</source>
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing OpenVsixSignTool job with {count} files.</source>
-        <target state="translated">Firma del processo OpenVsixSignTool con {count} file.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Firma del processo OpenVsixSignTool con {count} file.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -4,8 +4,8 @@
     <body>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
-        <target state="translated">{count} 個のファイルを使用して SignTool ジョブに署名しています。</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{count} 個のファイルを使用して SignTool ジョブに署名しています。</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CertificateIsExpired">
         <source>The certificate is expired.</source>
@@ -18,44 +18,44 @@
         <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
       </trans-unit>
       <trans-unit id="CliStandardError">
-        <source>{fileName} Err {error}</source>
-        <target state="translated">{fileName} Err {error}</target>
-        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the error {error}</source>
+        <target state="needs-review-translation">{fileName} Err {error}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="CliStandardOutput">
-        <source>{fileName} Out {output}</source>
-        <target state="translated">{fileName} Out {output}</target>
-        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the output {output}</source>
+        <target state="needs-review-translation">{fileName} Out {output}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{output}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="ClickOnceSignatureProviderSigning">
         <source>Signing Mage job with {count} files.</source>
-        <target state="translated">{count} 個のファイルを使用して Mage ジョブに署名しています。</target>
-        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{count} 個のファイルを使用して Mage ジョブに署名しています。</target>
+        <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
-        <target state="translated">ディレクトリ {path} を作成しています。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">ディレクトリ {path} を作成しています。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletedDirectory">
         <source>Directory {path} deleted.</source>
-        <target state="translated">ディレクトリ {path} が削除されました。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">ディレクトリ {path} が削除されました。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletingDirectory">
         <source>Deleting directory {path}.</source>
-        <target state="translated">ディレクトリ {path} を削除しています。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">ディレクトリ {path} を削除しています。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DirectoryNotDeleted">
         <source>Directory {path} still exists.</source>
-        <target state="translated">ディレクトリ {path} がまだ存在します。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">ディレクトリ {path} がまだ存在します。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="EditingAppInstaller">
         <source>Editing AppInstaller job with {count} files.</source>
-        <target state="translated">{count} 個のファイルを使用して AppInstaller ジョブを編集しています。</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{count} 個のファイルを使用して AppInstaller ジョブを編集しています。</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="ErrorSigningVsix">
         <source>An unspecified error occurred during VSIX signing.</source>
@@ -64,13 +64,13 @@
       </trans-unit>
       <trans-unit id="ExceptionWhileDeletingDirectory">
         <source>An exception occurred while attempting to delete directory {path}.</source>
-        <target state="translated">ディレクトリ {path} の削除しようとしている間に例外が発生しました。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">ディレクトリ {path} の削除しようとしている間に例外が発生しました。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="FetchedCertificate">
         <source>Fetched certificate. [{milliseconds} ms]</source>
-        <target state="translated">証明書をフェッチしました。[{milliseconds} ミリ秒]</target>
-        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">証明書をフェッチしました。[{milliseconds} ミリ秒]</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="FetchingCertificate">
         <source>Fetching certificate from Azure Key Vault.</source>
@@ -79,48 +79,48 @@
       </trans-unit>
       <trans-unit id="OpeningContainer">
         <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
-        <target state="translated">コンテナー {ContainerFilePath} を {DirectoryPath} に抽出しています。</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">コンテナー {ContainerFilePath} を {DirectoryPath} に抽出しています。</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="ProcessCouldNotBeKilled">
         <source>{0} timed out and could not be killed.</source>
-        <target state="translated">{0} がタイムアウトしましたが、強制終了できませんでした。</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">{0} がタイムアウトしましたが、強制終了できませんでした。</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTime">
         <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
         <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
-        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{exitCode}"} is a number representing the error code returned from a process.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTimeWithArguments">
         <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
-        <target state="translated">{0} の応答に時間がかかりすぎました。プロセス終了コードは {1} です。引数: {2}</target>
-        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+        <target state="needs-review-translation">{0} の応答に時間がかかりすぎました。プロセス終了コードは {1} です。引数: {2}</target>
+        <note>{NumberedPlaceholder="{0}"} is a file name.  {NumberedPlaceholder="{1}"} is a process exit code.  {NumberedPlaceholder="{2}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="RunningCli">
         <source>Running {fileName} with parameters: '{args}'.</source>
         <target state="new">Running {fileName} with parameters: '{args}'.</target>
-        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{args}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="SavingContainer">
         <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
-        <target state="translated">コンテナー {ContainerFilePath} を {DirectoryPath} から再構築しています。</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">コンテナー {ContainerFilePath} を {DirectoryPath} から再構築しています。</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="SignAsyncCalled">
         <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
-        <target state="translated">{filePath} に対して SignAsync が呼び出されました。{localFilePath} をローカルで使用しています。</target>
-        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath} に対して SignAsync が呼び出されました。{localFilePath} をローカルで使用しています。</target>
+        <note>{Placeholder="{filePath}", "{localFilePath}"} are both file paths.</note>
       </trans-unit>
       <trans-unit id="SigningAttempt">
         <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
-        <target state="translated">{seconds} 秒後に {maxAttempts} 回の試行のうち #{attempt} 回目の試行を実行しています。</target>
-        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{seconds} 秒後に {maxAttempts} 回の試行のうち #{attempt} 回目の試行を実行しています。</target>
+        <note>{Placeholder="{attempt}", "{maxAttempts}"} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  {Placeholder="{seconds}"} is a decimal number representing the number of seconds elapsed, and "s" is the unit abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="SigningFailed">
         <source>Could not sign {0}.</source>
-        <target state="translated">{0} に署名できませんでした。</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">{0} に署名できませんでした。</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningFailedAfterAllAttempts">
         <source>Failed to sign. Attempts exceeded.</source>
@@ -129,13 +129,13 @@
       </trans-unit>
       <trans-unit id="SigningFailedWithError">
         <source>Signing failed with error {errorCode}.</source>
-        <target state="translated">署名がエラー {errorCode} で失敗しました。</target>
-        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">署名がエラー {errorCode} で失敗しました。</target>
+        <note>{Placeholder="{errorCode}"} is an error code.</note>
       </trans-unit>
       <trans-unit id="SigningFile">
         <source>Signing {filePath}.</source>
-        <target state="translated">{filePath} に署名しています。</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath} に署名しています。</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing succeeded.</source>
@@ -144,13 +144,13 @@
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
         <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{millseconds} ミリ秒で {filePath} の署名に成功しました</target>
-        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{millseconds} ミリ秒で {filePath} の署名に成功しました</target>
+        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
-        <target state="translated">署名のために {filePath} を送信しています。</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">署名のために {filePath} を送信しています。</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
         <source>The value cannot be an empty string.</source>
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing OpenVsixSignTool job with {count} files.</source>
-        <target state="translated">{count} 個のファイルを使用して OpenVsixSignTool ジョブに署名しています。</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{count} 個のファイルを使用して OpenVsixSignTool ジョブに署名しています。</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -4,8 +4,8 @@
     <body>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
-        <target state="translated">{count} 파일로 SignTool 작업에 서명하는 중입니다.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{count} 파일로 SignTool 작업에 서명하는 중입니다.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CertificateIsExpired">
         <source>The certificate is expired.</source>
@@ -18,44 +18,44 @@
         <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
       </trans-unit>
       <trans-unit id="CliStandardError">
-        <source>{fileName} Err {error}</source>
-        <target state="translated">{fileName} Err {error}</target>
-        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the error {error}</source>
+        <target state="needs-review-translation">{fileName} Err {error}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="CliStandardOutput">
-        <source>{fileName} Out {output}</source>
-        <target state="translated">{fileName} Out {output}</target>
-        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the output {output}</source>
+        <target state="needs-review-translation">{fileName} Out {output}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{output}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="ClickOnceSignatureProviderSigning">
         <source>Signing Mage job with {count} files.</source>
-        <target state="translated">{count} 파일로 Mage 작업에 서명하는 중입니다.</target>
-        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{count} 파일로 Mage 작업에 서명하는 중입니다.</target>
+        <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
-        <target state="translated">디렉터리 {path}을(를) 생성하는 중입니다.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">디렉터리 {path}을(를) 생성하는 중입니다.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletedDirectory">
         <source>Directory {path} deleted.</source>
-        <target state="translated">디렉터리 {path}이(가) 삭제되었습니다.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">디렉터리 {path}이(가) 삭제되었습니다.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletingDirectory">
         <source>Deleting directory {path}.</source>
-        <target state="translated">디렉터리 {path}을(를) 삭제하는 중입니다.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">디렉터리 {path}을(를) 삭제하는 중입니다.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DirectoryNotDeleted">
         <source>Directory {path} still exists.</source>
-        <target state="translated">디렉터리 {path}이(가) 여전히 존재합니다.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">디렉터리 {path}이(가) 여전히 존재합니다.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="EditingAppInstaller">
         <source>Editing AppInstaller job with {count} files.</source>
-        <target state="translated">{count} 파일로 AppInstaller 작업을 편집하는 중입니다.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{count} 파일로 AppInstaller 작업을 편집하는 중입니다.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="ErrorSigningVsix">
         <source>An unspecified error occurred during VSIX signing.</source>
@@ -64,13 +64,13 @@
       </trans-unit>
       <trans-unit id="ExceptionWhileDeletingDirectory">
         <source>An exception occurred while attempting to delete directory {path}.</source>
-        <target state="translated">디렉터리 {path}을(를) 삭제하려고 시도하는 동안 예외가 발생했습니다.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">디렉터리 {path}을(를) 삭제하려고 시도하는 동안 예외가 발생했습니다.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="FetchedCertificate">
         <source>Fetched certificate. [{milliseconds} ms]</source>
-        <target state="translated">인증서를 가져왔습니다. [{milliseconds}ms]</target>
-        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">인증서를 가져왔습니다. [{milliseconds}ms]</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="FetchingCertificate">
         <source>Fetching certificate from Azure Key Vault.</source>
@@ -79,48 +79,48 @@
       </trans-unit>
       <trans-unit id="OpeningContainer">
         <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
-        <target state="translated">컨테이너 {ContainerFilePath}을(를) {DirectoryPath}(으)로 추출하는 중입니다.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">컨테이너 {ContainerFilePath}을(를) {DirectoryPath}(으)로 추출하는 중입니다.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="ProcessCouldNotBeKilled">
         <source>{0} timed out and could not be killed.</source>
-        <target state="translated">{0}이(가) 시간 초과되어 종료할 수 없습니다.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">{0}이(가) 시간 초과되어 종료할 수 없습니다.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTime">
         <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
         <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
-        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{exitCode}"} is a number representing the error code returned from a process.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTimeWithArguments">
         <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
-        <target state="translated">{0} 응답하는 데 너무 오래 걸렸습니다. 프로세스 종료 코드는 {1}입니다. 인수: {2}</target>
-        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+        <target state="needs-review-translation">{0} 응답하는 데 너무 오래 걸렸습니다. 프로세스 종료 코드는 {1}입니다. 인수: {2}</target>
+        <note>{NumberedPlaceholder="{0}"} is a file name.  {NumberedPlaceholder="{1}"} is a process exit code.  {NumberedPlaceholder="{2}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="RunningCli">
         <source>Running {fileName} with parameters: '{args}'.</source>
         <target state="new">Running {fileName} with parameters: '{args}'.</target>
-        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{args}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="SavingContainer">
         <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
-        <target state="translated">{DirectoryPath}에서 컨테이너 {ContainerFilePath}을(를) 다시 빌드하는 중입니다.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{DirectoryPath}에서 컨테이너 {ContainerFilePath}을(를) 다시 빌드하는 중입니다.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="SignAsyncCalled">
         <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
-        <target state="translated">{filePath}에 대해 SignAsync가 호출되었습니다. 로컬에서 {localFilePath}을(를) 사용하고 있습니다.</target>
-        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath}에 대해 SignAsync가 호출되었습니다. 로컬에서 {localFilePath}을(를) 사용하고 있습니다.</target>
+        <note>{Placeholder="{filePath}", "{localFilePath}"} are both file paths.</note>
       </trans-unit>
       <trans-unit id="SigningAttempt">
         <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
-        <target state="translated">{seconds}초 후에 {maxAttempts}회 시도 중 #{attempt}을(를) 시도하는 중입니다.</target>
-        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{seconds}초 후에 {maxAttempts}회 시도 중 #{attempt}을(를) 시도하는 중입니다.</target>
+        <note>{Placeholder="{attempt}", "{maxAttempts}"} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  {Placeholder="{seconds}"} is a decimal number representing the number of seconds elapsed, and "s" is the unit abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="SigningFailed">
         <source>Could not sign {0}.</source>
-        <target state="translated">{0}에 서명할 수 없습니다.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">{0}에 서명할 수 없습니다.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningFailedAfterAllAttempts">
         <source>Failed to sign. Attempts exceeded.</source>
@@ -129,13 +129,13 @@
       </trans-unit>
       <trans-unit id="SigningFailedWithError">
         <source>Signing failed with error {errorCode}.</source>
-        <target state="translated">오류 {errorCode}(으)로 인해 서명에 실패했습니다.</target>
-        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">오류 {errorCode}(으)로 인해 서명에 실패했습니다.</target>
+        <note>{Placeholder="{errorCode}"} is an error code.</note>
       </trans-unit>
       <trans-unit id="SigningFile">
         <source>Signing {filePath}.</source>
-        <target state="translated">{filePath}에 서명하는 중입니다.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath}에 서명하는 중입니다.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing succeeded.</source>
@@ -144,13 +144,13 @@
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
         <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{millseconds}ms 내에 {filePath}에 서명했습니다.</target>
-        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{millseconds}ms 내에 {filePath}에 서명했습니다.</target>
+        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
-        <target state="translated">서명을 위해 {filePath}을(를) 제출하는 중입니다.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">서명을 위해 {filePath}을(를) 제출하는 중입니다.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
         <source>The value cannot be an empty string.</source>
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing OpenVsixSignTool job with {count} files.</source>
-        <target state="translated">{count} 파일로 OpenVsixSignTool 작업에 서명하는 중입니다.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{count} 파일로 OpenVsixSignTool 작업에 서명하는 중입니다.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -4,8 +4,8 @@
     <body>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
-        <target state="translated">Podpisywanie zadania SignTool przy użyciu {count} plików.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Podpisywanie zadania SignTool przy użyciu {count} plików.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CertificateIsExpired">
         <source>The certificate is expired.</source>
@@ -18,44 +18,44 @@
         <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
       </trans-unit>
       <trans-unit id="CliStandardError">
-        <source>{fileName} Err {error}</source>
-        <target state="new">{fileName} Err {error}</target>
-        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the error {error}</source>
+        <target state="new">{fileName} returned the error {error}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="CliStandardOutput">
-        <source>{fileName} Out {output}</source>
-        <target state="new">{fileName} Out {output}</target>
-        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the output {output}</source>
+        <target state="new">{fileName} returned the output {output}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{output}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="ClickOnceSignatureProviderSigning">
         <source>Signing Mage job with {count} files.</source>
-        <target state="translated">Podpisywanie zadania Mage przy użyciu {count} plików.</target>
-        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Podpisywanie zadania Mage przy użyciu {count} plików.</target>
+        <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
-        <target state="translated">Tworzenie ścieżki {path} katalogu.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Tworzenie ścieżki {path} katalogu.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletedDirectory">
         <source>Directory {path} deleted.</source>
-        <target state="translated">Usunięto ścieżkę {path} katalogu.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Usunięto ścieżkę {path} katalogu.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletingDirectory">
         <source>Deleting directory {path}.</source>
-        <target state="translated">Usuwanie ścieżki {path} katalogu.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Usuwanie ścieżki {path} katalogu.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DirectoryNotDeleted">
         <source>Directory {path} still exists.</source>
-        <target state="translated">Ścieżka {path} katalogu nadal istnieje.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Ścieżka {path} katalogu nadal istnieje.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="EditingAppInstaller">
         <source>Editing AppInstaller job with {count} files.</source>
-        <target state="translated">Edytowanie zadania AppInstaller przy użyciu {count} plików.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Edytowanie zadania AppInstaller przy użyciu {count} plików.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="ErrorSigningVsix">
         <source>An unspecified error occurred during VSIX signing.</source>
@@ -64,13 +64,13 @@
       </trans-unit>
       <trans-unit id="ExceptionWhileDeletingDirectory">
         <source>An exception occurred while attempting to delete directory {path}.</source>
-        <target state="translated">Wystąpił wyjątek podczas próby usunięcia ścieżki {path} katalogu.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Wystąpił wyjątek podczas próby usunięcia ścieżki {path} katalogu.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="FetchedCertificate">
         <source>Fetched certificate. [{milliseconds} ms]</source>
-        <target state="translated">Pobrano certyfikat. [{milliseconds} ms]</target>
-        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Pobrano certyfikat. [{milliseconds} ms]</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="FetchingCertificate">
         <source>Fetching certificate from Azure Key Vault.</source>
@@ -79,48 +79,48 @@
       </trans-unit>
       <trans-unit id="OpeningContainer">
         <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
-        <target state="translated">Wyodrębnianie ścieżki {ContainerFilePath} kontenera do ścieżki {DirectoryPath}.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Wyodrębnianie ścieżki {ContainerFilePath} kontenera do ścieżki {DirectoryPath}.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="ProcessCouldNotBeKilled">
         <source>{0} timed out and could not be killed.</source>
-        <target state="translated">Przekroczono limit czasu dla ścieżki {0} i nie można jej zabić.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">Przekroczono limit czasu dla ścieżki {0} i nie można jej zabić.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTime">
         <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
         <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
-        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{exitCode}"} is a number representing the error code returned from a process.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTimeWithArguments">
         <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
-        <target state="translated">W przypadku pliku {0} uzyskanie odpowiedzi trwało zbyt długo. Kod zakończenia procesu to {1}. Argumenty: {2}</target>
-        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+        <target state="needs-review-translation">W przypadku pliku {0} uzyskanie odpowiedzi trwało zbyt długo. Kod zakończenia procesu to {1}. Argumenty: {2}</target>
+        <note>{NumberedPlaceholder="{0}"} is a file name.  {NumberedPlaceholder="{1}"} is a process exit code.  {NumberedPlaceholder="{2}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="RunningCli">
         <source>Running {fileName} with parameters: '{args}'.</source>
         <target state="new">Running {fileName} with parameters: '{args}'.</target>
-        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{args}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="SavingContainer">
         <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
-        <target state="translated">Ponowne kompilowanie ścieżki {ContainerFilePath} kontenera ze ścieżki {DirectoryPath}.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Ponowne kompilowanie ścieżki {ContainerFilePath} kontenera ze ścieżki {DirectoryPath}.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="SignAsyncCalled">
         <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
-        <target state="translated">Wywołano element SignAsync dla ścieżki {filePath}. Używanie ścieżki {localFilePath} lokalnie.</target>
-        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Wywołano element SignAsync dla ścieżki {filePath}. Używanie ścieżki {localFilePath} lokalnie.</target>
+        <note>{Placeholder="{filePath}", "{localFilePath}"} are both file paths.</note>
       </trans-unit>
       <trans-unit id="SigningAttempt">
         <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
-        <target state="translated">Wykonywanie #{attempt} próby z {maxAttempts} po {seconds} s.</target>
-        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Wykonywanie #{attempt} próby z {maxAttempts} po {seconds} s.</target>
+        <note>{Placeholder="{attempt}", "{maxAttempts}"} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  {Placeholder="{seconds}"} is a decimal number representing the number of seconds elapsed, and "s" is the unit abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="SigningFailed">
         <source>Could not sign {0}.</source>
-        <target state="translated">Nie można podpisać ścieżki {0}.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">Nie można podpisać ścieżki {0}.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningFailedAfterAllAttempts">
         <source>Failed to sign. Attempts exceeded.</source>
@@ -129,13 +129,13 @@
       </trans-unit>
       <trans-unit id="SigningFailedWithError">
         <source>Signing failed with error {errorCode}.</source>
-        <target state="translated">Podpisywanie nie powiodło się z powodu błędu {errorCode}.</target>
-        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Podpisywanie nie powiodło się z powodu błędu {errorCode}.</target>
+        <note>{Placeholder="{errorCode}"} is an error code.</note>
       </trans-unit>
       <trans-unit id="SigningFile">
         <source>Signing {filePath}.</source>
-        <target state="translated">Podpisywanie ścieżki {filePath}.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Podpisywanie ścieżki {filePath}.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing succeeded.</source>
@@ -144,13 +144,13 @@
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
         <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">Pomyślnie podpisano ścieżkę {filePath} w ciągu {millseconds} ms</target>
-        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Pomyślnie podpisano ścieżkę {filePath} w ciągu {millseconds} ms</target>
+        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
-        <target state="translated">Przesyłanie ścieżki {filePath} do podpisania.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Przesyłanie ścieżki {filePath} do podpisania.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
         <source>The value cannot be an empty string.</source>
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing OpenVsixSignTool job with {count} files.</source>
-        <target state="translated">Podpisywanie zadania OpenVsixSignTool przy użyciu {count} plików.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Podpisywanie zadania OpenVsixSignTool przy użyciu {count} plików.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -4,8 +4,8 @@
     <body>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
-        <target state="translated">Autenticando o trabalho SignTool com {count} arquivos.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Autenticando o trabalho SignTool com {count} arquivos.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CertificateIsExpired">
         <source>The certificate is expired.</source>
@@ -18,44 +18,44 @@
         <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
       </trans-unit>
       <trans-unit id="CliStandardError">
-        <source>{fileName} Err {error}</source>
-        <target state="new">{fileName} Err {error}</target>
-        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the error {error}</source>
+        <target state="new">{fileName} returned the error {error}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="CliStandardOutput">
-        <source>{fileName} Out {output}</source>
-        <target state="new">{fileName} Out {output}</target>
-        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the output {output}</source>
+        <target state="new">{fileName} returned the output {output}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{output}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="ClickOnceSignatureProviderSigning">
         <source>Signing Mage job with {count} files.</source>
-        <target state="translated">Autenticando o trabalho Mage com {count} arquivos.</target>
-        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Autenticando o trabalho Mage com {count} arquivos.</target>
+        <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
-        <target state="translated">Criando o diretório {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Criando o diretório {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletedDirectory">
         <source>Directory {path} deleted.</source>
-        <target state="translated">Diretório {path} excluído.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Diretório {path} excluído.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletingDirectory">
         <source>Deleting directory {path}.</source>
-        <target state="translated">Excluindo o diretório {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Excluindo o diretório {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DirectoryNotDeleted">
         <source>Directory {path} still exists.</source>
-        <target state="translated">O diretório {path} ainda existe.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">O diretório {path} ainda existe.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="EditingAppInstaller">
         <source>Editing AppInstaller job with {count} files.</source>
-        <target state="translated">Editando o trabalho do AppInstaller com {count} arquivos.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Editando o trabalho do AppInstaller com {count} arquivos.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="ErrorSigningVsix">
         <source>An unspecified error occurred during VSIX signing.</source>
@@ -64,13 +64,13 @@
       </trans-unit>
       <trans-unit id="ExceptionWhileDeletingDirectory">
         <source>An exception occurred while attempting to delete directory {path}.</source>
-        <target state="translated">Ocorreu uma exceção ao tentar excluir o diretório {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Ocorreu uma exceção ao tentar excluir o diretório {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="FetchedCertificate">
         <source>Fetched certificate. [{milliseconds} ms]</source>
-        <target state="translated">Certificado buscado. [{milissegundos} ms]</target>
-        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Certificado buscado. [{milissegundos} ms]</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="FetchingCertificate">
         <source>Fetching certificate from Azure Key Vault.</source>
@@ -79,48 +79,48 @@
       </trans-unit>
       <trans-unit id="OpeningContainer">
         <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
-        <target state="translated">Extraindo o contêiner {ContainerFilePath} para {DirectoryPath}.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Extraindo o contêiner {ContainerFilePath} para {DirectoryPath}.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="ProcessCouldNotBeKilled">
         <source>{0} timed out and could not be killed.</source>
-        <target state="translated">{0} atingiu o tempo limite e não pôde ser eliminado.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">{0} atingiu o tempo limite e não pôde ser eliminado.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTime">
         <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
         <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
-        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{exitCode}"} is a number representing the error code returned from a process.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTimeWithArguments">
         <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
-        <target state="translated">{0} demorou muito para responder. O código de saída do processo {1}. Argumentos: {2}</target>
-        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+        <target state="needs-review-translation">{0} demorou muito para responder. O código de saída do processo {1}. Argumentos: {2}</target>
+        <note>{NumberedPlaceholder="{0}"} is a file name.  {NumberedPlaceholder="{1}"} is a process exit code.  {NumberedPlaceholder="{2}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="RunningCli">
         <source>Running {fileName} with parameters: '{args}'.</source>
         <target state="new">Running {fileName} with parameters: '{args}'.</target>
-        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{args}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="SavingContainer">
         <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
-        <target state="translated">Recriando o contêiner {ContainerFilePath} a partir do {DirectoryPath}.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Recriando o contêiner {ContainerFilePath} a partir do {DirectoryPath}.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="SignAsyncCalled">
         <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
-        <target state="translated">SignAsync chamado para {filePath}. Usando {localFilePath} localmente.</target>
-        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">SignAsync chamado para {filePath}. Usando {localFilePath} localmente.</target>
+        <note>{Placeholder="{filePath}", "{localFilePath}"} are both file paths.</note>
       </trans-unit>
       <trans-unit id="SigningAttempt">
         <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
-        <target state="translated">Executando a tentativa #{attempt} de {maxAttempts} tentativas após {seconds} s.</target>
-        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Executando a tentativa #{attempt} de {maxAttempts} tentativas após {seconds} s.</target>
+        <note>{Placeholder="{attempt}", "{maxAttempts}"} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  {Placeholder="{seconds}"} is a decimal number representing the number of seconds elapsed, and "s" is the unit abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="SigningFailed">
         <source>Could not sign {0}.</source>
-        <target state="translated">Não foi possível autenticar {0}.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">Não foi possível autenticar {0}.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningFailedAfterAllAttempts">
         <source>Failed to sign. Attempts exceeded.</source>
@@ -129,13 +129,13 @@
       </trans-unit>
       <trans-unit id="SigningFailedWithError">
         <source>Signing failed with error {errorCode}.</source>
-        <target state="translated">Falha na autenticação com o erro {errorCode}.</target>
-        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Falha na autenticação com o erro {errorCode}.</target>
+        <note>{Placeholder="{errorCode}"} is an error code.</note>
       </trans-unit>
       <trans-unit id="SigningFile">
         <source>Signing {filePath}.</source>
-        <target state="translated">Autenticando {filePath}.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Autenticando {filePath}.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing succeeded.</source>
@@ -144,13 +144,13 @@
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
         <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{filePath} autenticado com êxito em {millseconds} ms</target>
-        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath} autenticado com êxito em {millseconds} ms</target>
+        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
-        <target state="translated">Enviando {filePath} para autenticação.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Enviando {filePath} para autenticação.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
         <source>The value cannot be an empty string.</source>
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing OpenVsixSignTool job with {count} files.</source>
-        <target state="translated">Autenticando o trabalho OpenVsixSignTool com {count} arquivos.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Autenticando o trabalho OpenVsixSignTool com {count} arquivos.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -4,8 +4,8 @@
     <body>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
-        <target state="translated">Задание подписывания SignTool с несколькими файлами ({count}).</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Задание подписывания SignTool с несколькими файлами ({count}).</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CertificateIsExpired">
         <source>The certificate is expired.</source>
@@ -18,44 +18,44 @@
         <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
       </trans-unit>
       <trans-unit id="CliStandardError">
-        <source>{fileName} Err {error}</source>
-        <target state="new">{fileName} Err {error}</target>
-        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the error {error}</source>
+        <target state="new">{fileName} returned the error {error}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="CliStandardOutput">
-        <source>{fileName} Out {output}</source>
-        <target state="new">{fileName} Out {output}</target>
-        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the output {output}</source>
+        <target state="new">{fileName} returned the output {output}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{output}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="ClickOnceSignatureProviderSigning">
         <source>Signing Mage job with {count} files.</source>
-        <target state="translated">Подписывание задания Mage с несколькими файлами ({count}).</target>
-        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Подписывание задания Mage с несколькими файлами ({count}).</target>
+        <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
-        <target state="translated">Идет создание каталога {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Идет создание каталога {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletedDirectory">
         <source>Directory {path} deleted.</source>
-        <target state="translated">Каталог {path} удален.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Каталог {path} удален.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletingDirectory">
         <source>Deleting directory {path}.</source>
-        <target state="translated">Идет удаление каталога {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Идет удаление каталога {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DirectoryNotDeleted">
         <source>Directory {path} still exists.</source>
-        <target state="translated">Каталог {path} все еще существует.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Каталог {path} все еще существует.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="EditingAppInstaller">
         <source>Editing AppInstaller job with {count} files.</source>
-        <target state="translated">Изменение задания AppInstaller с несколькими файлами ({count}).</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Изменение задания AppInstaller с несколькими файлами ({count}).</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="ErrorSigningVsix">
         <source>An unspecified error occurred during VSIX signing.</source>
@@ -64,13 +64,13 @@
       </trans-unit>
       <trans-unit id="ExceptionWhileDeletingDirectory">
         <source>An exception occurred while attempting to delete directory {path}.</source>
-        <target state="translated">Возникло исключение при попытке удаления каталога {path}.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Возникло исключение при попытке удаления каталога {path}.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="FetchedCertificate">
         <source>Fetched certificate. [{milliseconds} ms]</source>
-        <target state="translated">Получен сертификат. [{milliseconds} мс]</target>
-        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Получен сертификат. [{milliseconds} мс]</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="FetchingCertificate">
         <source>Fetching certificate from Azure Key Vault.</source>
@@ -79,48 +79,48 @@
       </trans-unit>
       <trans-unit id="OpeningContainer">
         <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
-        <target state="translated">Идет извлечение контейнера {ContainerFilePath} в {DirectoryPath}.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Идет извлечение контейнера {ContainerFilePath} в {DirectoryPath}.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="ProcessCouldNotBeKilled">
         <source>{0} timed out and could not be killed.</source>
-        <target state="translated">Время ожидания {0} истекло, и его не удалось завершить.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">Время ожидания {0} истекло, и его не удалось завершить.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTime">
         <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
         <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
-        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{exitCode}"} is a number representing the error code returned from a process.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTimeWithArguments">
         <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
-        <target state="translated">{0} слишком долго не отвечает. Код завершения процесса {1}. Аргументы: {2}</target>
-        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+        <target state="needs-review-translation">{0} слишком долго не отвечает. Код завершения процесса {1}. Аргументы: {2}</target>
+        <note>{NumberedPlaceholder="{0}"} is a file name.  {NumberedPlaceholder="{1}"} is a process exit code.  {NumberedPlaceholder="{2}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="RunningCli">
         <source>Running {fileName} with parameters: '{args}'.</source>
         <target state="new">Running {fileName} with parameters: '{args}'.</target>
-        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{args}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="SavingContainer">
         <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
-        <target state="translated">Идет перестроение контейнера {ContainerFilePath} из {DirectoryPath}.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Идет перестроение контейнера {ContainerFilePath} из {DirectoryPath}.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="SignAsyncCalled">
         <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
-        <target state="translated">SignAsync вызван для {filePath}. Используется {localFilePath} локально.</target>
-        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">SignAsync вызван для {filePath}. Используется {localFilePath} локально.</target>
+        <note>{Placeholder="{filePath}", "{localFilePath}"} are both file paths.</note>
       </trans-unit>
       <trans-unit id="SigningAttempt">
         <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
-        <target state="translated">Выполняется попытка #{attempt} из {maxAttempts} попыток за {seconds} с.</target>
-        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Выполняется попытка #{attempt} из {maxAttempts} попыток за {seconds} с.</target>
+        <note>{Placeholder="{attempt}", "{maxAttempts}"} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  {Placeholder="{seconds}"} is a decimal number representing the number of seconds elapsed, and "s" is the unit abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="SigningFailed">
         <source>Could not sign {0}.</source>
-        <target state="translated">Не удалось подписать {0}.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">Не удалось подписать {0}.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningFailedAfterAllAttempts">
         <source>Failed to sign. Attempts exceeded.</source>
@@ -129,13 +129,13 @@
       </trans-unit>
       <trans-unit id="SigningFailedWithError">
         <source>Signing failed with error {errorCode}.</source>
-        <target state="translated">Сбой подписывания с ошибкой {errorCode}.</target>
-        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Сбой подписывания с ошибкой {errorCode}.</target>
+        <note>{Placeholder="{errorCode}"} is an error code.</note>
       </trans-unit>
       <trans-unit id="SigningFile">
         <source>Signing {filePath}.</source>
-        <target state="translated">Подписывание {filePath}.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Подписывание {filePath}.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing succeeded.</source>
@@ -144,13 +144,13 @@
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
         <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">Успешно подписано {filePath} за {millseconds} мс</target>
-        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Успешно подписано {filePath} за {millseconds} мс</target>
+        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
-        <target state="translated">Отправка {filePath} для подписывания.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Отправка {filePath} для подписывания.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
         <source>The value cannot be an empty string.</source>
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing OpenVsixSignTool job with {count} files.</source>
-        <target state="translated">Подписывание задания OpenVsixSignTool с несколькими файлами ({count}).</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Подписывание задания OpenVsixSignTool с несколькими файлами ({count}).</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -4,8 +4,8 @@
     <body>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
-        <target state="translated">SignTool işi {count} dosya ile imzalanıyor.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">SignTool işi {count} dosya ile imzalanıyor.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CertificateIsExpired">
         <source>The certificate is expired.</source>
@@ -18,44 +18,44 @@
         <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
       </trans-unit>
       <trans-unit id="CliStandardError">
-        <source>{fileName} Err {error}</source>
-        <target state="new">{fileName} Err {error}</target>
-        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the error {error}</source>
+        <target state="new">{fileName} returned the error {error}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="CliStandardOutput">
-        <source>{fileName} Out {output}</source>
-        <target state="new">{fileName} Out {output}</target>
-        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the output {output}</source>
+        <target state="new">{fileName} returned the output {output}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{output}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="ClickOnceSignatureProviderSigning">
         <source>Signing Mage job with {count} files.</source>
-        <target state="translated">Mage işi {count} dosya ile imzalanıyor.</target>
-        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Mage işi {count} dosya ile imzalanıyor.</target>
+        <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
-        <target state="translated">{path} dizini oluşturuluyor.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{path} dizini oluşturuluyor.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletedDirectory">
         <source>Directory {path} deleted.</source>
-        <target state="translated">{path} dizini silindi.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{path} dizini silindi.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletingDirectory">
         <source>Deleting directory {path}.</source>
-        <target state="translated">{path} dizini siliniyor.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{path} dizini siliniyor.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DirectoryNotDeleted">
         <source>Directory {path} still exists.</source>
-        <target state="translated">{path} hala mevcut.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{path} hala mevcut.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="EditingAppInstaller">
         <source>Editing AppInstaller job with {count} files.</source>
-        <target state="translated">AppInstaller işi {count} dosya ile düzenleniyor.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">AppInstaller işi {count} dosya ile düzenleniyor.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="ErrorSigningVsix">
         <source>An unspecified error occurred during VSIX signing.</source>
@@ -64,13 +64,13 @@
       </trans-unit>
       <trans-unit id="ExceptionWhileDeletingDirectory">
         <source>An exception occurred while attempting to delete directory {path}.</source>
-        <target state="translated">{path} dizini silinmeye çalışılırken bir özel durum oluştu.</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{path} dizini silinmeye çalışılırken bir özel durum oluştu.</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="FetchedCertificate">
         <source>Fetched certificate. [{milliseconds} ms]</source>
-        <target state="translated">Sertifika getirildi. [{milliseconds} ms]</target>
-        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">Sertifika getirildi. [{milliseconds} ms]</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="FetchingCertificate">
         <source>Fetching certificate from Azure Key Vault.</source>
@@ -79,48 +79,48 @@
       </trans-unit>
       <trans-unit id="OpeningContainer">
         <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
-        <target state="translated">{ContainerFilePath} kapsayıcısı {DirectoryPath} dizinine ayıklanıyor..</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{ContainerFilePath} kapsayıcısı {DirectoryPath} dizinine ayıklanıyor..</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="ProcessCouldNotBeKilled">
         <source>{0} timed out and could not be killed.</source>
-        <target state="translated">{0} zaman aşımına uğradı ve sonlandırılamadı.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">{0} zaman aşımına uğradı ve sonlandırılamadı.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTime">
         <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
         <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
-        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{exitCode}"} is a number representing the error code returned from a process.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTimeWithArguments">
         <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
-        <target state="translated">{0} dosyasının yanıt vermesi çok uzun sürdü. İşlem çıkış kodu: {1}. Bağımsız değişkenler: {2}</target>
-        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+        <target state="needs-review-translation">{0} dosyasının yanıt vermesi çok uzun sürdü. İşlem çıkış kodu: {1}. Bağımsız değişkenler: {2}</target>
+        <note>{NumberedPlaceholder="{0}"} is a file name.  {NumberedPlaceholder="{1}"} is a process exit code.  {NumberedPlaceholder="{2}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="RunningCli">
         <source>Running {fileName} with parameters: '{args}'.</source>
         <target state="new">Running {fileName} with parameters: '{args}'.</target>
-        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{args}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="SavingContainer">
         <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
-        <target state="translated">{ContainerFilePath} kapsayıcısı {DirectoryPath} dizininden yeniden derleniyor.</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{ContainerFilePath} kapsayıcısı {DirectoryPath} dizininden yeniden derleniyor.</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="SignAsyncCalled">
         <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
-        <target state="translated">{filePath} SignAsync çağrıldı. Yerel olarak {localFilePath} kullanılıyor.</target>
-        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath} SignAsync çağrıldı. Yerel olarak {localFilePath} kullanılıyor.</target>
+        <note>{Placeholder="{filePath}", "{localFilePath}"} are both file paths.</note>
       </trans-unit>
       <trans-unit id="SigningAttempt">
         <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
-        <target state="translated">{seconds} sn sonra #{attempt}/{maxAttempts} deneme yapılıyor.</target>
-        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{seconds} sn sonra #{attempt}/{maxAttempts} deneme yapılıyor.</target>
+        <note>{Placeholder="{attempt}", "{maxAttempts}"} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  {Placeholder="{seconds}"} is a decimal number representing the number of seconds elapsed, and "s" is the unit abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="SigningFailed">
         <source>Could not sign {0}.</source>
-        <target state="translated">{0} imzalamadı.</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">{0} imzalamadı.</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningFailedAfterAllAttempts">
         <source>Failed to sign. Attempts exceeded.</source>
@@ -129,13 +129,13 @@
       </trans-unit>
       <trans-unit id="SigningFailedWithError">
         <source>Signing failed with error {errorCode}.</source>
-        <target state="translated">İmzalama {errorCode} hatasıyla başarısız oldu.</target>
-        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">İmzalama {errorCode} hatasıyla başarısız oldu.</target>
+        <note>{Placeholder="{errorCode}"} is an error code.</note>
       </trans-unit>
       <trans-unit id="SigningFile">
         <source>Signing {filePath}.</source>
-        <target state="translated">{filePath} imzalanıyor.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath} imzalanıyor.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing succeeded.</source>
@@ -144,13 +144,13 @@
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
         <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{filePath} dosya yolu {millseconds} ms içinde başarıyla imzalandı</target>
-        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath} dosya yolu {millseconds} ms içinde başarıyla imzalandı</target>
+        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
-        <target state="translated">{filePath} imzalama için gönderiliyor.</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">{filePath} imzalama için gönderiliyor.</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
         <source>The value cannot be an empty string.</source>
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing OpenVsixSignTool job with {count} files.</source>
-        <target state="translated">OpenVsixSignTool işi {count} dosya ile imzalanıyor.</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">OpenVsixSignTool işi {count} dosya ile imzalanıyor.</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -4,8 +4,8 @@
     <body>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
-        <target state="translated">正在对包含 {count} 个文件的 SignTool 作业进行签名。</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在对包含 {count} 个文件的 SignTool 作业进行签名。</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CertificateIsExpired">
         <source>The certificate is expired.</source>
@@ -18,44 +18,44 @@
         <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
       </trans-unit>
       <trans-unit id="CliStandardError">
-        <source>{fileName} Err {error}</source>
-        <target state="new">{fileName} Err {error}</target>
-        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the error {error}</source>
+        <target state="new">{fileName} returned the error {error}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="CliStandardOutput">
-        <source>{fileName} Out {output}</source>
-        <target state="new">{fileName} Out {output}</target>
-        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the output {output}</source>
+        <target state="new">{fileName} returned the output {output}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{output}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="ClickOnceSignatureProviderSigning">
         <source>Signing Mage job with {count} files.</source>
-        <target state="translated">正在对包含 {count} 个文件的 Mage 作业进行签名。</target>
-        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在对包含 {count} 个文件的 Mage 作业进行签名。</target>
+        <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
-        <target state="translated">正在创建目录 {path}。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在创建目录 {path}。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletedDirectory">
         <source>Directory {path} deleted.</source>
-        <target state="translated">已删除目录 {path}。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">已删除目录 {path}。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletingDirectory">
         <source>Deleting directory {path}.</source>
-        <target state="translated">正在删除目录 {path}。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在删除目录 {path}。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DirectoryNotDeleted">
         <source>Directory {path} still exists.</source>
-        <target state="translated">目录 {path} 仍然存在。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">目录 {path} 仍然存在。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="EditingAppInstaller">
         <source>Editing AppInstaller job with {count} files.</source>
-        <target state="translated">正在编辑包含 {count} 个文件的 AppInstaller 作业。</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在编辑包含 {count} 个文件的 AppInstaller 作业。</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="ErrorSigningVsix">
         <source>An unspecified error occurred during VSIX signing.</source>
@@ -64,13 +64,13 @@
       </trans-unit>
       <trans-unit id="ExceptionWhileDeletingDirectory">
         <source>An exception occurred while attempting to delete directory {path}.</source>
-        <target state="translated">尝试删除目录 {path} 时发生异常。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">尝试删除目录 {path} 时发生异常。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="FetchedCertificate">
         <source>Fetched certificate. [{milliseconds} ms]</source>
-        <target state="translated">已提取证书。[{milliseconds} 毫秒]</target>
-        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">已提取证书。[{milliseconds} 毫秒]</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="FetchingCertificate">
         <source>Fetching certificate from Azure Key Vault.</source>
@@ -79,48 +79,48 @@
       </trans-unit>
       <trans-unit id="OpeningContainer">
         <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
-        <target state="translated">正在将容器 {ContainerFilePath} 提取到 {DirectoryPath}。</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在将容器 {ContainerFilePath} 提取到 {DirectoryPath}。</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="ProcessCouldNotBeKilled">
         <source>{0} timed out and could not be killed.</source>
-        <target state="translated">{0} 超时，无法终止。</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">{0} 超时，无法终止。</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTime">
         <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
         <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
-        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{exitCode}"} is a number representing the error code returned from a process.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTimeWithArguments">
         <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
-        <target state="translated">{0} 响应的时间太长。进程退出代码为 {1}。参数: {2}</target>
-        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+        <target state="needs-review-translation">{0} 响应的时间太长。进程退出代码为 {1}。参数: {2}</target>
+        <note>{NumberedPlaceholder="{0}"} is a file name.  {NumberedPlaceholder="{1}"} is a process exit code.  {NumberedPlaceholder="{2}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="RunningCli">
         <source>Running {fileName} with parameters: '{args}'.</source>
         <target state="new">Running {fileName} with parameters: '{args}'.</target>
-        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{args}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="SavingContainer">
         <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
-        <target state="translated">正在从 {DirectoryPath} 重新生成容器 {ContainerFilePath}。</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在从 {DirectoryPath} 重新生成容器 {ContainerFilePath}。</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="SignAsyncCalled">
         <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
-        <target state="translated">为 {filePath} 调用了 SignAsync。请在本地使用 {localFilePath}。</target>
-        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">为 {filePath} 调用了 SignAsync。请在本地使用 {localFilePath}。</target>
+        <note>{Placeholder="{filePath}", "{localFilePath}"} are both file paths.</note>
       </trans-unit>
       <trans-unit id="SigningAttempt">
         <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
-        <target state="translated">正在 {seconds} 秒后执行第 #{attempt} 次尝试(最多 {maxAttempts} 次)。</target>
-        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在 {seconds} 秒后执行第 #{attempt} 次尝试(最多 {maxAttempts} 次)。</target>
+        <note>{Placeholder="{attempt}", "{maxAttempts}"} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  {Placeholder="{seconds}"} is a decimal number representing the number of seconds elapsed, and "s" is the unit abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="SigningFailed">
         <source>Could not sign {0}.</source>
-        <target state="translated">无法对 {0} 进行签名。</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">无法对 {0} 进行签名。</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningFailedAfterAllAttempts">
         <source>Failed to sign. Attempts exceeded.</source>
@@ -129,13 +129,13 @@
       </trans-unit>
       <trans-unit id="SigningFailedWithError">
         <source>Signing failed with error {errorCode}.</source>
-        <target state="translated">签名失败，出现错误 {errorCode}。</target>
-        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">签名失败，出现错误 {errorCode}。</target>
+        <note>{Placeholder="{errorCode}"} is an error code.</note>
       </trans-unit>
       <trans-unit id="SigningFile">
         <source>Signing {filePath}.</source>
-        <target state="translated">正在对 {filePath} 进行签名。</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在对 {filePath} 进行签名。</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing succeeded.</source>
@@ -144,13 +144,13 @@
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
         <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">已成功在 {millseconds} 毫秒内对 {filePath} 进行签名</target>
-        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">已成功在 {millseconds} 毫秒内对 {filePath} 进行签名</target>
+        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
-        <target state="translated">正在提交 {filePath} 进行签名。</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在提交 {filePath} 进行签名。</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
         <source>The value cannot be an empty string.</source>
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing OpenVsixSignTool job with {count} files.</source>
-        <target state="translated">正在对包含 {count} 个文件的 OpenVsixSignTool 作业进行签名。</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在对包含 {count} 个文件的 OpenVsixSignTool 作业进行签名。</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -4,8 +4,8 @@
     <body>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
-        <target state="translated">正在簽署具有 {count} 個檔案的 SignTool 工作。</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在簽署具有 {count} 個檔案的 SignTool 工作。</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CertificateIsExpired">
         <source>The certificate is expired.</source>
@@ -18,44 +18,44 @@
         <note>A certificate has a validity period with start and end dates.  "not yet time valid" means that the start date is in the future.</note>
       </trans-unit>
       <trans-unit id="CliStandardError">
-        <source>{fileName} Err {error}</source>
-        <target state="new">{fileName} Err {error}</target>
-        <note>{fileName} is a file name and {error} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the error {error}</source>
+        <target state="new">{fileName} returned the error {error}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="CliStandardOutput">
-        <source>{fileName} Out {output}</source>
-        <target state="new">{fileName} Out {output}</target>
-        <note>{fileName} is a file name and {output} is verbose output from a tool.  The literal text inside the brackets should not be localized.</note>
+        <source>{fileName} returned the output {output}</source>
+        <target state="new">{fileName} returned the output {output}</target>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{output}"} is verbose output from a tool.</note>
       </trans-unit>
       <trans-unit id="ClickOnceSignatureProviderSigning">
         <source>Signing Mage job with {count} files.</source>
-        <target state="translated">正在簽署具有 {count} 個檔案的 Mage 工作。</target>
-        <note>{Locked="Mage"} is another signing tool.  {count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在簽署具有 {count} 個檔案的 Mage 工作。</target>
+        <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
-        <target state="translated">正在建立目錄 {path}。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在建立目錄 {path}。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletedDirectory">
         <source>Directory {path} deleted.</source>
-        <target state="translated">已刪除目錄 {path}。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">已刪除目錄 {path}。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DeletingDirectory">
         <source>Deleting directory {path}.</source>
-        <target state="translated">正在刪除目錄 {path}。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在刪除目錄 {path}。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="DirectoryNotDeleted">
         <source>Directory {path} still exists.</source>
-        <target state="translated">目錄 {path} 仍然存在。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">目錄 {path} 仍然存在。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="EditingAppInstaller">
         <source>Editing AppInstaller job with {count} files.</source>
-        <target state="translated">正在編輯具有 {count} 個檔案的 AppInstaller 工作。</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在編輯具有 {count} 個檔案的 AppInstaller 工作。</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
       <trans-unit id="ErrorSigningVsix">
         <source>An unspecified error occurred during VSIX signing.</source>
@@ -64,13 +64,13 @@
       </trans-unit>
       <trans-unit id="ExceptionWhileDeletingDirectory">
         <source>An exception occurred while attempting to delete directory {path}.</source>
-        <target state="translated">嘗試刪除目錄 {path} 時發生例外狀況。</target>
-        <note>{path} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">嘗試刪除目錄 {path} 時發生例外狀況。</target>
+        <note>{Placeholder="{path}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="FetchedCertificate">
         <source>Fetched certificate. [{milliseconds} ms]</source>
-        <target state="translated">已擷取憑證。[{milliseconds} 毫秒]</target>
-        <note>{milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">已擷取憑證。[{milliseconds} 毫秒]</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="FetchingCertificate">
         <source>Fetching certificate from Azure Key Vault.</source>
@@ -79,48 +79,48 @@
       </trans-unit>
       <trans-unit id="OpeningContainer">
         <source>Extracting container {ContainerFilePath} to {DirectoryPath}.</source>
-        <target state="translated">正在將容器 {ContainerFilePath} 解壓縮到 {DirectoryPath}。</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在將容器 {ContainerFilePath} 解壓縮到 {DirectoryPath}。</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="ProcessCouldNotBeKilled">
         <source>{0} timed out and could not be killed.</source>
-        <target state="translated">{0} 逾時，無法終止。</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">{0} 逾時，無法終止。</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTime">
         <source>{fileName} took too long to respond. The process exit code is {exitCode}.</source>
         <target state="new">{fileName} took too long to respond. The process exit code is {exitCode}.</target>
-        <note>{fileName} is a file name and {exitCode} is a number representing the error code returned from a process.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{exitCode}"} is a number representing the error code returned from a process.</note>
       </trans-unit>
       <trans-unit id="ProcessDidNotExitInTimeWithArguments">
         <source>{0} took too long to respond. The process exit code is {1}. Arguments: {2}</source>
-        <target state="translated">{0} 的回應時間太長。處理序結束代碼為 {1}。引數: {2}</target>
-        <note>{0} is a file name.  {1} is a process exit code.  {2} is process arguments.</note>
+        <target state="needs-review-translation">{0} 的回應時間太長。處理序結束代碼為 {1}。引數: {2}</target>
+        <note>{NumberedPlaceholder="{0}"} is a file name.  {NumberedPlaceholder="{1}"} is a process exit code.  {NumberedPlaceholder="{2}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="RunningCli">
         <source>Running {fileName} with parameters: '{args}'.</source>
         <target state="new">Running {fileName} with parameters: '{args}'.</target>
-        <note>{fileName} is a file name and {args} is process arguments.  The literal text inside the brackets should not be localized.</note>
+        <note>{Placeholder="{fileName}"} is a file name, and {Placeholder="{args}"} is process arguments.</note>
       </trans-unit>
       <trans-unit id="SavingContainer">
         <source>Rebuilding container {ContainerFilePath} from {DirectoryPath}.</source>
-        <target state="translated">正在從 {DirectoryPath} 重建容器 {ContainerFilePath}。</target>
-        <note>{ContainerFilePath} is a file path and {DirectoryPath} is a directory path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在從 {DirectoryPath} 重建容器 {ContainerFilePath}。</target>
+        <note>{Placeholder="{ContainerFilePath}"} is a file path, and {Placeholder="{DirectoryPath}"} is a directory path.</note>
       </trans-unit>
       <trans-unit id="SignAsyncCalled">
         <source>SignAsync called for {filePath}. Using {localFilePath} locally.</source>
-        <target state="translated">已針對 {filePath} 呼叫 SignAsync。正在本機使用 {localFilePath}。</target>
-        <note>{filePath} and {localFilePath} are both file paths.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">已針對 {filePath} 呼叫 SignAsync。正在本機使用 {localFilePath}。</target>
+        <note>{Placeholder="{filePath}", "{localFilePath}"} are both file paths.</note>
       </trans-unit>
       <trans-unit id="SigningAttempt">
         <source>Performing attempt #{attempt} of {maxAttempts} attempts after {seconds} s.</source>
-        <target state="translated">在 {seconds} 秒後執行 {maxAttempts} 次嘗試的第 attempt #{attempt} 次嘗試。</target>
-        <note>{attempt} and {maxAttempts} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  "s" is the unit abbreviation for seconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">在 {seconds} 秒後執行 {maxAttempts} 次嘗試的第 attempt #{attempt} 次嘗試。</target>
+        <note>{Placeholder="{attempt}", "{maxAttempts}"} are numbers representing the current attempt (as a number) and the maximum allowed attempts (as a number).  {Placeholder="{seconds}"} is a decimal number representing the number of seconds elapsed, and "s" is the unit abbreviation for seconds.</note>
       </trans-unit>
       <trans-unit id="SigningFailed">
         <source>Could not sign {0}.</source>
-        <target state="translated">無法簽署 {0}。</target>
-        <note>{0} is a file path.</note>
+        <target state="needs-review-translation">無法簽署 {0}。</target>
+        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningFailedAfterAllAttempts">
         <source>Failed to sign. Attempts exceeded.</source>
@@ -129,13 +129,13 @@
       </trans-unit>
       <trans-unit id="SigningFailedWithError">
         <source>Signing failed with error {errorCode}.</source>
-        <target state="translated">簽署失敗。錯誤 {errorCode}。</target>
-        <note>{errorCode} is an error code.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">簽署失敗。錯誤 {errorCode}。</target>
+        <note>{Placeholder="{errorCode}"} is an error code.</note>
       </trans-unit>
       <trans-unit id="SigningFile">
         <source>Signing {filePath}.</source>
-        <target state="translated">正在簽署 {filePath}。</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在簽署 {filePath}。</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing succeeded.</source>
@@ -144,13 +144,13 @@
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
         <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">已成功在 {millseconds} 毫秒內簽署 {filePath}</target>
-        <note>{filePath} is a file path, {milliseconds} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">已成功在 {millseconds} 毫秒內簽署 {filePath}</target>
+        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>
-        <target state="translated">正在提交 {filePath} 進行簽署。</target>
-        <note>{filePath} is a file path.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在提交 {filePath} 進行簽署。</target>
+        <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
         <source>The value cannot be an empty string.</source>
@@ -159,8 +159,8 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing OpenVsixSignTool job with {count} files.</source>
-        <target state="translated">正在簽署具有 {count} 個檔案的 OpenVsixSignTool 工作。</target>
-        <note>{count} is the number of files to be signed.  The literal text inside the brackets should not be localized.</note>
+        <target state="needs-review-translation">正在簽署具有 {count} 個檔案的 OpenVsixSignTool 工作。</target>
+        <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/606.

This change updates resource string comments (and a couple resource strings) to have correct functional and contextual commenting.  This is necessary for localization.

CC @clairernovotny