### PR TITLE
Add README.md to NuGet package

### DIFF
--- a/src/Sign.Cli/Sign.Cli.csproj
+++ b/src/Sign.Cli/Sign.Cli.csproj
@@ -83,6 +83,10 @@
       <Pack>true</Pack>
       <PackagePath>\</PackagePath>
     </Content>
+    <Content Include="$(RepositoryRootDirectory)\README.md">
+      <Pack>true</Pack>
+      <PackagePath>\</PackagePath>
+    </Content>
     <Content Include="$(RepositoryRootDirectory)\THIRD-PARTY-NOTICES.txt">
       <Pack>true</Pack>
       <PackagePath>\</PackagePath>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/566.

Add the repository's README.md to the NuGet package root.

CC @clairernovotny