### PR TITLE
CI:  add baselines for SDL tooling

### DIFF
--- a/.config/1espt/PipelineAutobaseliningConfig.yml
+++ b/.config/1espt/PipelineAutobaseliningConfig.yml
@@ -1,0 +1,21 @@
+## DO NOT MODIFY THIS FILE MANUALLY. This is part of auto-baselining from 1ES Pipeline Templates. Go to [https://aka.ms/1espt-autobaselining] for more details.
+
+pipelines:
+  1190:
+    retail:
+      source:
+        credscan:
+          lastModifiedDate: 2024-03-28
+        eslint:
+          lastModifiedDate: 2024-03-28
+        psscriptanalyzer:
+          lastModifiedDate: 2024-03-28
+        armory:
+          lastModifiedDate: 2024-03-28
+      binary:
+        credscan:
+          lastModifiedDate: 2024-03-28
+        binskim:
+          lastModifiedDate: 2024-03-28
+        spotbugs:
+          lastModifiedDate: 2024-03-28

--- a/.config/1espt/README.md
+++ b/.config/1espt/README.md
@@ -1,0 +1,3 @@
+Do not merge changes to PipelineAutobaseliningConfig.yml in the internal Azure DevOps repository, as it would break commit mirroring from the public GitHub repository.  Instead, merge the changes into the public GitHub repository.
+
+See https://dev.azure.com/dnceng/internal/_wiki/wikis/DNCEng%20Services%20Wiki/1214/1ES-Pipeline-Template-Migration-FAQ?anchor=should-i-accept-these-automated-prs-into-my-repo-that-is-mirrored-from-github-to-fix-cg/security-issues%3F for guidance.


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/676

This PR adds a file which was automatically generated by SDL tooling after migrating the official pipeline to 1ES.  These files are necessary for the SDL tools to mark violations appropriately.  For more details, see: https://aka.ms/1espt-autobaselining.

I added README.md to alert maintainers on the risk of accepting (merging) autogenerated PR's raised by the same SDL tooling.

Reference PR:  https://github.com/dotnet/installer/pull/19127