### PR TITLE
Fix completion message

### DIFF
--- a/src/Sign.Core/Signer.cs
+++ b/src/Sign.Core/Signer.cs
@@ -160,7 +160,7 @@ namespace Sign.Core
                         fi.CopyTo(output.FullName, overwrite: true);
                     }
 
-                    _logger.LogInformation(Resources.SigningSucceededWithTimeElapsed, output.FullName, sw.ElapsedMilliseconds);
+                    _logger.LogInformation(Resources.SigningSucceededWithTimeElapsed, sw.ElapsedMilliseconds);
                 });
 
             }

--- a/test/Sign.Core.Test/SignerTests.cs
+++ b/test/Sign.Core.Test/SignerTests.cs
@@ -125,7 +125,8 @@ namespace Sign.Core.Test
         private async Task SignAsync(TemporaryDirectory temporaryDirectory, FileInfo file, FileInfo outputFile)
         {
             ServiceProvider serviceProvider = Create();
-            Signer signer = new(serviceProvider, Mock.Of<ILogger<ISigner>>());
+            TestLogger<ISigner> logger = new();
+            Signer signer = new(serviceProvider, logger);
 
             int exitCode = await signer.SignAsync(
                 new[] { file },
@@ -145,6 +146,11 @@ namespace Sign.Core.Test
                 certificateName: "c");
 
             Assert.Equal(ExitCode.Success, exitCode);
+
+            TestLogEntry lastLogEntry = logger.Entries.Last();
+
+            Assert.Equal(LogLevel.Information, lastLogEntry.LogLevel);
+            Assert.Matches(@"^Completed in \d+ ms.$", lastLogEntry.Message);
         }
 
         private static FileInfo GetTestAsset(TemporaryDirectory temporaryDirectory, string fileName)

--- a/test/Sign.Core.Test/TestInfrastructure/TestLogEntry.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/TestLogEntry.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Sign.Core.Test
+{
+    internal sealed class TestLogEntry
+    {
+        internal LogLevel LogLevel { get; }
+        internal string Message { get; }
+
+        internal TestLogEntry(LogLevel logLevel, string message)
+        {
+            LogLevel = logLevel;
+            Message = message;
+        }
+    }
+}

--- a/test/Sign.Core.Test/TestInfrastructure/TestLogger.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/TestLogger.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace Sign.Core.Test
+{
+    internal sealed class TestLogger<T> : ILogger<T>
+    {
+        private readonly ConcurrentQueue<TestLogEntry> _entries = new();
+
+        internal IEnumerable<TestLogEntry> Entries
+        {
+            get => _entries;
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            string message = formatter(state, exception);
+            TestLogEntry entry = new(logLevel, message);
+
+            _entries.Enqueue(entry);
+        }
+    }
+}


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/636.

https://github.com/dotnet/sign/pull/611 made the completion message more generic, mainly by removing the file path.  However, the change introduced a regression:  by not also removing the file path format string argument, the file path still displayed, but the completion time did not.

This change removes the file path format string argument and adds tests.

CC @clairernovotny