### PR TITLE
Rewrite ClickOnce signing to sign files directly instead of via the .clickonce zip mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,23 @@ While the current version is limited to RSA and Azure Key Vault, it is desirable
 
 - `.msi`, `.msp`, `.msm`, `.cab`, `.dll`, `.exe`, `.appx`, `.appxbundle`, `.msix`, `.msixbundle`, `.sys`, `.vxd`, `.ps1`, `.psm1`, and any portable executable (PE) file (via [AzureSignTool](https://github.com/vcsjones/AzureSignTool))
 - `.vsix` via [OpenOpcSignTool](https://github.com/vcsjones/OpenOpcSignTool)
-- ClickOnce `.application` and `.vsto` (via `Mage`). Special instructions below.
+- ClickOnce `.application` and `.vsto` (via `Mage`). Notes below.
 - `.nupkg` via [NuGetKeyVaultSignTool](https://github.com/novotnyllc/NuGetKeyVaultSignTool)
 
 ## ClickOnce
-ClickOnce files can be signed with this tool, but it requires an extra step -- you must zip up the `publish` directory containing the `setup.exe`, `foo.application` or `foo.vsto` files along with the `Application Files` directory. The `Application Files` must only have a single subdirectory (version you want to sign). Zip these and then rename the extension to `.clickonce` before submitting to the tool. Once done, you can extract the signed files wherever you'd like for publication. If the `name` parameter is supplied, it's used in the `Mage` name to update the `Product` in the manifests. If the `descriptionUrl` parameter is supplied, it's used as the `supportUrl` in the manifests.
+There are a couple of possibilities for signing ClickOnce packages.
+
+Generally you will want to sign an entire package and all its contents i.e. the deployment manifest (`.application` or `.vsto`),
+application manifest (`.exe.manifest` or `.dll.manifest`) and the underlying `.exe` and `.dll` files themselves.
+To do this, ensure that the entire contents of the package are available (i.e. the whole `publish` folder from your build) and pass
+the deployment manifest as the file to sign - the rest of the files will be detected and signed in the proper order automatically.
+
+You can also re-sign just the deployment manifest in case you want to e.g. change the Deployment URL but leave the rest of the contents the
+same. To do this, pass the deployment manifest as the file to sign as in the case above, but just don't have the rest of the files
+present on-disk alongside it. This tool will detect that they're missing and just update the signature on the deployment manifest.
+Note that this is strictly for re-signing an already-signed deployment manifest - you cannot have a signed deployment manifest that
+points to an un-signed application manifest. You must also take care to sign all manifests with the same certificate otherwise the application
+will not install.
 
 You should also use the `filter` parameter with the file list to sign, something like this:
 ```

--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -81,6 +81,15 @@ namespace Sign.Cli
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
                 }
+                
+                // this check exists as a courtesy to users who may have been signing .clickonce files via the old workaround.
+                // at some point we should remove this check, probably once we hit v1.0
+                if (fileArgument.EndsWith(".clickonce"))
+                {
+                    context.Console.Error.WriteLine(AzureKeyVaultResources.ClickOnceExtensionNotSupported);
+                    context.ExitCode = ExitCode.InvalidOptions;
+                    return;
+                }
 
                 Uri? url = context.ParseResult.GetValueForOption(UrlOption);
                 string? tenantId = context.ParseResult.GetValueForOption(TenantIdOption);

--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -84,7 +84,7 @@ namespace Sign.Cli
                 
                 // this check exists as a courtesy to users who may have been signing .clickonce files via the old workaround.
                 // at some point we should remove this check, probably once we hit v1.0
-                if (fileArgument.EndsWith(".clickonce"))
+                if (fileArgument.EndsWith(".clickonce", StringComparison.OrdinalIgnoreCase))
                 {
                     context.Console.Error.WriteLine(AzureKeyVaultResources.ClickOnceExtensionNotSupported);
                     context.ExitCode = ExitCode.InvalidOptions;

--- a/src/Sign.Cli/AzureKeyVaultResources.Designer.cs
+++ b/src/Sign.Cli/AzureKeyVaultResources.Designer.cs
@@ -70,7 +70,7 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - see the documentation..
+        ///   Looks up a localized string similar to ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation..
         /// </summary>
         internal static string ClickOnceExtensionNotSupported {
             get {

--- a/src/Sign.Cli/AzureKeyVaultResources.Designer.cs
+++ b/src/Sign.Cli/AzureKeyVaultResources.Designer.cs
@@ -70,6 +70,15 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - see the documentation..
+        /// </summary>
+        internal static string ClickOnceExtensionNotSupported {
+            get {
+                return ResourceManager.GetString("ClickOnceExtensionNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Client ID to authenticate to Azure Key Vault..
         /// </summary>
         internal static string ClientIdOptionDescription {

--- a/src/Sign.Cli/AzureKeyVaultResources.resx
+++ b/src/Sign.Cli/AzureKeyVaultResources.resx
@@ -120,6 +120,9 @@
   <data name="CertificateOptionDescription" xml:space="preserve">
     <value>Name of the certificate in Azure Key Vault.</value>
   </data>
+  <data name="ClickOnceExtensionNotSupported" xml:space="preserve">
+    <value>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - see the documentation.</value>
+  </data>
   <data name="ClientIdOptionDescription" xml:space="preserve">
     <value>Client ID to authenticate to Azure Key Vault.</value>
   </data>

--- a/src/Sign.Cli/AzureKeyVaultResources.resx
+++ b/src/Sign.Cli/AzureKeyVaultResources.resx
@@ -121,7 +121,7 @@
     <value>Name of the certificate in Azure Key Vault.</value>
   </data>
   <data name="ClickOnceExtensionNotSupported" xml:space="preserve">
-    <value>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - see the documentation.</value>
+    <value>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</value>
   </data>
   <data name="ClientIdOptionDescription" xml:space="preserve">
     <value>Client ID to authenticate to Azure Key Vault.</value>

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -115,7 +115,7 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Path to file containing paths of files to sign within an archive or ClickOnce package..
+        ///   Looks up a localized string similar to Path to file containing paths of files to sign or to exclude from signing..
         /// </summary>
         internal static string FileListOptionDescription {
             get {

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -115,7 +115,7 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Path to file containing paths of files to sign within an archive..
+        ///   Looks up a localized string similar to Path to file containing paths of files to sign within an archive or ClickOnce package..
         /// </summary>
         internal static string FileListOptionDescription {
             get {

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -137,7 +137,7 @@
     <comment>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</comment>
   </data>
   <data name="FileListOptionDescription" xml:space="preserve">
-    <value>Path to file containing paths of files to sign within an archive.</value>
+    <value>Path to file containing paths of files to sign within an archive or ClickOnce package.</value>
   </data>
   <data name="InvalidBaseDirectoryValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be a fully rooted directory path.</value>

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -137,7 +137,7 @@
     <comment>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</comment>
   </data>
   <data name="FileListOptionDescription" xml:space="preserve">
-    <value>Path to file containing paths of files to sign within an archive or ClickOnce package.</value>
+    <value>Path to file containing paths of files to sign or to exclude from signing.</value>
   </data>
   <data name="InvalidBaseDirectoryValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be a fully rooted directory path.</value>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
-        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Název certifikátu v Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClickOnceExtensionNotSupported">
+        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClientIdOptionDescription">
         <source>Client ID to authenticate to Azure Key Vault.</source>
         <target state="translated">ID klienta, které se má ověřit pro Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
-        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Name des Zertifikats in Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClickOnceExtensionNotSupported">
+        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClientIdOptionDescription">
         <source>Client ID to authenticate to Azure Key Vault.</source>
         <target state="translated">Client-ID für die Authentifizierung bei Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
-        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nombre del certificado en Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClickOnceExtensionNotSupported">
+        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClientIdOptionDescription">
         <source>Client ID to authenticate to Azure Key Vault.</source>
         <target state="translated">Id. de cliente para autenticarse en Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
-        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nom du certificat dans Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClickOnceExtensionNotSupported">
+        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClientIdOptionDescription">
         <source>Client ID to authenticate to Azure Key Vault.</source>
         <target state="translated">ID client à authentifier auprès d’Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
-        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nome del certificato in Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClickOnceExtensionNotSupported">
+        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClientIdOptionDescription">
         <source>Client ID to authenticate to Azure Key Vault.</source>
         <target state="translated">ID client da autenticare in Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
-        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Azure Key Vault 内の証明書の名前。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClickOnceExtensionNotSupported">
+        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClientIdOptionDescription">
         <source>Client ID to authenticate to Azure Key Vault.</source>
         <target state="translated">Azure Key Vault に対して認証するクライアント ID。</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Azure Key Vault의 인증서 이름입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClickOnceExtensionNotSupported">
+        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClientIdOptionDescription">
         <source>Client ID to authenticate to Azure Key Vault.</source>
         <target state="translated">Azure Key Vault에 인증하기 위한 클라이언트 ID입니다.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
-        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
-        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nazwa certyfikatu w usłudze Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClickOnceExtensionNotSupported">
+        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClientIdOptionDescription">
         <source>Client ID to authenticate to Azure Key Vault.</source>
         <target state="translated">Identyfikator klienta do uwierzytelnienia w usłudze Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
-        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nome do certificado no Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClickOnceExtensionNotSupported">
+        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClientIdOptionDescription">
         <source>Client ID to authenticate to Azure Key Vault.</source>
         <target state="translated">ID do cliente a ser autenticada no Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
-        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Имя сертификата в Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClickOnceExtensionNotSupported">
+        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClientIdOptionDescription">
         <source>Client ID to authenticate to Azure Key Vault.</source>
         <target state="translated">ИД клиента для проверки подлинности в Azure Key Vault.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
-        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Azure Key Vault’taki sertifikanın adı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClickOnceExtensionNotSupported">
+        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClientIdOptionDescription">
         <source>Client ID to authenticate to Azure Key Vault.</source>
         <target state="translated">Azure Key Vault için kimlik doğrulamak amacıyla kullanılan istemci kimliği.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Azure Key Vault 中的证书名称。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClickOnceExtensionNotSupported">
+        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClientIdOptionDescription">
         <source>Client ID to authenticate to Azure Key Vault.</source>
         <target state="translated">要向 Azure Key Vault 进行身份验证的客户端 ID。</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
-        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
-        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Azure Key Vault 中的憑證名稱。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClickOnceExtensionNotSupported">
+        <source>ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</source>
+        <target state="new">ClickOnce signing via the legacy .clickonce zip workaround is not supported anymore - pass the path to your deployment manifest directly instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClientIdOptionDescription">
         <source>Client ID to authenticate to Azure Key Vault.</source>
         <target state="translated">要向 Azure Key Vault 進行驗證的用戶端識別碼。</target>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -33,7 +33,7 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <source>Path to file containing paths of files to sign or to exclude from signing.</source>
         <target state="needs-review-translation">Cesta k souboru obsahujícímu cesty k souborům, které se mají podepsat v rámci archivu.</target>
         <note />
       </trans-unit>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -33,8 +33,8 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive.</source>
-        <target state="translated">Cesta k souboru obsahujícímu cesty k souborům, které se mají podepsat v rámci archivu.</target>
+        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <target state="needs-review-translation">Cesta k souboru obsahujícímu cesty k souborům, které se mají podepsat v rámci archivu.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -33,8 +33,8 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive.</source>
-        <target state="translated">Pfad zu einer Datei, die Pfade von Dateien enthält, die innerhalb eines Archivs signiert werden sollen.</target>
+        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <target state="needs-review-translation">Pfad zu einer Datei, die Pfade von Dateien enthält, die innerhalb eines Archivs signiert werden sollen.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -33,7 +33,7 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <source>Path to file containing paths of files to sign or to exclude from signing.</source>
         <target state="needs-review-translation">Pfad zu einer Datei, die Pfade von Dateien enthält, die innerhalb eines Archivs signiert werden sollen.</target>
         <note />
       </trans-unit>

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -33,7 +33,7 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <source>Path to file containing paths of files to sign or to exclude from signing.</source>
         <target state="needs-review-translation">Ruta de acceso al archivo que contiene las rutas de acceso de los archivos que se van a firmar dentro de un archivo.</target>
         <note />
       </trans-unit>

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -33,8 +33,8 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive.</source>
-        <target state="translated">Ruta de acceso al archivo que contiene las rutas de acceso de los archivos que se van a firmar dentro de un archivo.</target>
+        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <target state="needs-review-translation">Ruta de acceso al archivo que contiene las rutas de acceso de los archivos que se van a firmar dentro de un archivo.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -33,8 +33,8 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive.</source>
-        <target state="translated">Chemin d’accès au fichier contenant les chemins d’accès des fichiers à signer dans une archive.</target>
+        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <target state="needs-review-translation">Chemin d’accès au fichier contenant les chemins d’accès des fichiers à signer dans une archive.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -33,7 +33,7 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <source>Path to file containing paths of files to sign or to exclude from signing.</source>
         <target state="needs-review-translation">Chemin d’accès au fichier contenant les chemins d’accès des fichiers à signer dans une archive.</target>
         <note />
       </trans-unit>

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -33,7 +33,7 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <source>Path to file containing paths of files to sign or to exclude from signing.</source>
         <target state="needs-review-translation">Percorso del file contenente i percorsi dei file da firmare all'interno di un archivio.</target>
         <note />
       </trans-unit>

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -33,8 +33,8 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive.</source>
-        <target state="translated">Percorso del file contenente i percorsi dei file da firmare all'interno di un archivio.</target>
+        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <target state="needs-review-translation">Percorso del file contenente i percorsi dei file da firmare all'interno di un archivio.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -33,8 +33,8 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive.</source>
-        <target state="translated">アーカイブ内の署名するファイルのパスを含むファイルへのパス。</target>
+        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <target state="needs-review-translation">アーカイブ内の署名するファイルのパスを含むファイルへのパス。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -33,7 +33,7 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <source>Path to file containing paths of files to sign or to exclude from signing.</source>
         <target state="needs-review-translation">アーカイブ内の署名するファイルのパスを含むファイルへのパス。</target>
         <note />
       </trans-unit>

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -33,8 +33,8 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive.</source>
-        <target state="translated">보관함 내에서 서명할 파일의 경로를 포함하는 파일 경로입니다.</target>
+        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <target state="needs-review-translation">보관함 내에서 서명할 파일의 경로를 포함하는 파일 경로입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -33,7 +33,7 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <source>Path to file containing paths of files to sign or to exclude from signing.</source>
         <target state="needs-review-translation">보관함 내에서 서명할 파일의 경로를 포함하는 파일 경로입니다.</target>
         <note />
       </trans-unit>

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -33,8 +33,8 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive.</source>
-        <target state="translated">Ścieżka do pliku zawierającego ścieżki plików do podpisania w archiwum.</target>
+        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <target state="needs-review-translation">Ścieżka do pliku zawierającego ścieżki plików do podpisania w archiwum.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -33,7 +33,7 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <source>Path to file containing paths of files to sign or to exclude from signing.</source>
         <target state="needs-review-translation">Ścieżka do pliku zawierającego ścieżki plików do podpisania w archiwum.</target>
         <note />
       </trans-unit>

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive.</source>
-        <target state="translated">Caminho para o arquivo contendo caminhos de arquivos para autenticar uma camada de arquivos.</target>
+        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <target state="needs-review-translation">Caminho para o arquivo contendo caminhos de arquivos para autenticar uma camada de arquivos.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -33,7 +33,7 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <source>Path to file containing paths of files to sign or to exclude from signing.</source>
         <target state="needs-review-translation">Caminho para o arquivo contendo caminhos de arquivos para autenticar uma camada de arquivos.</target>
         <note />
       </trans-unit>

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -33,7 +33,7 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <source>Path to file containing paths of files to sign or to exclude from signing.</source>
         <target state="needs-review-translation">Путь к файлу, содержащему пути к файлам для подписи в архиве.</target>
         <note />
       </trans-unit>

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -33,8 +33,8 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive.</source>
-        <target state="translated">Путь к файлу, содержащему пути к файлам для подписи в архиве.</target>
+        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <target state="needs-review-translation">Путь к файлу, содержащему пути к файлам для подписи в архиве.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -33,7 +33,7 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <source>Path to file containing paths of files to sign or to exclude from signing.</source>
         <target state="needs-review-translation">Bir arşivde imzalanacak dosyaların yollarını içeren dosya yolu.</target>
         <note />
       </trans-unit>

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -33,8 +33,8 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive.</source>
-        <target state="translated">Bir arşivde imzalanacak dosyaların yollarını içeren dosya yolu.</target>
+        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <target state="needs-review-translation">Bir arşivde imzalanacak dosyaların yollarını içeren dosya yolu.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -33,7 +33,7 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <source>Path to file containing paths of files to sign or to exclude from signing.</source>
         <target state="needs-review-translation">文件的路径，包含存档中要签名的文件的路径。</target>
         <note />
       </trans-unit>

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive.</source>
-        <target state="translated">文件的路径，包含存档中要签名的文件的路径。</target>
+        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <target state="needs-review-translation">文件的路径，包含存档中要签名的文件的路径。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive.</source>
-        <target state="translated">檔案路徑，包含要在封存內簽署的檔案路徑。</target>
+        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <target state="needs-review-translation">檔案路徑，包含要在封存內簽署的檔案路徑。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -33,7 +33,7 @@
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.</note>
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
-        <source>Path to file containing paths of files to sign within an archive or ClickOnce package.</source>
+        <source>Path to file containing paths of files to sign or to exclude from signing.</source>
         <target state="needs-review-translation">檔案路徑，包含要在封存內簽署的檔案路徑。</target>
         <note />
       </trans-unit>

--- a/src/Sign.Core/Resources.Designer.cs
+++ b/src/Sign.Core/Resources.Designer.cs
@@ -304,7 +304,7 @@ namespace Sign.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Signing succeeded..
+        ///   Looks up a localized string similar to Signing {filePath} succeeded..
         /// </summary>
         internal static string SigningSucceeded {
             get {

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -222,7 +222,7 @@
     <comment>{Placeholder="{filePath}"} is a file path.</comment>
   </data>
   <data name="SigningSucceeded" xml:space="preserve">
-    <value>Signing succeeded.</value>
+    <value>Signing {filePath} succeeded.</value>
   </data>
   <data name="SigningSucceededWithTimeElapsed" xml:space="preserve">
     <value>Completed in {millseconds} ms.</value>

--- a/src/Sign.Core/SignatureProviders/AggregatingSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/AggregatingSignatureProvider.cs
@@ -204,6 +204,18 @@ namespace Sign.Core
             await Task.WhenAll(grouped.Select(g => g.Key.SignAsync(g.ToList(), options)));
         }
 
+        public void CopySigningDependencies(FileInfo file, DirectoryInfo destination, SignOptions options)
+        {
+            // pass the handling for this down to the actual implementations
+            foreach (ISignatureProvider signatureProvider in _signatureProviders)
+            {
+                if (signatureProvider.CanSign(file))
+                {
+                    signatureProvider.CopySigningDependencies(file, destination, options);
+                }
+            }
+        }
+
         private static IEnumerable<FileInfo> GetFiles(IContainer container, SignOptions options)
         {
             IEnumerable<FileInfo> files;

--- a/src/Sign.Core/SignatureProviders/AzureSignToolSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/AzureSignToolSignatureProvider.cs
@@ -176,7 +176,7 @@ namespace Sign.Core
 
             if (success)
             {
-                _logger.LogInformation(Resources.SigningSucceeded);
+                _logger.LogInformation(Resources.SigningSucceeded, file.FullName);
                 return true;
             }
 

--- a/src/Sign.Core/SignatureProviders/ClickOnceSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/ClickOnceSignatureProvider.cs
@@ -91,7 +91,7 @@ namespace Sign.Core
                     // finally the top-level clickonce/vsto file
                     // It's possible that there might not actually be a .manifest file or any data files if the user just
                     // wants to re-sign an existing deployment manifest because e.g. the update URL has changed but nothing
-                    // else. In that case we don't need to touch the other files and we can just sign the deployment manifest.
+                    // else has. In that case we don't need to touch the other files and we can just sign the deployment manifest.
 
                     // Look for the data files first - these are .deploy files
                     // we need to rename them, sign, then restore the name

--- a/src/Sign.Core/SignatureProviders/ClickOnceSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/ClickOnceSignatureProvider.cs
@@ -145,18 +145,10 @@ namespace Sign.Core
 
                     if (string.IsNullOrEmpty(options.PublisherName))
                     {
-                        // Read the publisher name from the manifest for use below
-                        XDocument manifestDoc = XDocument.Load(manifestFile.FullName);
-                        XNamespace ns = manifestDoc.Root!.GetDefaultNamespace();
-                        XElement? publisherIdentity = manifestDoc.Root.Element(ns + "publisherIdentity");
-                        string publisherName = publisherIdentity!.Attribute("name")!.Value;
-                        Dictionary<string, List<string>> dict = DistinguishedNameParser.Parse(publisherName);
+                        string publisherName = certificate.SubjectName.Name;
  
-                        if (dict.TryGetValue("CN", out List<string>? cns))
-                        {
-                            // get the CN. it may be quoted
-                            publisherParam = $@"-pub ""{string.Join("+", cns.Select(s => s.Replace("\"", "")))}"" ";
-                        }
+                        // get the DN. it may be quoted
+                        publisherParam = $@"-pub ""{publisherName.Replace("\"", "")}"" ";
                     }
                     else
                     {

--- a/src/Sign.Core/SignatureProviders/ClickOnceSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/ClickOnceSignatureProvider.cs
@@ -15,7 +15,6 @@ namespace Sign.Core
     internal sealed class ClickOnceSignatureProvider : RetryingSignatureProvider, ISignatureProvider
     {
         private readonly Lazy<IAggregatingSignatureProvider> _aggregatingSignatureProvider;
-        private readonly IContainerProvider _containerProvider;
         private readonly IDirectoryService _directoryService;
         private readonly ICertificateProvider _certificateProvider;
         private readonly ISignatureAlgorithmProvider _signatureAlgorithmProvider;
@@ -28,7 +27,6 @@ namespace Sign.Core
         public ClickOnceSignatureProvider(
             ISignatureAlgorithmProvider signatureAlgorithmProvider,
             ICertificateProvider certificateProvider,
-            IContainerProvider containerProvider,
             IServiceProvider serviceProvider,
             IDirectoryService directoryService,
             IMageCli mageCli,
@@ -39,7 +37,6 @@ namespace Sign.Core
         {
             ArgumentNullException.ThrowIfNull(signatureAlgorithmProvider, nameof(signatureAlgorithmProvider));
             ArgumentNullException.ThrowIfNull(certificateProvider, nameof(certificateProvider));
-            ArgumentNullException.ThrowIfNull(containerProvider, nameof(containerProvider));
             ArgumentNullException.ThrowIfNull(serviceProvider, nameof(serviceProvider));
             ArgumentNullException.ThrowIfNull(directoryService, nameof(directoryService));
             ArgumentNullException.ThrowIfNull(mageCli, nameof(mageCli));
@@ -47,7 +44,6 @@ namespace Sign.Core
 
             _signatureAlgorithmProvider = signatureAlgorithmProvider;
             _certificateProvider = certificateProvider;
-            _containerProvider = containerProvider;
             _directoryService = directoryService;
             _mageCli = mageCli;
             _manifestSigner = manifestSigner;

--- a/src/Sign.Core/SignatureProviders/ISignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/ISignatureProvider.cs
@@ -8,5 +8,10 @@ namespace Sign.Core
     {
         bool CanSign(FileInfo file);
         Task SignAsync(IEnumerable<FileInfo> files, SignOptions options);
+        // Some signature mechanisms (e.g. ClickOnce) require extra files alongside the main file to be signed.
+        // We can't rely on the user specifying everything (and even if we did, we sign all inputs in parallel
+        // so we'd have to add extra synchronisation) so this method instructs an implementation to grab all
+        // dependencies of a file and copy them to the specified directory.
+        void CopySigningDependencies(FileInfo file, DirectoryInfo destination, SignOptions options) { }
     }
 }

--- a/src/Sign.Core/SignatureProviders/RetryingSignatureProvider.cs
+++ b/src/Sign.Core/SignatureProviders/RetryingSignatureProvider.cs
@@ -39,7 +39,7 @@ namespace Sign.Core
 
                 if (await SignCoreAsync(args, file, rsaPrivateKey, publicCertificate, options))
                 {
-                    Logger.LogInformation(Resources.SigningSucceeded);
+                    Logger.LogInformation(Resources.SigningSucceeded, file.FullName);
                     return true;
                 }
 

--- a/src/Sign.Core/Signer.cs
+++ b/src/Sign.Core/Signer.cs
@@ -146,13 +146,18 @@ namespace Sign.Core
                         if (input.Length > 0)
                         {
                             input.CopyTo(inputFileName, overwrite: true);
+                            // for things like clickonce we will need additional files from the source location
+                            // in order to fully sign everything, so ask the signature provider to do it for us.
+                            signatureProvider.CopySigningDependencies(input, temporaryDirectory.Directory, signOptions);
                         }
 
                         FileInfo fi = new(inputFileName);
 
                         await signatureProvider.SignAsync(new[] { fi }, signOptions);
 
+                        // copy everything back
                         fi.CopyTo(output.FullName, overwrite: true);
+                        signatureProvider.CopySigningDependencies(fi, output.Directory!, signOptions);
                     }
 
                     _logger.LogInformation(Resources.SigningSucceededWithTimeElapsed, sw.ElapsedMilliseconds);

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -138,8 +138,8 @@
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
-        <source>Signing succeeded.</source>
-        <target state="translated">Podepisování proběhlo úspěšně.</target>
+        <source>Signing {filePath} succeeded.</source>
+        <target state="needs-review-translation">Podepisování proběhlo úspěšně.</target>
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -138,8 +138,8 @@
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
-        <source>Signing succeeded.</source>
-        <target state="translated">Das Signieren war erfolgreich.</target>
+        <source>Signing {filePath} succeeded.</source>
+        <target state="needs-review-translation">Das Signieren war erfolgreich.</target>
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -138,8 +138,8 @@
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
-        <source>Signing succeeded.</source>
-        <target state="translated">La firma se realizó correctamente.</target>
+        <source>Signing {filePath} succeeded.</source>
+        <target state="needs-review-translation">La firma se realizó correctamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -138,8 +138,8 @@
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
-        <source>Signing succeeded.</source>
-        <target state="translated">Signature réussie.</target>
+        <source>Signing {filePath} succeeded.</source>
+        <target state="needs-review-translation">Signature réussie.</target>
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -138,8 +138,8 @@
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
-        <source>Signing succeeded.</source>
-        <target state="translated">La firma è riuscita.</target>
+        <source>Signing {filePath} succeeded.</source>
+        <target state="needs-review-translation">La firma è riuscita.</target>
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -138,8 +138,8 @@
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
-        <source>Signing succeeded.</source>
-        <target state="translated">署名に成功しました。</target>
+        <source>Signing {filePath} succeeded.</source>
+        <target state="needs-review-translation">署名に成功しました。</target>
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -138,8 +138,8 @@
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
-        <source>Signing succeeded.</source>
-        <target state="translated">서명에 성공했습니다.</target>
+        <source>Signing {filePath} succeeded.</source>
+        <target state="needs-review-translation">서명에 성공했습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -138,8 +138,8 @@
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
-        <source>Signing succeeded.</source>
-        <target state="translated">Podpisywanie powiodło się.</target>
+        <source>Signing {filePath} succeeded.</source>
+        <target state="needs-review-translation">Podpisywanie powiodło się.</target>
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -138,8 +138,8 @@
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
-        <source>Signing succeeded.</source>
-        <target state="translated">Autenticação bem-sucedida.</target>
+        <source>Signing {filePath} succeeded.</source>
+        <target state="needs-review-translation">Autenticação bem-sucedida.</target>
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -138,8 +138,8 @@
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
-        <source>Signing succeeded.</source>
-        <target state="translated">Подписывание выполнено успешно.</target>
+        <source>Signing {filePath} succeeded.</source>
+        <target state="needs-review-translation">Подписывание выполнено успешно.</target>
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -138,8 +138,8 @@
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
-        <source>Signing succeeded.</source>
-        <target state="translated">İmzalama başarılı oldu.</target>
+        <source>Signing {filePath} succeeded.</source>
+        <target state="needs-review-translation">İmzalama başarılı oldu.</target>
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -138,8 +138,8 @@
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
-        <source>Signing succeeded.</source>
-        <target state="translated">签名成功。</target>
+        <source>Signing {filePath} succeeded.</source>
+        <target state="needs-review-translation">签名成功。</target>
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -138,8 +138,8 @@
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceeded">
-        <source>Signing succeeded.</source>
-        <target state="translated">簽署成功。</target>
+        <source>Signing {filePath} succeeded.</source>
+        <target state="needs-review-translation">簽署成功。</target>
         <note />
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">

--- a/test/Sign.Core.Test/SignatureProviders/AggregatingSignatureProviderTests.Containers.cs
+++ b/test/Sign.Core.Test/SignatureProviders/AggregatingSignatureProviderTests.Containers.cs
@@ -164,7 +164,6 @@ namespace Sign.Core.Test
                 $"{AppxContainerName}/nestedcontainer0.zip/b.dll",
                 $"{AppxContainerName}/nestedcontainer0.zip/nestedcontainer1.zip/c.dll",
                 $"{AppxContainerName}/d.appinstaller",
-                $"{AppxContainerName}/e.clickonce",
                 $"{AppxContainerName}/nestedcontainer.nupkg/folder0/folder1/f.dll",
                 $"{AppxContainerName}/nestedcontainer.vsix/folder0/folder1/folder2/g.dll");
 
@@ -196,7 +195,6 @@ namespace Sign.Core.Test
                 signedFile => Assert.Equal("g.dll", signedFile.Name),
                 signedFile => Assert.Equal("a.dll", signedFile.Name),
                 signedFile => Assert.Equal("d.appinstaller", signedFile.Name),
-                signedFile => Assert.Equal("e.clickonce", signedFile.Name),
                 signedFile => Assert.Equal("nestedcontainer.nupkg", signedFile.Name),
                 signedFile => Assert.Equal("nestedcontainer.vsix", signedFile.Name),
                 signedFile => Assert.Equal("container.appx", signedFile.Name));
@@ -309,7 +307,6 @@ namespace Sign.Core.Test
                 $"{ZipContainerName}/nestedcontainer0.zip/b.dll",
                 $"{ZipContainerName}/nestedcontainer0.zip/nestedcontainer1.zip/c.dll",
                 $"{ZipContainerName}/d.appinstaller",
-                $"{ZipContainerName}/e.clickonce",
                 $"{ZipContainerName}/nestedcontainer.nupkg/folder0/folder1/f.dll",
                 $"{ZipContainerName}/nestedcontainer.vsix/folder0/folder1/folder2/g.dll");
 
@@ -341,7 +338,6 @@ namespace Sign.Core.Test
                 signedFile => Assert.Equal("g.dll", signedFile.Name),
                 signedFile => Assert.Equal("a.dll", signedFile.Name),
                 signedFile => Assert.Equal("d.appinstaller", signedFile.Name),
-                signedFile => Assert.Equal("e.clickonce", signedFile.Name),
                 signedFile => Assert.Equal("nestedcontainer.nupkg", signedFile.Name),
                 signedFile => Assert.Equal("nestedcontainer.vsix", signedFile.Name));
         }

--- a/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
@@ -312,7 +312,7 @@ namespace Sign.Core.Test
 
                     if (string.IsNullOrEmpty(options.PublisherName))
                     {
-                        publisher = commonName;
+                        publisher = certificate.SubjectName.Name;
                     }
                     else
                     {

--- a/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
@@ -20,7 +20,6 @@ namespace Sign.Core.Test
                 Mock.Of<ISignatureAlgorithmProvider>(),
                 Mock.Of<ICertificateProvider>(),
                 Mock.Of<IServiceProvider>(),
-                Mock.Of<IDirectoryService>(),
                 Mock.Of<IMageCli>(),
                 Mock.Of<IManifestSigner>(),
                 Mock.Of<ILogger<ISignatureProvider>>(),
@@ -40,7 +39,6 @@ namespace Sign.Core.Test
                     signatureAlgorithmProvider: null!,
                     Mock.Of<ICertificateProvider>(),
                     Mock.Of<IServiceProvider>(),
-                    Mock.Of<IDirectoryService>(),
                     Mock.Of<IMageCli>(),
                     Mock.Of<IManifestSigner>(),
                     Mock.Of<ILogger<ISignatureProvider>>(),
@@ -57,7 +55,6 @@ namespace Sign.Core.Test
                     Mock.Of<ISignatureAlgorithmProvider>(),
                     certificateProvider: null!,
                     Mock.Of<IServiceProvider>(),
-                    Mock.Of<IDirectoryService>(),
                     Mock.Of<IMageCli>(),
                     Mock.Of<IManifestSigner>(),
                     Mock.Of<ILogger<ISignatureProvider>>(),
@@ -74,30 +71,12 @@ namespace Sign.Core.Test
                     Mock.Of<ISignatureAlgorithmProvider>(),
                     Mock.Of<ICertificateProvider>(),
                     serviceProvider: null!,
-                    Mock.Of<IDirectoryService>(),
                     Mock.Of<IMageCli>(),
                     Mock.Of<IManifestSigner>(),
                     Mock.Of<ILogger<ISignatureProvider>>(),
                     Mock.Of<IFileMatcher>()));
 
             Assert.Equal("serviceProvider", exception.ParamName);
-        }
-
-        [Fact]
-        public void Constructor_WhenDirectoryServiceIsNull_Throws()
-        {
-            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new ClickOnceSignatureProvider(
-                    Mock.Of<ISignatureAlgorithmProvider>(),
-                    Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IServiceProvider>(),
-                    directoryService: null!,
-                    Mock.Of<IMageCli>(),
-                    Mock.Of<IManifestSigner>(),
-                    Mock.Of<ILogger<ISignatureProvider>>(),
-                    Mock.Of<IFileMatcher>()));
-
-            Assert.Equal("directoryService", exception.ParamName);
         }
 
         [Fact]
@@ -108,7 +87,6 @@ namespace Sign.Core.Test
                     Mock.Of<ISignatureAlgorithmProvider>(),
                     Mock.Of<ICertificateProvider>(),
                     Mock.Of<IServiceProvider>(),
-                    Mock.Of<IDirectoryService>(),
                     mageCli: null!,
                     Mock.Of<IManifestSigner>(),
                     Mock.Of<ILogger<ISignatureProvider>>(),
@@ -125,7 +103,6 @@ namespace Sign.Core.Test
                     Mock.Of<ISignatureAlgorithmProvider>(),
                     Mock.Of<ICertificateProvider>(),
                     Mock.Of<IServiceProvider>(),
-                    Mock.Of<IDirectoryService>(),
                     Mock.Of<IMageCli>(),
                     manifestSigner: null!,
                     Mock.Of<ILogger<ISignatureProvider>>(),
@@ -142,13 +119,28 @@ namespace Sign.Core.Test
                     Mock.Of<ISignatureAlgorithmProvider>(),
                     Mock.Of<ICertificateProvider>(),
                     Mock.Of<IServiceProvider>(),
-                    Mock.Of<IDirectoryService>(),
                     Mock.Of<IMageCli>(),
                     Mock.Of<IManifestSigner>(),
                     logger: null!,
                     Mock.Of<IFileMatcher>()));
 
             Assert.Equal("logger", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenFileMatcherIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new ClickOnceSignatureProvider(
+                    Mock.Of<ISignatureAlgorithmProvider>(),
+                    Mock.Of<ICertificateProvider>(),
+                    Mock.Of<IServiceProvider>(),
+                    Mock.Of<IMageCli>(),
+                    Mock.Of<IManifestSigner>(),
+                    Mock.Of<ILogger<ISignatureProvider>>(),
+                    fileMatcher: null!));
+
+            Assert.Equal("fileMatcher", exception.ParamName);
         }
 
         [Fact]
@@ -279,7 +271,6 @@ namespace Sign.Core.Test
                     serviceProvider.Setup(x => x.GetService(It.IsAny<Type>()))
                         .Returns(aggregatingSignatureProviderSpy);
 
-                    IDirectoryService directoryService = Mock.Of<IDirectoryService>();
                     Mock<IMageCli> mageCli = new();
                     string expectedArgs = $"-update \"{manifestFile.FullName}\" -a sha256RSA -n \"{options.ApplicationName}\"";
                     mageCli.Setup(x => x.RunAsync(
@@ -324,7 +315,6 @@ namespace Sign.Core.Test
                         signatureAlgorithmProvider.Object,
                         certificateProvider.Object,
                         serviceProvider.Object,
-                        directoryService,
                         mageCli.Object,
                         manifestSigner.Object,
                         logger,
@@ -377,7 +367,6 @@ namespace Sign.Core.Test
                     string.Empty,
                     "MyApp.application");
 
-
                 SignOptions options = new(
                     "ApplicationName",
                     "PublisherName",
@@ -407,7 +396,6 @@ namespace Sign.Core.Test
                     serviceProvider.Setup(x => x.GetService(It.IsAny<Type>()))
                         .Returns(aggregatingSignatureProviderSpy);
 
-                    IDirectoryService directoryService = Mock.Of<IDirectoryService>();
                     Mock<IMageCli> mageCli = new();
 
                     string publisher;
@@ -441,7 +429,6 @@ namespace Sign.Core.Test
                         signatureAlgorithmProvider.Object,
                         certificateProvider.Object,
                         serviceProvider.Object,
-                        directoryService,
                         mageCli.Object,
                         manifestSigner.Object,
                         logger,
@@ -506,7 +493,6 @@ namespace Sign.Core.Test
                     serviceProvider.Setup(x => x.GetService(It.IsAny<Type>()))
                         .Returns(aggregatingSignatureProviderSpy);
 
-                    IDirectoryService directoryService = Mock.Of<IDirectoryService>();
                     Mock<IMageCli> mageCli = new();
                     string publisher = certificate.SubjectName.Name;
 
@@ -537,7 +523,6 @@ namespace Sign.Core.Test
                         signatureAlgorithmProvider.Object,
                         certificateProvider.Object,
                         serviceProvider.Object,
-                        directoryService,
                         mageCli.Object,
                         manifestSigner.Object,
                         logger,
@@ -551,8 +536,8 @@ namespace Sign.Core.Test
                         // tell the provider to copy what it needs into the signing directory
                         provider.CopySigningDependencies(applicationFile, signingDirectory.Directory, options);
                         // and make sure we got it. We expect only the DLL to be copied, and NOT the .application file itself.
-                        var copiedFiles = signingDirectory.Directory.EnumerateFiles("*", SearchOption.AllDirectories);
-                        var copiedDirectories = signingDirectory.Directory.EnumerateDirectories();
+                        IEnumerable<FileInfo> copiedFiles = signingDirectory.Directory.EnumerateFiles("*", SearchOption.AllDirectories);
+                        IEnumerable<DirectoryInfo> copiedDirectories = signingDirectory.Directory.EnumerateDirectories();
                         Assert.Single(copiedFiles);
                         Assert.Single(copiedDirectories);
                         Assert.Contains(copiedDirectories, d => d.Name == "MyApp_1_0_0_0");

--- a/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
@@ -178,8 +178,9 @@ namespace Sign.Core.Test
         }
 
         [Theory]
-        [InlineData(".clickonce")]
-        [InlineData(".CLICKONCE")] // test case insensitivity
+        [InlineData(".application")]
+        [InlineData(".APPLICATION")] // test case insensitivity
+        [InlineData(".vsto")]
         public void CanSign_WhenFileExtensionMatches_ReturnsTrue(string extension)
         {
             FileInfo file = new($"file{extension}");
@@ -189,8 +190,8 @@ namespace Sign.Core.Test
 
         [Theory]
         [InlineData(".txt")]
-        [InlineData(".clİckonce")] // Turkish İ (U+0130)
-        [InlineData(".clıckonce")] // Turkish ı (U+0131)
+        [InlineData(".applİcation")] // Turkish İ (U+0130)
+        [InlineData(".applıcation")] // Turkish ı (U+0131)
         public void CanSign_WhenFileExtensionDoesNotMatch_ReturnsFalse(string extension)
         {
             FileInfo file = new($"file{extension}");

--- a/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
@@ -19,12 +19,12 @@ namespace Sign.Core.Test
             _provider = new ClickOnceSignatureProvider(
                 Mock.Of<ISignatureAlgorithmProvider>(),
                 Mock.Of<ICertificateProvider>(),
-                Mock.Of<IContainerProvider>(),
                 Mock.Of<IServiceProvider>(),
                 Mock.Of<IDirectoryService>(),
                 Mock.Of<IMageCli>(),
                 Mock.Of<IManifestSigner>(),
-                Mock.Of<ILogger<ISignatureProvider>>());
+                Mock.Of<ILogger<ISignatureProvider>>(),
+                Mock.Of<IFileMatcher>());
         }
 
         public void Dispose()
@@ -39,12 +39,12 @@ namespace Sign.Core.Test
                 () => new ClickOnceSignatureProvider(
                     signatureAlgorithmProvider: null!,
                     Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IContainerProvider>(),
                     Mock.Of<IServiceProvider>(),
                     Mock.Of<IDirectoryService>(),
                     Mock.Of<IMageCli>(),
                     Mock.Of<IManifestSigner>(),
-                    Mock.Of<ILogger<ISignatureProvider>>()));
+                    Mock.Of<ILogger<ISignatureProvider>>(),
+                    Mock.Of<IFileMatcher>()));
 
             Assert.Equal("signatureAlgorithmProvider", exception.ParamName);
         }
@@ -56,31 +56,14 @@ namespace Sign.Core.Test
                 () => new ClickOnceSignatureProvider(
                     Mock.Of<ISignatureAlgorithmProvider>(),
                     certificateProvider: null!,
-                    Mock.Of<IContainerProvider>(),
                     Mock.Of<IServiceProvider>(),
                     Mock.Of<IDirectoryService>(),
                     Mock.Of<IMageCli>(),
                     Mock.Of<IManifestSigner>(),
-                    Mock.Of<ILogger<ISignatureProvider>>()));
+                    Mock.Of<ILogger<ISignatureProvider>>(),
+                    Mock.Of<IFileMatcher>()));
 
             Assert.Equal("certificateProvider", exception.ParamName);
-        }
-
-        [Fact]
-        public void Constructor_WhenContainerProviderIsNull_Throws()
-        {
-            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new ClickOnceSignatureProvider(
-                    Mock.Of<ISignatureAlgorithmProvider>(),
-                    Mock.Of<ICertificateProvider>(),
-                    containerProvider: null!,
-                    Mock.Of<IServiceProvider>(),
-                    Mock.Of<IDirectoryService>(),
-                    Mock.Of<IMageCli>(),
-                    Mock.Of<IManifestSigner>(),
-                    Mock.Of<ILogger<ISignatureProvider>>()));
-
-            Assert.Equal("containerProvider", exception.ParamName);
         }
 
         [Fact]
@@ -90,12 +73,12 @@ namespace Sign.Core.Test
                 () => new ClickOnceSignatureProvider(
                     Mock.Of<ISignatureAlgorithmProvider>(),
                     Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IContainerProvider>(),
                     serviceProvider: null!,
                     Mock.Of<IDirectoryService>(),
                     Mock.Of<IMageCli>(),
                     Mock.Of<IManifestSigner>(),
-                    Mock.Of<ILogger<ISignatureProvider>>()));
+                    Mock.Of<ILogger<ISignatureProvider>>(),
+                    Mock.Of<IFileMatcher>()));
 
             Assert.Equal("serviceProvider", exception.ParamName);
         }
@@ -107,12 +90,12 @@ namespace Sign.Core.Test
                 () => new ClickOnceSignatureProvider(
                     Mock.Of<ISignatureAlgorithmProvider>(),
                     Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IContainerProvider>(),
                     Mock.Of<IServiceProvider>(),
                     directoryService: null!,
                     Mock.Of<IMageCli>(),
                     Mock.Of<IManifestSigner>(),
-                    Mock.Of<ILogger<ISignatureProvider>>()));
+                    Mock.Of<ILogger<ISignatureProvider>>(),
+                    Mock.Of<IFileMatcher>()));
 
             Assert.Equal("directoryService", exception.ParamName);
         }
@@ -124,12 +107,12 @@ namespace Sign.Core.Test
                 () => new ClickOnceSignatureProvider(
                     Mock.Of<ISignatureAlgorithmProvider>(),
                     Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IContainerProvider>(),
                     Mock.Of<IServiceProvider>(),
                     Mock.Of<IDirectoryService>(),
                     mageCli: null!,
                     Mock.Of<IManifestSigner>(),
-                    Mock.Of<ILogger<ISignatureProvider>>()));
+                    Mock.Of<ILogger<ISignatureProvider>>(),
+                    Mock.Of<IFileMatcher>()));
 
             Assert.Equal("mageCli", exception.ParamName);
         }
@@ -141,12 +124,12 @@ namespace Sign.Core.Test
                 () => new ClickOnceSignatureProvider(
                     Mock.Of<ISignatureAlgorithmProvider>(),
                     Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IContainerProvider>(),
                     Mock.Of<IServiceProvider>(),
                     Mock.Of<IDirectoryService>(),
                     Mock.Of<IMageCli>(),
                     manifestSigner: null!,
-                    Mock.Of<ILogger<ISignatureProvider>>()));
+                    Mock.Of<ILogger<ISignatureProvider>>(),
+                    Mock.Of<IFileMatcher>()));
 
             Assert.Equal("manifestSigner", exception.ParamName);
         }
@@ -158,12 +141,12 @@ namespace Sign.Core.Test
                 () => new ClickOnceSignatureProvider(
                     Mock.Of<ISignatureAlgorithmProvider>(),
                     Mock.Of<ICertificateProvider>(),
-                    Mock.Of<IContainerProvider>(),
                     Mock.Of<IServiceProvider>(),
                     Mock.Of<IDirectoryService>(),
                     Mock.Of<IMageCli>(),
                     Mock.Of<IManifestSigner>(),
-                    logger: null!));
+                    logger: null!,
+                    Mock.Of<IFileMatcher>()));
 
             Assert.Equal("logger", exception.ParamName);
         }
@@ -290,11 +273,6 @@ namespace Sign.Core.Test
                     signatureAlgorithmProvider.Setup(x => x.GetRsaAsync(It.IsAny<CancellationToken>()))
                         .ReturnsAsync(privateKey);
 
-                    Mock<IContainerProvider> containerProvider = new();
-
-                    containerProvider.Setup(x => x.GetContainer(It.IsAny<FileInfo>()))
-                        .Returns(containerSpy);
-
                     Mock<IServiceProvider> serviceProvider = new();
                     AggregatingSignatureProviderSpy aggregatingSignatureProviderSpy = new();
 
@@ -325,6 +303,7 @@ namespace Sign.Core.Test
                         .ReturnsAsync(0);
 
                     Mock<IManifestSigner> manifestSigner = new();
+                    Mock<IFileMatcher> fileMatcher = new();
 
                     manifestSigner.Setup(
                         x => x.Sign(
@@ -344,20 +323,14 @@ namespace Sign.Core.Test
                     ClickOnceSignatureProvider provider = new(
                         signatureAlgorithmProvider.Object,
                         certificateProvider.Object,
-                        containerProvider.Object,
                         serviceProvider.Object,
                         directoryService,
                         mageCli.Object,
                         manifestSigner.Object,
-                        logger);
+                        logger,
+                        fileMatcher.Object);
 
-                    await provider.SignAsync(new[] { clickOnceFile }, options);
-
-                    Assert.Equal(1, containerSpy.OpenAsync_CallCount);
-                    Assert.Equal(0, containerSpy.GetFilesWithMatcher_CallCount);
-                    Assert.Equal(2, containerSpy.GetFiles_CallCount);
-                    Assert.Equal(1, containerSpy.SaveAsync_CallCount);
-                    Assert.Equal(1, containerSpy.Dispose_CallCount);
+                    await provider.SignAsync(new[] { applicationFile }, options);
 
                     // Verify that files have been renamed back.
                     foreach (FileInfo file in containerSpy.Files)

--- a/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/ClickOnceSignatureProviderTests.cs
@@ -328,14 +328,14 @@ namespace Sign.Core.Test
 
                     manifestSigner.Setup(
                         x => x.Sign(
-                            It.Is<FileInfo>(fi => ReferenceEquals(manifestFile, fi)),
+                            It.Is<FileInfo>(fi => fi.Name == manifestFile.Name),
                             It.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
                             It.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
                             It.Is<SignOptions>(o => ReferenceEquals(options, o))));
 
                     manifestSigner.Setup(
                         x => x.Sign(
-                            It.Is<FileInfo>(fi => ReferenceEquals(applicationFile, fi)),
+                            It.Is<FileInfo>(fi => fi.Name == applicationFile.Name),
                             It.Is<X509Certificate2>(c => ReferenceEquals(certificate, c)),
                             It.Is<RSA>(rsa => ReferenceEquals(privateKey, rsa)),
                             It.Is<SignOptions>(o => ReferenceEquals(options, o))));

--- a/test/Sign.Core.Test/TestInfrastructure/SignatureProviderSpy.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/SignatureProviderSpy.cs
@@ -21,7 +21,6 @@ namespace Sign.Core.Test
 
         internal SignatureProviderSpy()
         {
-            IContainerProvider containerProvider = Mock.Of<IContainerProvider>();
             IDirectoryService directoryService = Mock.Of<IDirectoryService>();
             ISignatureAlgorithmProvider signatureAlgorithmProvider = Mock.Of<ISignatureAlgorithmProvider>();
             ICertificateProvider certificateProvider = Mock.Of<ICertificateProvider>();
@@ -32,6 +31,7 @@ namespace Sign.Core.Test
             IOpenVsixSignTool openVsixSignTool = Mock.Of<IOpenVsixSignTool>();
             IServiceProvider serviceProvider = Mock.Of<IServiceProvider>();
             IToolConfigurationProvider toolConfigurationProvider = Mock.Of<IToolConfigurationProvider>();
+            IFileMatcher fileMatcher = Mock.Of<IFileMatcher>();
 
             SignatureProvider = new AzureSignToolSignatureProvider(
                 toolConfigurationProvider,
@@ -46,12 +46,12 @@ namespace Sign.Core.Test
                 new ClickOnceSignatureProvider(
                     signatureAlgorithmProvider,
                     certificateProvider,
-                    containerProvider,
                     serviceProvider,
                     directoryService,
                     mageCli,
                     manifestSigner,
-                    logger),
+                    logger,
+                    fileMatcher),
                 new NuGetSignatureProvider(signatureAlgorithmProvider, certificateProvider, nuGetSignTool, logger),
                 new VsixSignatureProvider(signatureAlgorithmProvider, certificateProvider, openVsixSignTool, logger)
             };

--- a/test/Sign.Core.Test/TestInfrastructure/SignatureProviderSpy.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/SignatureProviderSpy.cs
@@ -21,7 +21,6 @@ namespace Sign.Core.Test
 
         internal SignatureProviderSpy()
         {
-            IDirectoryService directoryService = Mock.Of<IDirectoryService>();
             ISignatureAlgorithmProvider signatureAlgorithmProvider = Mock.Of<ISignatureAlgorithmProvider>();
             ICertificateProvider certificateProvider = Mock.Of<ICertificateProvider>();
             ILogger<ISignatureProvider> logger = Mock.Of<ILogger<ISignatureProvider>>();
@@ -47,7 +46,6 @@ namespace Sign.Core.Test
                     signatureAlgorithmProvider,
                     certificateProvider,
                     serviceProvider,
-                    directoryService,
                     mageCli,
                     manifestSigner,
                     logger,


### PR DESCRIPTION
This is my first-draft implementation of signing for clickonce files that doesn't require you to zip up everything into the .clickonce file. Instead, you can just point the tool at your .application file (or .vsto) and it will figure out which other files need to be signed and sign them all for you. The actual signing still happens in a temporary path (as it does for other file types) and then the results are copied back in-place to the original location.

I wrote this a couple of months ago but finally got approval from my company to contribute it back to the project. I've rebased it onto the latest `main` this morning.

We're not using this in production yet; we'd prefer to wait until this work has been accepted into the upstream repository before we build on it internally. I'm happy to work with the maintainers and change the code/design around as-needed to get this merged.

Resolves #643 and #470.