### PR TITLE
Update dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Azure.Identity" Version="1.10.3" />
-    <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.5.1" />
+    <PackageVersion Include="Azure.Identity" Version="1.10.4" />
+    <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
     <PackageVersion Include="AzureSign.Core" Version="4.0.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
@@ -17,12 +17,12 @@
     <!-- Lift this dependency to enable Sign.Core.Test override the version. -->
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="7.0.0" />
     <!-- Only use release versions.  Pre-release versions are signed with an untrusted certificate. -->
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <!-- Lift this dependency from NuGetKeyVaultSignTool.Core to get the latest version. -->
-    <PackageVersion Include="NuGet.Packaging" Version="6.7.0" />
+    <PackageVersion Include="NuGet.Packaging" Version="6.9.1" />
     <!-- Lift this dependency from NuGetKeyVaultSignTool.Core to get the latest version. -->
-    <PackageVersion Include="NuGet.Protocol" Version="6.7.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.9.1" />
     <PackageVersion Include="NuGetKeyVaultSignTool.Core" Version="3.2.3" />
     <PackageVersion Include="OpenVsixSignTool.Core" Version="0.4.0" />
     <PackageVersion Include="RSAKeyVaultProvider" Version="2.1.1" />


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/657.

Azure.Identity 1.10.3 -> 1.10.4
Azure.Security.KeyVault.Certificates 4.5.1 -> 4.6.0
Microsoft.Windows.SDK.BuildTools 10.0.22621.756 -> 10.0.22621.2428
NuGet.Packaging 6.7.0 -> 6.9.1
NuGet.Protocol 6.7.0 -> 6.9.1

CC @clairernovotny