### PR TITLE
Update MSBuild to 17.8.5

### DIFF
--- a/global.json
+++ b/global.json
@@ -5,7 +5,8 @@
       "dotnet/x64": [
         "8.0.3"
       ]
-    }
+    },
+    "xcopy-msbuild": "17.8.5"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24168.6",


### PR DESCRIPTION
The [previous attempt](https://github.com/dotnet/sign/pull/669) to fix internal build didn't bring in the required version of MSBuild.

This PR brings in MSBuild version 17.8.5 when >=17.8.3 is required.

CC @clairernovotny, @javierdlg