### PR TITLE
Add .NET SDK directory as PoliCheck exclusion

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -144,4 +144,5 @@ stages:
         -TsaRepositoryName dotnet-sign
         -TsaCodebaseName dotnet-sign
         -TsaOnboard $True
-        -TsaPublish $True'
+        -TsaPublish $True
+        -PoliCheckAdditionalRunConfigParams @("UserExclusionPath < $(Build.SourcesDirectory)/eng/PoliCheckExclusions.xml")'

--- a/eng/PoliCheckExclusions.xml
+++ b/eng/PoliCheckExclusions.xml
@@ -1,0 +1,13 @@
+﻿<!-- Original source:  https://github.com/dotnet/install-scripts/blob/707d374fc90068daedb5048ce95a1b34d269995e/eng/policheck_exclusions.xml -->
+<PoliCheckExclusions>
+  <!-- All strings must be UPPER CASE -->
+  <!--Each of these exclusions is a folder name -if \[name]\exists in the file path, it will be skipped -->
+  <!--<Exclusion Type="FolderPathFull">ABC|XYZ</Exclusion>-->
+  <!--Each of these exclusions is a folder name -if any folder or file starts with "\[name]", it will be skipped -->
+  <!--<Exclusion Type="FolderPathStart">ABC|XYZ</Exclusion>-->
+  <!--Each of these file types will be completely skipped for the entire scan -->
+  <!--<Exclusion Type="FileType">.ABC|.XYZ</Exclusion>-->
+  <!--The specified file names will be skipped during the scan regardless which folder they are in -->
+  <!--<Exclusion Type="FileName">ABC.TXT|XYZ.CS</Exclusion>-->
+  <Exclusion Type="FolderPathFull">.DOTNET</Exclusion>
+</PoliCheckExclusions>


### PR DESCRIPTION
The last internal build had generated some PoliCheck warnings for strings in the .NET SDK directory.  We should ignore these as part of our builds.

CC @clairernovotny, @javierdlg