### PR TITLE
CI:  fix undefined variable

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -10,6 +10,7 @@ variables:
   - name: Codeql.TSAEnabled
     value: true
   - group: DotNet-Sign-SDLValidation-Params
+  - template: /eng/common/templates-official/variables/pool-providers.yml
 
 trigger:
   batch: true


### PR DESCRIPTION
Progress on https://github.com/dotnet/sign/issues/676.

This PR pulls in the definition for the `DncEngInternalBuildPool` variable.