### PR TITLE
Make successful completion message more generic 

### DIFF
--- a/src/Sign.Core/Resources.Designer.cs
+++ b/src/Sign.Core/Resources.Designer.cs
@@ -313,7 +313,7 @@ namespace Sign.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Successfully signed {filePath} in {millseconds} ms.
+        ///   Looks up a localized string similar to Completed in {millseconds} ms..
         /// </summary>
         internal static string SigningSucceededWithTimeElapsed {
             get {

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -225,8 +225,8 @@
     <value>Signing succeeded.</value>
   </data>
   <data name="SigningSucceededWithTimeElapsed" xml:space="preserve">
-    <value>Successfully signed {filePath} in {millseconds} ms</value>
-    <comment>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</comment>
+    <value>Completed in {millseconds} ms.</value>
+    <comment>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</comment>
   </data>
   <data name="SubmittingFileForSigning" xml:space="preserve">
     <value>Submitting {filePath} for signing.</value>

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -143,9 +143,9 @@
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
-        <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">Soubor {filePath} se úspěšně podepsal za {millseconds} ms.</target>
-        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
+        <source>Completed in {millseconds} ms.</source>
+        <target state="needs-review-translation">Soubor {filePath} se úspěšně podepsal za {millseconds} ms.</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -143,9 +143,9 @@
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
-        <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{filePath} wurde in {millseconds} ms erfolgreich signiert.</target>
-        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
+        <source>Completed in {millseconds} ms.</source>
+        <target state="needs-review-translation">{filePath} wurde in {millseconds} ms erfolgreich signiert.</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -143,9 +143,9 @@
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
-        <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{filePath} se firmó correctamente en {millseconds} ms</target>
-        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
+        <source>Completed in {millseconds} ms.</source>
+        <target state="needs-review-translation">{filePath} se firmó correctamente en {millseconds} ms</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -143,9 +143,9 @@
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
-        <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{filePath} signé en {millseconds} ms</target>
-        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
+        <source>Completed in {millseconds} ms.</source>
+        <target state="needs-review-translation">{filePath} signé en {millseconds} ms</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -143,9 +143,9 @@
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
-        <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{filePath} è stato firmato in {millseconds} ms</target>
-        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
+        <source>Completed in {millseconds} ms.</source>
+        <target state="needs-review-translation">{filePath} è stato firmato in {millseconds} ms</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -143,9 +143,9 @@
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
-        <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{millseconds} ミリ秒で {filePath} の署名に成功しました</target>
-        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
+        <source>Completed in {millseconds} ms.</source>
+        <target state="needs-review-translation">{millseconds} ミリ秒で {filePath} の署名に成功しました</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -143,9 +143,9 @@
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
-        <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{millseconds}ms 내에 {filePath}에 서명했습니다.</target>
-        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
+        <source>Completed in {millseconds} ms.</source>
+        <target state="needs-review-translation">{millseconds}ms 내에 {filePath}에 서명했습니다.</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -143,9 +143,9 @@
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
-        <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">Pomyślnie podpisano ścieżkę {filePath} w ciągu {millseconds} ms</target>
-        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
+        <source>Completed in {millseconds} ms.</source>
+        <target state="needs-review-translation">Pomyślnie podpisano ścieżkę {filePath} w ciągu {millseconds} ms</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -143,9 +143,9 @@
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
-        <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{filePath} autenticado com êxito em {millseconds} ms</target>
-        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
+        <source>Completed in {millseconds} ms.</source>
+        <target state="needs-review-translation">{filePath} autenticado com êxito em {millseconds} ms</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -143,9 +143,9 @@
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
-        <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">Успешно подписано {filePath} за {millseconds} мс</target>
-        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
+        <source>Completed in {millseconds} ms.</source>
+        <target state="needs-review-translation">Успешно подписано {filePath} за {millseconds} мс</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -143,9 +143,9 @@
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
-        <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">{filePath} dosya yolu {millseconds} ms içinde başarıyla imzalandı</target>
-        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
+        <source>Completed in {millseconds} ms.</source>
+        <target state="needs-review-translation">{filePath} dosya yolu {millseconds} ms içinde başarıyla imzalandı</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -143,9 +143,9 @@
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
-        <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">已成功在 {millseconds} 毫秒内对 {filePath} 进行签名</target>
-        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
+        <source>Completed in {millseconds} ms.</source>
+        <target state="needs-review-translation">已成功在 {millseconds} 毫秒内对 {filePath} 进行签名</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -143,9 +143,9 @@
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
-        <source>Successfully signed {filePath} in {millseconds} ms</source>
-        <target state="translated">已成功在 {millseconds} 毫秒內簽署 {filePath}</target>
-        <note>{Placeholder="{filePath}"} is a file path, {Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
+        <source>Completed in {millseconds} ms.</source>
+        <target state="needs-review-translation">已成功在 {millseconds} 毫秒內簽署 {filePath}</target>
+        <note>{Placeholder="{milliseconds}"} is a decimal number representing the number of milliseconds elapsed, and "ms" is the unit abbreviation for milliseconds.</note>
       </trans-unit>
       <trans-unit id="SubmittingFileForSigning">
         <source>Submitting {filePath} for signing.</source>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/564.

This change removes the input file path from the successful completion message so that the completion message is more general:  Completed in _x_ ms.

CC @clairernovotny