### PR TITLE
Remove SHA-1 thumbprint usage

### DIFF
--- a/sign.sln
+++ b/sign.sln
@@ -26,6 +26,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sign.Cli", "src\Sign.CLI\Si
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sign.Cli.Test", "test\Sign.Cli.Test\Sign.Cli.Test.csproj", "{3C6FC0EB-F5B9-430C-B420-4DEC6B390768}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sign.SignatureProviders.KeyVault", "src\Sign.SignatureProviders.KeyVault\Sign.SignatureProviders.KeyVault.csproj", "{5B69CC06-5CBA-4A0B-B262-76ABF01542AC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sign.SignatureProviders.KeyVault.Test", "test\Sign.SignatureProviders.KeyVault.Test\Sign.SignatureProviders.KeyVault.Test.csproj", "{2EF3535D-E359-4211-98AB-FC992815355E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sign.TestInfrastructure", "test\Sign.TestInfrastructure\Sign.TestInfrastructure.csproj", "{47F03ADD-A646-44C8-92FA-9594CD4506E6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,6 +54,18 @@ Global
 		{3C6FC0EB-F5B9-430C-B420-4DEC6B390768}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3C6FC0EB-F5B9-430C-B420-4DEC6B390768}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3C6FC0EB-F5B9-430C-B420-4DEC6B390768}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B69CC06-5CBA-4A0B-B262-76ABF01542AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B69CC06-5CBA-4A0B-B262-76ABF01542AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B69CC06-5CBA-4A0B-B262-76ABF01542AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B69CC06-5CBA-4A0B-B262-76ABF01542AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2EF3535D-E359-4211-98AB-FC992815355E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2EF3535D-E359-4211-98AB-FC992815355E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2EF3535D-E359-4211-98AB-FC992815355E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2EF3535D-E359-4211-98AB-FC992815355E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{47F03ADD-A646-44C8-92FA-9594CD4506E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{47F03ADD-A646-44C8-92FA-9594CD4506E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{47F03ADD-A646-44C8-92FA-9594CD4506E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{47F03ADD-A646-44C8-92FA-9594CD4506E6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -57,6 +75,9 @@ Global
 		{67DCC7B7-C98D-452E-AE69-1F3E81833D34} = {780818DD-6B52-47C8-AC54-71448DF822BD}
 		{A54EAFBE-AB23-48F7-86C5-C91ACEEDF509} = {92C73EE1-4EF3-4721-B6A9-9F458A673CA3}
 		{3C6FC0EB-F5B9-430C-B420-4DEC6B390768} = {780818DD-6B52-47C8-AC54-71448DF822BD}
+		{5B69CC06-5CBA-4A0B-B262-76ABF01542AC} = {92C73EE1-4EF3-4721-B6A9-9F458A673CA3}
+		{2EF3535D-E359-4211-98AB-FC992815355E} = {780818DD-6B52-47C8-AC54-71448DF822BD}
+		{47F03ADD-A646-44C8-92FA-9594CD4506E6} = {780818DD-6B52-47C8-AC54-71448DF822BD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7AA1043F-37A2-404F-8EC3-34C747C1CEB7}

--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -26,7 +26,7 @@ namespace Sign.Cli
         internal Option<string> CertificateOption { get; } = new(new[] { "-kvc", "--azure-key-vault-certificate" }, AzureKeyVaultResources.CertificateOptionDescription);
         internal Option<string?> ClientIdOption { get; } = new(new[] { "-kvi", "--azure-key-vault-client-id" }, AzureKeyVaultResources.ClientIdOptionDescription);
         internal Option<string?> ClientSecretOption { get; } = new(new[] { "-kvs", "--azure-key-vault-client-secret" }, AzureKeyVaultResources.ClientSecretOptionDescription);
-        internal Argument<string?> FileArgument { get; } = new("file(s)", AzureKeyVaultResources.FilesArgumentDescription);
+        internal Argument<string?> FileArgument { get; } = new("file(s)", Resources.FilesArgumentDescription);
         internal Option<bool> ManagedIdentityOption { get; } = new(new[] { "-kvm", "--azure-key-vault-managed-identity" }, getDefaultValue: () => false, AzureKeyVaultResources.ManagedIdentityOptionDescription);
         internal Option<string?> TenantIdOption { get; } = new(new[] { "-kvt", "--azure-key-vault-tenant-id" }, AzureKeyVaultResources.TenantIdOptionDescription);
         internal Option<Uri> UrlOption { get; } = new(new[] { "-kvu", "--azure-key-vault-url" }, AzureKeyVaultResources.UrlOptionDescription);
@@ -78,7 +78,7 @@ namespace Sign.Cli
 
                 if (string.IsNullOrEmpty(fileArgument))
                 {
-                    context.Console.Error.WriteLine(AzureKeyVaultResources.MissingFileValue);
+                    context.Console.Error.WriteLine(Resources.MissingFileValue);
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
                 }
@@ -130,7 +130,7 @@ namespace Sign.Cli
                 {
                     context.Console.Error.WriteLine(
                         FormatMessage(
-                            AzureKeyVaultResources.InvalidBaseDirectoryValue,
+                            Resources.InvalidBaseDirectoryValue,
                             _codeCommand.BaseDirectoryOption));
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
@@ -158,7 +158,7 @@ namespace Sign.Cli
                 {
                     if (Path.IsPathRooted(fileArgument))
                     {
-                        context.Console.Error.WriteLine(AzureKeyVaultResources.InvalidFileValue);
+                        context.Console.Error.WriteLine(Resources.InvalidFileValue);
                         context.ExitCode = ExitCode.InvalidOptions;
 
                         return;
@@ -208,7 +208,7 @@ namespace Sign.Cli
 
                 if (inputFiles.Count == 0)
                 {
-                    context.Console.Error.WriteLine(AzureKeyVaultResources.NoFilesToSign);
+                    context.Console.Error.WriteLine(Resources.NoFilesToSign);
                     context.ExitCode = ExitCode.NoInputsFound;
                     return;
                 }
@@ -217,7 +217,7 @@ namespace Sign.Cli
                 {
                     context.Console.Error.WriteLine(
                         FormatMessage(
-                            AzureKeyVaultResources.SomeFilesDoNotExist,
+                            Resources.SomeFilesDoNotExist,
                             _codeCommand.BaseDirectoryOption));
 
                     foreach (FileInfo file in inputFiles.Where(file => !file.Exists))

--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -5,7 +5,6 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
-using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using Azure.Core;
@@ -82,7 +81,7 @@ namespace Sign.Cli
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
                 }
-                
+
                 // this check exists as a courtesy to users who may have been signing .clickonce files via the old workaround.
                 // at some point we should remove this check, probably once we hit v1.0
                 if (fileArgument.EndsWith(".clickonce", StringComparison.OrdinalIgnoreCase))
@@ -111,14 +110,12 @@ namespace Sign.Cli
                         string.IsNullOrEmpty(clientId) ||
                         string.IsNullOrEmpty(secret))
                     {
-                        context.Console.Error.WriteLine(
-                            FormatMessage(
-                                AzureKeyVaultResources.InvalidClientSecretCredential,
-                                TenantIdOption,
-                                ClientIdOption,
-                                ClientSecretOption));
+                        context.Console.Error.WriteFormattedLine(
+                            AzureKeyVaultResources.InvalidClientSecretCredential,
+                            TenantIdOption,
+                            ClientIdOption,
+                            ClientSecretOption);
                         context.ExitCode = ExitCode.NoInputsFound;
-
                         return;
                     }
 
@@ -128,10 +125,9 @@ namespace Sign.Cli
                 // Make sure this is rooted
                 if (!Path.IsPathRooted(baseDirectory.FullName))
                 {
-                    context.Console.Error.WriteLine(
-                        FormatMessage(
-                            Resources.InvalidBaseDirectoryValue,
-                            _codeCommand.BaseDirectoryOption));
+                    context.Console.Error.WriteFormattedLine(
+                        Resources.InvalidBaseDirectoryValue,
+                        _codeCommand.BaseDirectoryOption);
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
                 }
@@ -160,7 +156,6 @@ namespace Sign.Cli
                     {
                         context.Console.Error.WriteLine(Resources.InvalidFileValue);
                         context.ExitCode = ExitCode.InvalidOptions;
-
                         return;
                     }
 
@@ -215,10 +210,9 @@ namespace Sign.Cli
 
                 if (inputFiles.Any(file => !file.Exists))
                 {
-                    context.Console.Error.WriteLine(
-                        FormatMessage(
-                            Resources.SomeFilesDoNotExist,
-                            _codeCommand.BaseDirectoryOption));
+                    context.Console.Error.WriteFormattedLine(
+                        Resources.SomeFilesDoNotExist,
+                        _codeCommand.BaseDirectoryOption);
 
                     foreach (FileInfo file in inputFiles.Where(file => !file.Exists))
                     {
@@ -255,15 +249,6 @@ namespace Sign.Cli
             }
 
             return Path.Combine(baseDirectory.FullName, file);
-        }
-
-        private static string FormatMessage(string format, params IdentifierSymbol[] symbols)
-        {
-            string[] formattedSymbols = symbols
-                .Select(symbol => $"--{symbol.Name}")
-                .ToArray();
-
-            return string.Format(CultureInfo.CurrentCulture, format, formattedSymbols);
         }
     }
 }

--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 using Microsoft.Extensions.Logging;
 using Sign.Core;
+using Sign.SignatureProviders.KeyVault;
 
 namespace Sign.Cli
 {

--- a/src/Sign.Cli/AzureKeyVaultResources.Designer.cs
+++ b/src/Sign.Cli/AzureKeyVaultResources.Designer.cs
@@ -106,24 +106,6 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File(s) to sign..
-        /// </summary>
-        internal static string FilesArgumentDescription {
-            get {
-                return ResourceManager.GetString("FilesArgumentDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid value for {0}. The value must be a fully rooted directory path..
-        /// </summary>
-        internal static string InvalidBaseDirectoryValue {
-            get {
-                return ResourceManager.GetString("InvalidBaseDirectoryValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to If not using a managed identity, all of these options are required: {0}, {1}, and {2}..
         /// </summary>
         internal static string InvalidClientSecretCredential {
@@ -133,47 +115,11 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used)..
-        /// </summary>
-        internal static string InvalidFileValue {
-            get {
-                return ResourceManager.GetString("InvalidFileValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Managed identity to authenticate to Azure Key Vault..
         /// </summary>
         internal static string ManagedIdentityOptionDescription {
             get {
                 return ResourceManager.GetString("ManagedIdentityOptionDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A file or glob is required..
-        /// </summary>
-        internal static string MissingFileValue {
-            get {
-                return ResourceManager.GetString("MissingFileValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to No inputs found to sign..
-        /// </summary>
-        internal static string NoFilesToSign {
-            get {
-                return ResourceManager.GetString("NoFilesToSign", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Some files do not exist.  Try using a different {0} value or a fully qualified file path..
-        /// </summary>
-        internal static string SomeFilesDoNotExist {
-            get {
-                return ResourceManager.GetString("SomeFilesDoNotExist", resourceCulture);
             }
         }
         

--- a/src/Sign.Cli/AzureKeyVaultResources.resx
+++ b/src/Sign.Cli/AzureKeyVaultResources.resx
@@ -132,32 +132,12 @@
   <data name="CommandDescription" xml:space="preserve">
     <value>Use Azure Key Vault.</value>
   </data>
-  <data name="FilesArgumentDescription" xml:space="preserve">
-    <value>File(s) to sign.</value>
-  </data>
-  <data name="InvalidBaseDirectoryValue" xml:space="preserve">
-    <value>Invalid value for {0}. The value must be a fully rooted directory path.</value>
-    <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
-  </data>
   <data name="InvalidClientSecretCredential" xml:space="preserve">
     <value>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</value>
     <comment>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</comment>
   </data>
-  <data name="InvalidFileValue" xml:space="preserve">
-    <value>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</value>
-  </data>
   <data name="ManagedIdentityOptionDescription" xml:space="preserve">
     <value>Managed identity to authenticate to Azure Key Vault.</value>
-  </data>
-  <data name="MissingFileValue" xml:space="preserve">
-    <value>A file or glob is required.</value>
-  </data>
-  <data name="NoFilesToSign" xml:space="preserve">
-    <value>No inputs found to sign.</value>
-  </data>
-  <data name="SomeFilesDoNotExist" xml:space="preserve">
-    <value>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</value>
-    <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
   </data>
   <data name="TenantIdOptionDescription" xml:space="preserve">
     <value>Tenant ID to authenticate to Azure Key Vault.</value>

--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -5,7 +5,6 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
-using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
@@ -87,10 +86,10 @@ namespace Sign.Cli
                 // SHA-1 Thumbprint is required in case the provided certificate container contains multiple certificates.
                 if (string.IsNullOrEmpty(sha1Thumbprint))
                 {
-                    context.Console.Error.WriteLine(
-                        FormatMessage(Resources.InvalidSha1ThumbprintValue, Sha1ThumbprintOption));
+                    context.Console.Error.WriteFormattedLine(
+                        Resources.InvalidSha1ThumbprintValue,
+                        Sha1ThumbprintOption);
                     context.ExitCode = ExitCode.NoInputsFound;
-
                     return;
                 }
 
@@ -114,10 +113,9 @@ namespace Sign.Cli
                 // Make sure this is rooted
                 if (!Path.IsPathRooted(baseDirectory.FullName))
                 {
-                    context.Console.Error.WriteLine(
-                        FormatMessage(
-                            Resources.InvalidBaseDirectoryValue,
-                            _codeCommand.BaseDirectoryOption));
+                    context.Console.Error.WriteFormattedLine(
+                        Resources.InvalidBaseDirectoryValue,
+                        _codeCommand.BaseDirectoryOption);
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
                 }
@@ -152,7 +150,6 @@ namespace Sign.Cli
                     {
                         context.Console.Error.WriteLine(Resources.InvalidFileValue);
                         context.ExitCode = ExitCode.InvalidOptions;
-
                         return;
                     }
 
@@ -207,10 +204,9 @@ namespace Sign.Cli
 
                 if (inputFiles.Any(file => !file.Exists))
                 {
-                    context.Console.Error.WriteLine(
-                        FormatMessage(
-                            Resources.SomeFilesDoNotExist,
-                            _codeCommand.BaseDirectoryOption));
+                    context.Console.Error.WriteFormattedLine(
+                        Resources.SomeFilesDoNotExist,
+                        _codeCommand.BaseDirectoryOption);
 
                     foreach (FileInfo file in inputFiles.Where(file => !file.Exists))
                     {
@@ -247,15 +243,6 @@ namespace Sign.Cli
             }
 
             return Path.Combine(baseDirectory.FullName, file);
-        }
-
-        private static string FormatMessage(string format, params IdentifierSymbol[] symbols)
-        {
-            string[] formattedSymbols = symbols
-                .Select(symbol => $"--{symbol.Name}")
-                .ToArray();
-
-            return string.Format(CultureInfo.CurrentCulture, format, formattedSymbols);
         }
     }
 }

--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -92,34 +92,11 @@ namespace Sign.Cli
                 if (string.IsNullOrEmpty(certificateFingerprint))
                 {
                     context.Console.Error.WriteFormattedLine(
-                        Resources.InvalidCertificateThumbprintValue,
-                        CertificateThumbprintOption);
+                        Resources.InvalidCertificateFingerprintValue,
+                        CertificateFingerprintOption);
                     context.ExitCode = ExitCode.NoInputsFound;
 
                     return;
-                }
-
-                HashAlgorithmName certificateFingerprintAlgorithm = HashAlgorithmName.SHA256;
-
-                // CertificateFingerprintAlgorithm defaults to SHA-256, but one could pass in an empty argument through PowerShell scripts.
-                if (unparsedCertificateFingerprintAlgorithm != null)
-                {
-                    // Remove "-" from the unparsed entry to match with HashAlgorithmName.
-                    unparsedCertificateFingerprintAlgorithm = string.Join(string.Empty, unparsedCertificateFingerprintAlgorithm.Split('-'));
-
-                    // We only accept SHA256, SHA384, and SHA512 as valid fingerprint algorithms.
-                    if (!Enum.TryParse<HashAlgorithmName>(unparsedCertificateFingerprintAlgorithm, ignoreCase: true, out certificateFingerprintAlgorithm)
-                        && (certificateFingerprintAlgorithm != HashAlgorithmName.SHA256
-                            || certificateFingerprintAlgorithm != HashAlgorithmName.SHA384
-                            || certificateFingerprintAlgorithm != HashAlgorithmName.SHA512))
-                    {
-                        context.Console.Error.WriteFormattedLine(
-                            Resources.InvalidCertificateFingerprintAlgorithmValue,
-                            CertificateFingerprintAlgorithmOption);
-                        context.ExitCode = ExitCode.NoInputsFound;
-
-                        return;
-                    }
                 }
 
                 // CSP requires a private key container to function.

--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -78,7 +78,6 @@ namespace Sign.Cli
                 bool useMachineKeyContainer = context.ParseResult.GetValueForOption(UseMachineKeyContainerOption);
 
                 string? fileArgument = context.ParseResult.GetValueForArgument(FileArgument);
-                HashAlgorithmName certificateFingerprintAlgorithm = HashAlgorithmName.SHA256;
 
                 if (string.IsNullOrEmpty(fileArgument))
                 {
@@ -98,14 +97,27 @@ namespace Sign.Cli
                     return;
                 }
 
-                // Certificate Fingerprint algorithm defaults to SHA-256 and can only be SHA-256, SHA-384, or SHA-512.
-                if (Enum.TryParse<HashAlgorithmName>(unparsedCertificateFingerprintAlgorithm, ignoreCase: true, out certificateFingerprintAlgorithm))
+                HashAlgorithmName certificateFingerprintAlgorithm = HashAlgorithmName.SHA256;
+
+                // CertificateFingerprintAlgorithm defaults to SHA-256, but one could pass in an empty argument through PowerShell scripts.
+                if (unparsedCertificateFingerprintAlgorithm != null)
                 {
-                    context.Console.Error.WriteFormattedLine(
-                        Resources.InvalidCertificateThumbprintAlgorithmValue,
-                        CertificateThumbprintAlgorithmOption);
-                    context.ExitCode = ExitCode.NoInputsFound;
-                    return;
+                    // Remove "-" from the unparsed entry to match with HashAlgorithmName.
+                    unparsedCertificateFingerprintAlgorithm = string.Join(string.Empty, unparsedCertificateFingerprintAlgorithm.Split('-'));
+
+                    // We only accept SHA256, SHA384, and SHA512 as valid fingerprint algorithms.
+                    if (!Enum.TryParse<HashAlgorithmName>(unparsedCertificateFingerprintAlgorithm, ignoreCase: true, out certificateFingerprintAlgorithm)
+                        && (certificateFingerprintAlgorithm != HashAlgorithmName.SHA256
+                            || certificateFingerprintAlgorithm != HashAlgorithmName.SHA384
+                            || certificateFingerprintAlgorithm != HashAlgorithmName.SHA512))
+                    {
+                        context.Console.Error.WriteFormattedLine(
+                            Resources.InvalidCertificateFingerprintAlgorithmValue,
+                            CertificateFingerprintAlgorithmOption);
+                        context.ExitCode = ExitCode.NoInputsFound;
+
+                        return;
+                    }
                 }
 
                 // CSP requires a private key container to function.

--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -27,7 +27,7 @@ namespace Sign.Cli
         internal Option<string?> PrivateKeyContainerOption { get; } = new(new[] { "-k", "--key-container" }, CertificateStoreResources.KeyContainerOptionDescription);
         internal Option<bool> UseMachineKeyContainerOption { get; } = new(new[] { "-km", "--use-machine-key-container" }, getDefaultValue: () => false, description: CertificateStoreResources.UseMachineKeyContainerOptionDescription);
 
-        internal Argument<string?> FileArgument { get; } = new("file(s)", AzureKeyVaultResources.FilesArgumentDescription);
+        internal Argument<string?> FileArgument { get; } = new("file(s)", Resources.FilesArgumentDescription);
 
         internal CertificateStoreCommand(CodeCommand codeCommand, IServiceProviderFactory serviceProviderFactory)
             : base("certificate-store", Resources.CertificateStoreCommandDescription)
@@ -79,7 +79,7 @@ namespace Sign.Cli
 
                 if (string.IsNullOrEmpty(fileArgument))
                 {
-                    context.Console.Error.WriteLine(AzureKeyVaultResources.MissingFileValue);
+                    context.Console.Error.WriteLine(Resources.MissingFileValue);
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
                 }
@@ -116,7 +116,7 @@ namespace Sign.Cli
                 {
                     context.Console.Error.WriteLine(
                         FormatMessage(
-                            AzureKeyVaultResources.InvalidBaseDirectoryValue,
+                            Resources.InvalidBaseDirectoryValue,
                             _codeCommand.BaseDirectoryOption));
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
@@ -150,7 +150,7 @@ namespace Sign.Cli
                 {
                     if (Path.IsPathRooted(fileArgument))
                     {
-                        context.Console.Error.WriteLine(AzureKeyVaultResources.InvalidFileValue);
+                        context.Console.Error.WriteLine(Resources.InvalidFileValue);
                         context.ExitCode = ExitCode.InvalidOptions;
 
                         return;
@@ -200,7 +200,7 @@ namespace Sign.Cli
 
                 if (inputFiles.Count == 0)
                 {
-                    context.Console.Error.WriteLine(AzureKeyVaultResources.NoFilesToSign);
+                    context.Console.Error.WriteLine(Resources.NoFilesToSign);
                     context.ExitCode = ExitCode.NoInputsFound;
                     return;
                 }
@@ -209,7 +209,7 @@ namespace Sign.Cli
                 {
                     context.Console.Error.WriteLine(
                         FormatMessage(
-                            AzureKeyVaultResources.SomeFilesDoNotExist,
+                            Resources.SomeFilesDoNotExist,
                             _codeCommand.BaseDirectoryOption));
 
                     foreach (FileInfo file in inputFiles.Where(file => !file.Exists))

--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -19,13 +19,13 @@ namespace Sign.Cli
     {
         private readonly CodeCommand _codeCommand;
 
-        internal Option<string> CertificateFingerprintOption { get; } = new(new[] { "-cfp", "--certificate-fingerprint" }, CertificateStoreResources.CertificateFingerprintOptionDescription);
-        internal Option<string> CertificateFingerprintAlgorithmOption { get; } = new(new[] { "-cfpa", "--certificate-fingerprint-algorithm" }, getDefaultValue:() => "SHA-256", CertificateStoreResources.CertificateFingerprintAlgorithmOptionDescription);
-        internal Option<string?> CertificateFileOption { get; } = new(new[] { "-cf", "--certificate-file" }, CertificateStoreResources.CertificateFileOptionDescription);
-        internal Option<string?> CertificatePasswordOption { get; } = new(new[] { "-p", "--password" }, CertificateStoreResources.CertificatePasswordOptionDescription);
-        internal Option<string?> CryptoServiceProviderOption { get; } = new(new[] { "-csp", "--crypto-service-provider" }, CertificateStoreResources.CspOptionDescription);
-        internal Option<string?> PrivateKeyContainerOption { get; } = new(new[] { "-k", "--key-container" }, CertificateStoreResources.KeyContainerOptionDescription);
-        internal Option<bool> UseMachineKeyContainerOption { get; } = new(new[] { "-km", "--use-machine-key-container" }, getDefaultValue: () => false, description: CertificateStoreResources.UseMachineKeyContainerOptionDescription);
+        internal Option<string> CertificateFingerprintOption { get; } = new(["-cfp", "--certificate-fingerprint"], CertificateStoreResources.CertificateFingerprintOptionDescription);
+        internal Option<HashAlgorithmName> CertificateFingerprintAlgorithmOption { get; } = new([ "-cfpa", "--certificate-fingerprint-algorithm" ], HashAlgorithmParser.ParseHashAlgorithmName, description: CertificateStoreResources.CertificateFingerprintAlgorithmOptionDescription);
+        internal Option<string?> CertificateFileOption { get; } = new(["-cf", "--certificate-file"], CertificateStoreResources.CertificateFileOptionDescription);
+        internal Option<string?> CertificatePasswordOption { get; } = new(["-p", "--password"], CertificateStoreResources.CertificatePasswordOptionDescription);
+        internal Option<string?> CryptoServiceProviderOption { get; } = new(["-csp", "--crypto-service-provider"], CertificateStoreResources.CspOptionDescription);
+        internal Option<string?> PrivateKeyContainerOption { get; } = new(["-k", "--key-container"], CertificateStoreResources.KeyContainerOptionDescription);
+        internal Option<bool> UseMachineKeyContainerOption { get; } = new(["-km", "--use-machine-key-container"], getDefaultValue: () => false, description: CertificateStoreResources.UseMachineKeyContainerOptionDescription);
 
         internal Argument<string?> FileArgument { get; } = new("file(s)", Resources.FilesArgumentDescription);
 
@@ -38,6 +38,8 @@ namespace Sign.Cli
             _codeCommand = codeCommand;
 
             CertificateFingerprintOption.IsRequired = true;
+
+            CertificateFingerprintAlgorithmOption.SetDefaultValue(HashAlgorithmName.SHA256);
 
             AddOption(CertificateFingerprintOption);
             AddOption(CertificateFingerprintAlgorithmOption);
@@ -70,7 +72,7 @@ namespace Sign.Cli
                 int maxConcurrency = context.ParseResult.GetValueForOption(_codeCommand.MaxConcurrencyOption);
 
                 string? certificateFingerprint = context.ParseResult.GetValueForOption(CertificateFingerprintOption);
-                string? unparsedCertificateFingerprintAlgorithm = context.ParseResult.GetValueForOption(CertificateFingerprintAlgorithmOption);
+                HashAlgorithmName certificateFingerprintAlgorithm = context.ParseResult.GetValueForOption(CertificateFingerprintAlgorithmOption);
                 string? certificatePath = context.ParseResult.GetValueForOption(CertificateFileOption);
                 string? certificatePassword = context.ParseResult.GetValueForOption(CertificatePasswordOption);
                 string? cryptoServiceProvider = context.ParseResult.GetValueForOption(CryptoServiceProviderOption);

--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -19,8 +19,8 @@ namespace Sign.Cli
     {
         private readonly CodeCommand _codeCommand;
 
-        internal Option<string> CertificateThumbprintOption { get; } = new(new[] { "-cfp", "--certificate-fingerprint" }, CertificateStoreResources.CertificateThumbprintOptionDescription);
-        internal Option<string> CertificateThumbprintAlgorithmOption { get; } = new(new[] { "-cfpa", "--certificate-fingerprint-algorithm" }, getDefaultValue:() => "SHA-256", CertificateStoreResources.CertificateThumbprintAlgorithmOptionDescription);
+        internal Option<string> CertificateFingerprintOption { get; } = new(new[] { "-cfp", "--certificate-fingerprint" }, CertificateStoreResources.CertificateFingerprintOptionDescription);
+        internal Option<string> CertificateFingerprintAlgorithmOption { get; } = new(new[] { "-cfpa", "--certificate-fingerprint-algorithm" }, getDefaultValue:() => "SHA-256", CertificateStoreResources.CertificateFingerprintAlgorithmOptionDescription);
         internal Option<string?> CertificateFileOption { get; } = new(new[] { "-cf", "--certificate-file" }, CertificateStoreResources.CertificateFileOptionDescription);
         internal Option<string?> CertificatePasswordOption { get; } = new(new[] { "-p", "--password" }, CertificateStoreResources.CertificatePasswordOptionDescription);
         internal Option<string?> CryptoServiceProviderOption { get; } = new(new[] { "-csp", "--crypto-service-provider" }, CertificateStoreResources.CspOptionDescription);
@@ -37,10 +37,10 @@ namespace Sign.Cli
 
             _codeCommand = codeCommand;
 
-            CertificateThumbprintOption.IsRequired = true;
+            CertificateFingerprintOption.IsRequired = true;
 
-            AddOption(CertificateThumbprintOption);
-            AddOption(CertificateThumbprintAlgorithmOption);
+            AddOption(CertificateFingerprintOption);
+            AddOption(CertificateFingerprintAlgorithmOption);
             AddOption(CertificateFileOption);
             AddOption(CertificatePasswordOption);
             AddOption(CryptoServiceProviderOption);
@@ -69,8 +69,8 @@ namespace Sign.Cli
                 string? output = context.ParseResult.GetValueForOption(_codeCommand.OutputOption);
                 int maxConcurrency = context.ParseResult.GetValueForOption(_codeCommand.MaxConcurrencyOption);
 
-                string? certificateThumbprint = context.ParseResult.GetValueForOption(CertificateThumbprintOption);
-                string? unparsedCertificateThumbprintAlgorithm = context.ParseResult.GetValueForOption(CertificateThumbprintAlgorithmOption);
+                string? certificateFingerprint = context.ParseResult.GetValueForOption(CertificateFingerprintOption);
+                string? unparsedCertificateFingerprintAlgorithm = context.ParseResult.GetValueForOption(CertificateFingerprintAlgorithmOption);
                 string? certificatePath = context.ParseResult.GetValueForOption(CertificateFileOption);
                 string? certificatePassword = context.ParseResult.GetValueForOption(CertificatePasswordOption);
                 string? cryptoServiceProvider = context.ParseResult.GetValueForOption(CryptoServiceProviderOption);
@@ -78,7 +78,7 @@ namespace Sign.Cli
                 bool useMachineKeyContainer = context.ParseResult.GetValueForOption(UseMachineKeyContainerOption);
 
                 string? fileArgument = context.ParseResult.GetValueForArgument(FileArgument);
-                HashAlgorithmName certificateThumbprintAlgorithm = HashAlgorithmName.SHA256;
+                HashAlgorithmName certificateFingerprintAlgorithm = HashAlgorithmName.SHA256;
 
                 if (string.IsNullOrEmpty(fileArgument))
                 {
@@ -87,8 +87,8 @@ namespace Sign.Cli
                     return;
                 }
 
-                // Certificate Thumbprint is required in case the provided certificate container contains multiple certificates.
-                if (string.IsNullOrEmpty(certificateThumbprint))
+                // Certificate Fingerprint is required in case the provided certificate container contains multiple certificates.
+                if (string.IsNullOrEmpty(certificateFingerprint))
                 {
                     context.Console.Error.WriteFormattedLine(
                         Resources.InvalidCertificateThumbprintValue,
@@ -98,8 +98,8 @@ namespace Sign.Cli
                     return;
                 }
 
-                // Certificate Thumbprint algorithm defaults to SHA-256 and can only be SHA-256, SHA-384, or SHA-512.
-                if (Enum.TryParse<HashAlgorithmName>(unparsedCertificateThumbprintAlgorithm, ignoreCase: true, out certificateThumbprintAlgorithm))
+                // Certificate Fingerprint algorithm defaults to SHA-256 and can only be SHA-256, SHA-384, or SHA-512.
+                if (Enum.TryParse<HashAlgorithmName>(unparsedCertificateFingerprintAlgorithm, ignoreCase: true, out certificateFingerprintAlgorithm))
                 {
                     context.Console.Error.WriteFormattedLine(
                         Resources.InvalidCertificateThumbprintAlgorithmValue,
@@ -140,8 +140,8 @@ namespace Sign.Cli
                     addServices: (IServiceCollection services) =>
                     {
                         CertificateStoreServiceProvider certificateStoreServiceProvider = new(
-                            certificateThumbprint,
-                            certificateThumbprintAlgorithm,
+                            certificateFingerprint,
+                            certificateFingerprintAlgorithm,
                             cryptoServiceProvider,
                             privateKeyContainer,
                             certificatePath,

--- a/src/Sign.Cli/CertificateStoreResources.Designer.cs
+++ b/src/Sign.Cli/CertificateStoreResources.Designer.cs
@@ -70,7 +70,7 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512.
+        ///   Looks up a localized string similar to Certificate fingerprint algorithm. Allowed values are &apos;sha256&apos;, &apos;sha384&apos;, and &apos;sha512&apos;..
         /// </summary>
         internal static string CertificateFingerprintAlgorithmOptionDescription {
             get {

--- a/src/Sign.Cli/CertificateStoreResources.Designer.cs
+++ b/src/Sign.Cli/CertificateStoreResources.Designer.cs
@@ -79,6 +79,24 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512.
+        /// </summary>
+        internal static string CertificateThumbprintAlgorithmOptionDescription {
+            get {
+                return ResourceManager.GetString("CertificateThumbprintAlgorithmOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SHA thumbprint used to identify a certificate..
+        /// </summary>
+        internal static string CertificateThumbprintOptionDescription {
+            get {
+                return ResourceManager.GetString("CertificateThumbprintOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cryptographic Service Provider containing the private key container. Requires /k and optionally /km..
         /// </summary>
         internal static string CspOptionDescription {
@@ -111,15 +129,6 @@ namespace Sign.Cli {
         internal static string MissingPrivateKeyContainerError {
             get {
                 return ResourceManager.GetString("MissingPrivateKeyContainerError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to SHA-1 thumbprint used to identify a certificate..
-        /// </summary>
-        internal static string Sha1ThumbprintOptionDescription {
-            get {
-                return ResourceManager.GetString("Sha1ThumbprintOptionDescription", resourceCulture);
             }
         }
         

--- a/src/Sign.Cli/CertificateStoreResources.Designer.cs
+++ b/src/Sign.Cli/CertificateStoreResources.Designer.cs
@@ -70,29 +70,29 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512.
+        /// </summary>
+        internal static string CertificateFingerprintAlgorithmOptionDescription {
+            get {
+                return ResourceManager.GetString("CertificateFingerprintAlgorithmOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SHA fingerprint used to identify a certificate..
+        /// </summary>
+        internal static string CertificateFingerprintOptionDescription {
+            get {
+                return ResourceManager.GetString("CertificateFingerprintOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Password for certificate file..
         /// </summary>
         internal static string CertificatePasswordOptionDescription {
             get {
                 return ResourceManager.GetString("CertificatePasswordOptionDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512.
-        /// </summary>
-        internal static string CertificateThumbprintAlgorithmOptionDescription {
-            get {
-                return ResourceManager.GetString("CertificateThumbprintAlgorithmOptionDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to SHA thumbprint used to identify a certificate..
-        /// </summary>
-        internal static string CertificateThumbprintOptionDescription {
-            get {
-                return ResourceManager.GetString("CertificateThumbprintOptionDescription", resourceCulture);
             }
         }
         

--- a/src/Sign.Cli/CertificateStoreResources.resx
+++ b/src/Sign.Cli/CertificateStoreResources.resx
@@ -121,16 +121,16 @@
     <value>PFX, P7B, or CER file containing a certificate and potentially a private key.</value>
     <comment>{Locked="PFX", "P7B", "CER"} are file extensions.</comment>
   </data>
-  <data name="CertificatePasswordOptionDescription" xml:space="preserve">
-    <value>Password for certificate file.</value>
-  </data>
-  <data name="CertificateThumbprintAlgorithmOptionDescription" xml:space="preserve">
-    <value>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</value>
+  <data name="CertificateFingerprintAlgorithmOptionDescription" xml:space="preserve">
+    <value>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</value>
     <comment>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</comment>
   </data>
-  <data name="CertificateThumbprintOptionDescription" xml:space="preserve">
-    <value>SHA thumbprint used to identify a certificate.</value>
+  <data name="CertificateFingerprintOptionDescription" xml:space="preserve">
+    <value>SHA fingerprint used to identify a certificate.</value>
     <comment>{Locked="SHA"} is a cryptographic algorithm.</comment>
+  </data>
+  <data name="CertificatePasswordOptionDescription" xml:space="preserve">
+    <value>Password for certificate file.</value>
   </data>
   <data name="CspOptionDescription" xml:space="preserve">
     <value>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</value>

--- a/src/Sign.Cli/CertificateStoreResources.resx
+++ b/src/Sign.Cli/CertificateStoreResources.resx
@@ -122,8 +122,8 @@
     <comment>{Locked="PFX", "P7B", "CER"} are file extensions.</comment>
   </data>
   <data name="CertificateFingerprintAlgorithmOptionDescription" xml:space="preserve">
-    <value>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</value>
-    <comment>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</comment>
+    <value>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</value>
+    <comment>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</comment>
   </data>
   <data name="CertificateFingerprintOptionDescription" xml:space="preserve">
     <value>SHA fingerprint used to identify a certificate.</value>

--- a/src/Sign.Cli/CertificateStoreResources.resx
+++ b/src/Sign.Cli/CertificateStoreResources.resx
@@ -124,6 +124,14 @@
   <data name="CertificatePasswordOptionDescription" xml:space="preserve">
     <value>Password for certificate file.</value>
   </data>
+  <data name="CertificateThumbprintAlgorithmOptionDescription" xml:space="preserve">
+    <value>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</value>
+    <comment>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</comment>
+  </data>
+  <data name="CertificateThumbprintOptionDescription" xml:space="preserve">
+    <value>SHA thumbprint used to identify a certificate.</value>
+    <comment>{Locked="SHA"} is a cryptographic algorithm.</comment>
+  </data>
   <data name="CspOptionDescription" xml:space="preserve">
     <value>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</value>
     <comment>{Locked="/k", "/km"} are command line options.</comment>
@@ -138,10 +146,6 @@
   <data name="MissingPrivateKeyContainerError" xml:space="preserve">
     <value>Private key container name missing. Use /k to specify a key container name.</value>
     <comment>{Locked="/k"} is a command line option.</comment>
-  </data>
-  <data name="Sha1ThumbprintOptionDescription" xml:space="preserve">
-    <value>SHA-1 thumbprint used to identify a certificate.</value>
-    <comment>{Locked="SHA-1"} is a cryptographic algorithm.</comment>
   </data>
   <data name="UseMachineKeyContainerOptionDescription" xml:space="preserve">
     <value>Use a machine-level private key container.  (The default is user-level.)</value>

--- a/src/Sign.Cli/CodeCommand.cs
+++ b/src/Sign.Cli/CodeCommand.cs
@@ -12,18 +12,18 @@ namespace Sign.Cli
 {
     internal sealed class CodeCommand : Command
     {
-        internal Option<string?> ApplicationNameOption { get; } = new(new[] { "-an", "--application-name" }, Resources.ApplicationNameOptionDescription);
-        internal Option<DirectoryInfo> BaseDirectoryOption { get; } = new(new[] { "-b", "--base-directory" }, ParseBaseDirectoryOption, description: Resources.BaseDirectoryOptionDescription);
-        internal Option<string> DescriptionOption { get; } = new(new[] { "-d", "--description" }, Resources.DescriptionOptionDescription);
-        internal Option<Uri?> DescriptionUrlOption { get; } = new(new[] { "-u", "--description-url" }, ParseUrl, description: Resources.DescriptionUrlOptionDescription);
-        internal Option<HashAlgorithmName> FileDigestOption { get; } = new(new[] { "-fd", "--file-digest" }, ParseHashAlgorithmName, description: Resources.FileDigestOptionDescription);
-        internal Option<string?> FileListOption = new(new[] { "-fl", "--file-list" }, Resources.FileListOptionDescription);
-        internal Option<int> MaxConcurrencyOption { get; } = new(new[] { "-m", "--max-concurrency" }, ParseMaxConcurrencyOption, description: Resources.MaxConcurrencyOptionDescription);
-        internal Option<string?> OutputOption { get; } = new(new[] { "-o", "--output" }, Resources.OutputOptionDescription);
-        internal Option<string?> PublisherNameOption { get; } = new(new[] { "-pn", "--publisher-name" }, Resources.PublisherNameOptionDescription);
-        internal Option<HashAlgorithmName> TimestampDigestOption { get; } = new(new[] { "-td", "--timestamp-digest" }, ParseHashAlgorithmName, description: Resources.TimestampDigestOptionDescription);
-        internal Option<Uri?> TimestampUrlOption { get; } = new(new[] { "-t", "--timestamp-url" }, ParseUrl, description: Resources.TimestampUrlOptionDescription);
-        internal Option<LogLevel> VerbosityOption { get; } = new(new[] { "-v", "--verbosity" }, () => LogLevel.Warning, Resources.VerbosityOptionDescription);
+        internal Option<string?> ApplicationNameOption { get; } = new(["-an", "--application-name"], Resources.ApplicationNameOptionDescription);
+        internal Option<DirectoryInfo> BaseDirectoryOption { get; } = new(["-b", "--base-directory"], ParseBaseDirectoryOption, description: Resources.BaseDirectoryOptionDescription);
+        internal Option<string> DescriptionOption { get; } = new(["-d", "--description"], Resources.DescriptionOptionDescription);
+        internal Option<Uri?> DescriptionUrlOption { get; } = new(["-u", "--description-url"], ParseUrl, description: Resources.DescriptionUrlOptionDescription);
+        internal Option<HashAlgorithmName> FileDigestOption { get; } = new(["-fd", "--file-digest"], HashAlgorithmParser.ParseHashAlgorithmName, description: Resources.FileDigestOptionDescription);
+        internal Option<string?> FileListOption = new(["-fl", "--file-list"], Resources.FileListOptionDescription);
+        internal Option<int> MaxConcurrencyOption { get; } = new(["-m", "--max-concurrency"], ParseMaxConcurrencyOption, description: Resources.MaxConcurrencyOptionDescription);
+        internal Option<string?> OutputOption { get; } = new(["-o", "--output"], Resources.OutputOptionDescription);
+        internal Option<string?> PublisherNameOption { get; } = new(["-pn", "--publisher-name"], Resources.PublisherNameOptionDescription);
+        internal Option<HashAlgorithmName> TimestampDigestOption { get; } = new(["-td", "--timestamp-digest"], HashAlgorithmParser.ParseHashAlgorithmName, description: Resources.TimestampDigestOptionDescription);
+        internal Option<Uri?> TimestampUrlOption { get; } = new(["-t", "--timestamp-url"], ParseUrl, description: Resources.TimestampUrlOptionDescription);
+        internal Option<LogLevel> VerbosityOption { get; } = new(["-v", "--verbosity"], () => LogLevel.Warning, Resources.VerbosityOptionDescription);
 
         internal CodeCommand()
             : base("code", Resources.CodeCommandDescription)
@@ -88,33 +88,6 @@ namespace Sign.Cli
             }
 
             return value;
-        }
-
-        private static HashAlgorithmName ParseHashAlgorithmName(ArgumentResult result)
-        {
-            if (result.Tokens.Count == 0)
-            {
-                return HashAlgorithmName.SHA256;
-            }
-
-            string token = result.Tokens.Single().Value.ToLowerInvariant();
-
-            switch (token)
-            {
-                case "sha256":
-                    return HashAlgorithmName.SHA256;
-
-                case "sha384":
-                    return HashAlgorithmName.SHA384;
-
-                case "sha512":
-                    return HashAlgorithmName.SHA512;
-
-                default:
-                    result.ErrorMessage = FormatMessage(Resources.InvalidDigestValue, result.Argument);
-
-                    return HashAlgorithmName.SHA256;
-            }
         }
 
         private static Uri? ParseUrl(ArgumentResult result)

--- a/src/Sign.Cli/Helpers/HashAlgorithmParser.cs
+++ b/src/Sign.Cli/Helpers/HashAlgorithmParser.cs
@@ -2,15 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.CommandLine.Parsing;
-using System.Linq;
-using System.Security.Cryptography;
 using System.Globalization;
-using System.Text;
-using System.Threading.Tasks;
-using System.CommandLine;
+using System.Security.Cryptography;
 
 namespace Sign.Cli
 {

--- a/src/Sign.Cli/Helpers/HashAlgorithmParser.cs
+++ b/src/Sign.Cli/Helpers/HashAlgorithmParser.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.CommandLine.Parsing;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+using System.CommandLine;
+
+namespace Sign.Cli
+{
+    internal static class HashAlgorithmParser
+    {
+        public static HashAlgorithmName ParseHashAlgorithmName(ArgumentResult result)
+        {
+            if (result.Tokens.Count == 0)
+            {
+                return HashAlgorithmName.SHA256;
+            }
+
+            string token = result.Tokens.Single().Value.ToLowerInvariant();
+
+            switch (token)
+            {
+                case "sha256":
+                    return HashAlgorithmName.SHA256;
+
+                case "sha384":
+                    return HashAlgorithmName.SHA384;
+
+                case "sha512":
+                    return HashAlgorithmName.SHA512;
+
+                default:
+                    result.ErrorMessage = string.Format(CultureInfo.CurrentCulture, Resources.InvalidDigestValue, $"--{result.Argument.Name}");
+
+                    return HashAlgorithmName.SHA256;
+            }
+        }
+    }
+}

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -153,6 +153,24 @@ namespace Sign.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Invalid value for {0}. The value must be &apos;sha256&apos;, &apos;sha384&apos;, or &apos;sha512&apos;..
         /// </summary>
+        internal static string InvalidCertificateThumbprintAlgorithmValue {
+            get {
+                return ResourceManager.GetString("InvalidCertificateThumbprintAlgorithmValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid value for {0}. The value must be the certificate&apos;s SHA-256, SHA-384, or SHA-512 thumbprint..
+        /// </summary>
+        internal static string InvalidCertificateThumbprintValue {
+            get {
+                return ResourceManager.GetString("InvalidCertificateThumbprintValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid value for {0}. The value must be &apos;sha256&apos;, &apos;sha384&apos;, or &apos;sha512&apos;..
+        /// </summary>
         internal static string InvalidDigestValue {
             get {
                 return ResourceManager.GetString("InvalidDigestValue", resourceCulture);
@@ -174,15 +192,6 @@ namespace Sign.Cli {
         internal static string InvalidMaxConcurrencyValue {
             get {
                 return ResourceManager.GetString("InvalidMaxConcurrencyValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid value for {0}. The value must be the certificate&apos;s SHA-1 thumbprint..
-        /// </summary>
-        internal static string InvalidSha1ThumbprintValue {
-            get {
-                return ResourceManager.GetString("InvalidSha1ThumbprintValue", resourceCulture);
             }
         }
         

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -153,18 +153,18 @@ namespace Sign.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Invalid value for {0}. The value must be &apos;sha256&apos;, &apos;sha384&apos;, or &apos;sha512&apos;..
         /// </summary>
-        internal static string InvalidCertificateThumbprintAlgorithmValue {
+        internal static string InvalidCertificateFingerprintAlgorithmValue {
             get {
-                return ResourceManager.GetString("InvalidCertificateThumbprintAlgorithmValue", resourceCulture);
+                return ResourceManager.GetString("InvalidCertificateFingerprintAlgorithmValue", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid value for {0}. The value must be the certificate&apos;s SHA-256, SHA-384, or SHA-512 thumbprint..
+        ///   Looks up a localized string similar to Invalid value for {0}. The value must be the certificate&apos;s SHA-256, SHA-384, or SHA-512 fingerprint..
         /// </summary>
-        internal static string InvalidCertificateThumbprintValue {
+        internal static string InvalidCertificateFingerprintValue {
             get {
-                return ResourceManager.GetString("InvalidCertificateThumbprintValue", resourceCulture);
+                return ResourceManager.GetString("InvalidCertificateFingerprintValue", resourceCulture);
             }
         }
         

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -115,7 +115,7 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Digest algorithm to hash files with. Allowed values are &apos;Sha256&apos;, &apos;Sha384&apos;, and &apos;Sha512&apos;..
+        ///   Looks up a localized string similar to Digest algorithm to hash files with. Allowed values are &apos;sha256&apos;, &apos;sha384&apos;, and &apos;sha512&apos;..
         /// </summary>
         internal static string FileDigestOptionDescription {
             get {
@@ -133,6 +133,15 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to File(s) to sign..
+        /// </summary>
+        internal static string FilesArgumentDescription {
+            get {
+                return ResourceManager.GetString("FilesArgumentDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid value for {0}. The value must be a fully rooted directory path..
         /// </summary>
         internal static string InvalidBaseDirectoryValue {
@@ -142,11 +151,20 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid value for {0}. The value must be &apos;Sha256&apos;, &apos;Sha384&apos;, or &apos;Sha512&apos;..
+        ///   Looks up a localized string similar to Invalid value for {0}. The value must be &apos;sha256&apos;, &apos;sha384&apos;, or &apos;sha512&apos;..
         /// </summary>
         internal static string InvalidDigestValue {
             get {
                 return ResourceManager.GetString("InvalidDigestValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used)..
+        /// </summary>
+        internal static string InvalidFileValue {
+            get {
+                return ResourceManager.GetString("InvalidFileValue", resourceCulture);
             }
         }
         
@@ -187,6 +205,24 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A file or glob is required..
+        /// </summary>
+        internal static string MissingFileValue {
+            get {
+                return ResourceManager.GetString("MissingFileValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No inputs found to sign..
+        /// </summary>
+        internal static string NoFilesToSign {
+            get {
+                return ResourceManager.GetString("NoFilesToSign", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Output file or directory. If omitted, input files will be overwritten..
         /// </summary>
         internal static string OutputOptionDescription {
@@ -214,7 +250,16 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Digest algorithm for the RFC 3161 timestamp server. Allowed values are Sha256, Sha384, and Sha512..
+        ///   Looks up a localized string similar to Some files do not exist.  Try using a different {0} value or a fully qualified file path..
+        /// </summary>
+        internal static string SomeFilesDoNotExist {
+            get {
+                return ResourceManager.GetString("SomeFilesDoNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512..
         /// </summary>
         internal static string TimestampDigestOptionDescription {
             get {

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -160,7 +160,7 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid value for {0}. The value must be the certificate&apos;s SHA-256, SHA-384, or SHA-512 fingerprint..
+        ///   Looks up a localized string similar to Invalid value for {0}. The value must be the certificate&apos;s fingerprint (in hexadecimal)..
         /// </summary>
         internal static string InvalidCertificateFingerprintValue {
             get {

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -149,11 +149,11 @@
     <value>Invalid value for {0}. The value must be a fully rooted directory path.</value>
     <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
   </data>
-  <data name="InvalidCertificateThumbprintAlgorithmValue" xml:space="preserve">
+  <data name="InvalidCertificateFingerprintAlgorithmValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</value>
   </data>
-  <data name="InvalidCertificateThumbprintValue" xml:space="preserve">
-    <value>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</value>
+  <data name="InvalidCertificateFingerprintValue" xml:space="preserve">
+    <value>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</value>
     <comment>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</comment>
   </data>
   <data name="InvalidDigestValue" xml:space="preserve">

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -149,6 +149,13 @@
     <value>Invalid value for {0}. The value must be a fully rooted directory path.</value>
     <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
   </data>
+  <data name="InvalidCertificateThumbprintAlgorithmValue" xml:space="preserve">
+    <value>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</value>
+  </data>
+  <data name="InvalidCertificateThumbprintValue" xml:space="preserve">
+    <value>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</value>
+    <comment>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</comment>
+  </data>
   <data name="InvalidDigestValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</value>
     <comment>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</comment>
@@ -159,10 +166,6 @@
   <data name="InvalidMaxConcurrencyValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be a number value greater than or equal to 1.</value>
     <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</comment>
-  </data>
-  <data name="InvalidSha1ThumbprintValue" xml:space="preserve">
-    <value>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</value>
-    <comment>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</comment>
   </data>
   <data name="InvalidUrlValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</value>

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -142,6 +142,9 @@
   <data name="FileListOptionDescription" xml:space="preserve">
     <value>Path to file containing paths of files to sign or to exclude from signing.</value>
   </data>
+  <data name="FilesArgumentDescription" xml:space="preserve">
+    <value>File(s) to sign.</value>
+  </data>
   <data name="InvalidBaseDirectoryValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be a fully rooted directory path.</value>
     <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
@@ -149,6 +152,9 @@
   <data name="InvalidDigestValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</value>
     <comment>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</comment>
+  </data>
+  <data name="InvalidFileValue" xml:space="preserve">
+    <value>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</value>
   </data>
   <data name="InvalidMaxConcurrencyValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be a number value greater than or equal to 1.</value>
@@ -165,6 +171,12 @@
   <data name="MaxConcurrencyOptionDescription" xml:space="preserve">
     <value>Maximum concurrency.</value>
   </data>
+  <data name="MissingFileValue" xml:space="preserve">
+    <value>A file or glob is required.</value>
+  </data>
+  <data name="NoFilesToSign" xml:space="preserve">
+    <value>No inputs found to sign.</value>
+  </data>
   <data name="OutputOptionDescription" xml:space="preserve">
     <value>Output file or directory. If omitted, input files will be overwritten.</value>
   </data>
@@ -174,6 +186,10 @@
   </data>
   <data name="SignCommandDescription" xml:space="preserve">
     <value>Sign CLI</value>
+  </data>
+  <data name="SomeFilesDoNotExist" xml:space="preserve">
+    <value>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</value>
+    <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
   </data>
   <data name="TimestampDigestOptionDescription" xml:space="preserve">
     <value>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</value>

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -151,10 +151,11 @@
   </data>
   <data name="InvalidCertificateFingerprintAlgorithmValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</value>
+    <comment>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</comment>
   </data>
   <data name="InvalidCertificateFingerprintValue" xml:space="preserve">
-    <value>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</value>
-    <comment>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</comment>
+    <value>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</value>
+    <comment>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</comment>
   </data>
   <data name="InvalidDigestValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</value>

--- a/src/Sign.Cli/Sign.Cli.csproj
+++ b/src/Sign.Cli/Sign.Cli.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(RepositoryRootDirectory)\SdkTools.props" />
 
   <PropertyGroup>
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Sign.Core\Sign.Core.csproj" />
+    <ProjectReference Include="..\Sign.SignatureProviders.KeyVault\Sign.SignatureProviders.KeyVault.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sign.Cli/StandardStreamWriterExtensions.cs
+++ b/src/Sign.Cli/StandardStreamWriterExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System.CommandLine;
+using System.CommandLine.IO;
+using System.Globalization;
+
+namespace Sign.Cli
+{
+    internal static class StandardStreamWriterExtensions
+    {
+        internal static void WriteFormattedLine(this IStandardStreamWriter writer, string format, params IdentifierSymbol[] symbols)
+        {
+            string[] formattedSymbols = symbols
+                .Select(symbol => $"--{symbol.Name}")
+                .ToArray();
+
+            writer.WriteLine(string.Format(CultureInfo.InvariantCulture, format, formattedSymbols));
+        }
+    }
+}

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Použijte Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">Soubor nebo soubory, které se mají podepsat.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být plně kořenová cesta k adresáři.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Pokud se nepoužívá spravovaná identita, vyžadují se všechny tyto možnosti: {0}, {1}a {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Cestu k souboru nelze při použití glob zakořenit. Použijte relativní cestu k pracovnímu adresáři (nebo základnímu adresáři, pokud se používá).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Spravovaná identita pro ověření pro Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">Vyžaduje se soubor nebo glob.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">Nenašly se žádné vstupy, které by bylo možné podepsat.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Některé soubory neexistují.  Zkuste použít jinou hodnotu {0} nebo plně kvalifikovanou cestu k souboru.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
+        <target state="translated">Podepisování ClickOnce prostřednictvím starší verze alternativního řešení .clickonce ZIP se už nepodporuje. Projděte si dokumentaci.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
+        <target state="translated">Die ClickOnce-Signierung über die Legacy-.clickonce-ZIP-Problemumgehung wird nicht mehr unterstützt. Siehe Dokumentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Verwenden Sie Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">Zu signierende Datei(en).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Ungültiger Wert für {0}. Der Wert muss ein vollständiger Stammverzeichnispfad sein.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Wenn Sie keine verwaltete Identität verwenden, sind alle diese Optionen erforderlich: {0}, {1} und {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Der Dateipfad kann keinem Stamm zugewiesen werden, wenn ein Glob verwendet wird. Verwenden Sie einen Pfad relativ zum Arbeitsverzeichnis (oder Basisverzeichnis, falls verwendet).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Verwaltete Identität für die Authentifizierung bei Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">Eine Datei oder ein Glob ist erforderlich.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">Es wurden keine Eingaben zum Signieren gefunden.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Einige Dateien sind nicht vorhanden.  Versuchen Sie, einen anderen {0}-Wert oder einen vollqualifizierten Dateipfad zu verwenden.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Use Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">Archivos para firmar.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valor no válido para {0}. El valor debe ser una ruta de acceso de directorio totalmente raíz.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Si no usa una identidad administrada, se requieren todas estas opciones: {0}, {1} y {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">La ruta de acceso del archivo no se puede rootear cuando se usa un glob. Use una ruta de acceso relativa al directorio de trabajo (o directorio base, si se usa).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Identidad administrada para autenticarse en Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">Se requiere un archivo o glob.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">No se encontraron entradas para firmar.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Algunos archivos no existen.  Pruebe a usar otro valor {0} o una ruta de acceso de archivo completa.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
+        <target state="translated">Ya no se admite la firma ClickOnce a través de la solución zip heredada .clickonce. Consulte la documentación.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Utilisez Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">Fichier(s) à signer.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valeur non valide pour {0}. La valeur doit être un chemin d’accès de répertoire entièrement rooté.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Si vous n’utilisez pas d’identité managée, toutes ces options sont requises : {0}, {1} et {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Le chemin d’accès du fichier ne peut pas être rooté lors de l’utilisation d’un glob. Utilisez un chemin d’accès relatif au répertoire de travail (ou au répertoire de base, s’il est utilisé).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Identité managée à authentifier auprès d’Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">Un fichier ou un glob est requis.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">Aucune entrée à signer.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Certains fichiers n’existent pas. Essayez d’utiliser une autre valeur {0} ou un chemin de fichier complet.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
+        <target state="translated">La signature ClickOnce via la solution de contournement zip .clickonce héritée n’est plus prise en charge. Consulter la documentation.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
+        <target state="translated">La firma ClickOnce tramite la soluzione alternativa legacy .clickonce ZIP non è più supportata. Vedere la documentazione.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Usare Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">File da firmare.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valore non valido per {0}. Il valore deve essere un percorso di directory completo.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Se non si usa un'identità gestita, saranno necessarie tutte le opzioni seguenti: {0}, {1} e {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Il percorso del file non può avere accesso root quando si utilizza un GLOB. Usare un percorso relativo alla directory di lavoro (o alla directory di base, se usata).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Identità gestita da autenticare in Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">È necessario specificare un file o un GLOB.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">Non sono stati trovati input da firmare.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Alcuni file non esistono.  Provare a usare un valore di {0} diverso o un percorso di file completo.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
+        <target state="translated">従来の .clickonce ZIP 回避策による ClickOnce 署名はサポートされなくなりました。ドキュメントを参照してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Azure Key Vault を使用してください。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">署名するファイル。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} の値が無効です。値は、完全にルート化されたディレクトリ パスである必要があります。</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">マネージド ID を使用しない場合は、{0}、{1}、{2} のオプションがすべて必要です。</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">glob を使用している場合、ファイル パスをルート化できません。作業ディレクトリへの相対パス (または使用されている場合はベース ディレクトリ) を使用してください。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Azure Key Vault に対して認証するマネージド ID。</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">ファイルまたは glob が必要です。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">署名する入力が見つかりません。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">一部のファイルが存在しません。別の {0} 値または完全修飾ファイル パスを使用してみてください。</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Azure Key Vault를 사용합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">서명할 파일입니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 완전한 루트 디렉터리 경로여야 합니다.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">관리 ID를 사용하고 있지 않은 경우 {0}, {1} 및 {2} 옵션이 모두 필요합니다.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">glob을 사용할 때 파일 경로를 루팅할 수 없습니다. 작업 디렉터리(또는 사용되는 경우 기본 디렉터리)에 상대적인 경로를 사용하세요.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Azure Key Vault에 인증하기 위한 관리 ID입니다.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">파일 또는 글로브가 필요합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">서명할 입력이 없습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">일부 파일이 존재하지 않습니다.  다른 {0} 값 또는 정규화된 파일 경로를 사용해 보세요.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
+        <target state="translated">레거시 .clickonce ZIP 해결 방법을 통한 ClickOnce 서명은 더 이상 지원되지 않습니다. 설명서를 참조하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
+        <target state="translated">Podpisywanie clickOnce za pośrednictwem starszego obejścia .clickonce ZIP nie jest już obsługiwane. Zobacz dokumentację.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Użyj usługi Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">Pliki do podpisania.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Nieprawidłowa wartość dla {0}. Wartość musi być w pełni główną ścieżką katalogu.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Jeśli tożsamość zarządzana nie jest używana, wymagane są wszystkie następujące opcje: {0}, {1} i {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Ścieżka pliku nie może być z dostępem do konta root, gdy jest używany element globalny. Użyj ścieżki odnoszącej się do katalogu roboczego (lub katalogu podstawowego, jeśli jest używany).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Tożsamość zarządzana do uwierzytelnienia w usłudze Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">Wymagany jest plik lub element globalny.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">Nie znaleziono danych wejściowych do podpisania.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Niektóre pliki nie istnieją.  Spróbuj użyć innej wartości {0} lub w pełni kwalifikowanej ścieżki pliku.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
+        <target state="translated">Não há mais suporte para a assinatura do ClickOnce por meio da solução alternativa .clickonce ZIP herdada. Consulte a documentação.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Use o Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">Arquivo(s) para autenticar.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valor inválido para {0}. O valor deve ser um caminho de diretório totalmente desbloqueado por rooting.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Se não estiver usando uma identidade gerenciada, todas essas opções serão necessárias: {0}, {1} e {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">O caminho do arquivo não pode estar desbloqueado por rooting ao usar um glob. Use um caminho relativo ao diretório de trabalho (ou diretório base, se usado).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Identidade gerenciada a ser autenticada no Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">É necessário um arquivo ou um glob.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">Nenhuma entrada encontrada para autenticar.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Alguns arquivos não existem.  Tente usar um valor diferente de {0} ou um caminho de arquivo totalmente qualificado.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Использование Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">Файлы для подписи.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Недопустимое значение для {0}. Значение должно быть полным корневым путем к каталогу.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Если управляемое удостоверение не используется, требуются все следующие параметры: {0}, {1} и {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Путь к файлу не может быть корневым при использовании стандартной маски. Используйте путь относительно рабочего каталога (или базового каталога, если он используется).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Управляемое удостоверение для проверки подлинности в Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">Требуется файл или стандартная маска.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">Не найдены входящие данные для подписи.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Некоторые файлы не существуют.  Попробуйте использовать другое значение {0} или полный путь к файлу.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
+        <target state="translated">Подписание ClickOnce с помощью устаревшего обходного пути .clickonce ZIP больше не поддерживается. См. документацию.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Azure Key Vault’u kullanın.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">İmzalanacak dosyalar.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} için geçersiz değer. Değer, tam olarak kök erişim izni verilmiş bir dizin yolu olmalıdır.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Bir yönetilen kimlik kullanılmıyorsa bu seçeneklerin tümü gereklidir: {0}, {1} ve {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Glob kullanılırken dosya yoluna kök erişim izni verilemez. Çalışma diziniyle (veya kullanılıyorsa, temel dizinle) ilişkili bir yol kullanın.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Azure Key Vault için kimlik doğrulamak amacıyla kullanılan yönetilen kimlik.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">Dosya veya glob gerekiyor.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">İmzalanacak giriş dosyası yok.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Bazı dosyalar mevcut değil. Farklı bir {0} değeri veya tam bir dosya yolu kullanmayı deneyin.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
+        <target state="translated">Eski .clickonce ZIP geçici çözümü aracılığıyla ClickOnce imzalama işlemi artık desteklenmiyor. Belgelere bakın.</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
@@ -27,45 +27,15 @@
         <target state="translated">使用 Azure Key Vault。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">要签名的文件。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} 的值无效。该值必须是完整的根目录路径。</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">如果不使用托管标识，则需要以下所有选项: {0}、{1} 和 {2}。</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">使用 glob 时，文件路径不能为根路径。请使用相对于工作目录(或基目录，如果使用)的路径。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">要向 Azure Key Vault 进行身份验证的托管标识。</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">文件或 glob 是必需的。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">找不到要签名的输入。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">某些文件不存在。请尝试使用其他 {0} 值或完全限定的文件路径。</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
+        <target state="translated">不再支持通过旧版 .clickonce ZIP 解决方法进行 ClickOnce 签名。参阅文档。</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
@@ -9,7 +9,7 @@
       </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
-        <target state="new">ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</target>
+        <target state="translated">已不再支援透過舊版 .clickonce ZIP 因應措施進行 ClickOnce 簽署。請參閱文件。</target>
         <note />
       </trans-unit>
       <trans-unit id="ClientIdOptionDescription">

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
@@ -27,45 +27,15 @@
         <target state="translated">使用 Azure Key Vault。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">要簽署的檔案。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} 的值無效。值必須是完整的根目錄路徑。</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">如果未使用受控識別，則需要下列所有選項: {0}、{1} 和 {2}。</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">使用 Glob 時，檔案路徑不可為根目錄。請使用工作目錄或基底目錄 (若使用該目錄) 的相對路徑。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">要向 Azure Key Vault 進行驗證的受控識別。</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">需要檔案或 Glob。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">找不到要簽署的輸入。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">某些檔案不存在。請嘗試使用不同的 {0} 值或完整檔案路徑。</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/CertManagerResources.cs.xlf
+++ b/src/Sign.Cli/xlf/CertManagerResources.cs.xlf
@@ -4,32 +4,32 @@
     <body>
       <trans-unit id="CSPOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k or /km</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k or /km</target>
+        <target state="translated">Zprostředkovatel kryptografických služeb obsahující kontejner privátního klíče. Vyžaduje se /k nebo /km.</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container in the user store</source>
-        <target state="new">Private key container in the user store</target>
+        <target state="translated">Kontejner privátního klíče v úložišti uživatele.</target>
         <note />
       </trans-unit>
       <trans-unit id="MachineKeyContainerOptionDescription">
         <source>Private key container in the machine store</source>
-        <target state="new">Private key container in the machine store</target>
+        <target state="translated">Kontejner privátního klíče v úložišti počítače.</target>
         <note />
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores</target>
+        <target state="translated">Poskytlo se několik kontejnerů privátních klíčů. Pro úložiště uživatele použijte /k a pro úložiště počítače použijte /km.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Při použití /csp chybí kontejner privátního klíče. K poskytnutí kontejneru klíčů použijte /k nebo /km.</target>
         <note />
       </trans-unit>
       <trans-unit id="SHA1ThumbprintOptionDescription">
         <source>SHA1 thumprint used to access a certificate from a certificate store (VSIX)</source>
-        <target state="new">SHA1 thumprint used to access a certificate from a certificate store (VSIX)</target>
+        <target state="translated">Kryptografický otisk SHA1 použitý pro přístup k certifikátu z úložiště certifikátů (VSIX).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertManagerResources.de.xlf
+++ b/src/Sign.Cli/xlf/CertManagerResources.de.xlf
@@ -4,32 +4,32 @@
     <body>
       <trans-unit id="CSPOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k or /km</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k or /km</target>
+        <target state="translated">Kryptografiedienstanbieter, der den privaten Schlüsselcontainer enthält. Erfordert /k oder /km</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container in the user store</source>
-        <target state="new">Private key container in the user store</target>
+        <target state="translated">Container mit privatem Schlüssel im Benutzerspeicher</target>
         <note />
       </trans-unit>
       <trans-unit id="MachineKeyContainerOptionDescription">
         <source>Private key container in the machine store</source>
-        <target state="new">Private key container in the machine store</target>
+        <target state="translated">Container mit privatem Schlüssel im Computerspeicher</target>
         <note />
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores</target>
+        <target state="translated">Es wurden mehrere Container mit privatem Schlüssel bereitgestellt. Verwenden Sie entweder "/k" für Benutzerspeicher oder "/km" für Computerspeicher.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Der Container für den privaten Schlüssel fehlt bei Verwendung von "/csp". Verwenden Sie "/k" oder "/km", um einen Schlüsselcontainer bereitzustellen.</target>
         <note />
       </trans-unit>
       <trans-unit id="SHA1ThumbprintOptionDescription">
         <source>SHA1 thumprint used to access a certificate from a certificate store (VSIX)</source>
-        <target state="new">SHA1 thumprint used to access a certificate from a certificate store (VSIX)</target>
+        <target state="translated">SHA1-Fingerabdruck für den Zugriff auf ein Zertifikat aus einem Zertifikatspeicher (VSIX)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertManagerResources.es.xlf
+++ b/src/Sign.Cli/xlf/CertManagerResources.es.xlf
@@ -4,32 +4,32 @@
     <body>
       <trans-unit id="CSPOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k or /km</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k or /km</target>
+        <target state="translated">Proveedor de servicios criptográficos que contiene el contenedor de claves privadas. Requiere /k o /km</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container in the user store</source>
-        <target state="new">Private key container in the user store</target>
+        <target state="translated">Contenedor de claves privadas en el almacén de usuarios</target>
         <note />
       </trans-unit>
       <trans-unit id="MachineKeyContainerOptionDescription">
         <source>Private key container in the machine store</source>
-        <target state="new">Private key container in the machine store</target>
+        <target state="translated">Contenedor de claves privadas en el almacén de máquinas</target>
         <note />
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores</target>
+        <target state="translated">Se proporcionaron varios contenedores de clave privada. Use /k para almacenes de usuarios o /km para almacenes de máquinas</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Falta el contenedor de clave privada al usar /csp. Use /k o /km para proporcionar un contenedor de claves.</target>
         <note />
       </trans-unit>
       <trans-unit id="SHA1ThumbprintOptionDescription">
         <source>SHA1 thumprint used to access a certificate from a certificate store (VSIX)</source>
-        <target state="new">SHA1 thumprint used to access a certificate from a certificate store (VSIX)</target>
+        <target state="translated">Huella digital SHA1 usada para obtener acceso a un certificado desde un almacén de certificados (VSIX)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertManagerResources.fr.xlf
+++ b/src/Sign.Cli/xlf/CertManagerResources.fr.xlf
@@ -4,32 +4,32 @@
     <body>
       <trans-unit id="CSPOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k or /km</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k or /km</target>
+        <target state="translated">Fournisseur de services de chiffrement contenant le conteneur de clé privée. Nécessite /k ou /km</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container in the user store</source>
-        <target state="new">Private key container in the user store</target>
+        <target state="translated">Conteneur de clés privées dans le magasin d’utilisateurs</target>
         <note />
       </trans-unit>
       <trans-unit id="MachineKeyContainerOptionDescription">
         <source>Private key container in the machine store</source>
-        <target state="new">Private key container in the machine store</target>
+        <target state="translated">Conteneur de clés privées dans le magasin d’ordinateurs</target>
         <note />
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores</target>
+        <target state="translated">Plusieurs conteneurs de clé privée ont été fournis. Utiliser /k pour les magasins d’utilisateurs ou /km pour les magasins d’ordinateurs</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Le conteneur de clé privée est manquant lors de l’utilisation de /csp. Utilisez /k ou /km pour fournir un conteneur de clé.</target>
         <note />
       </trans-unit>
       <trans-unit id="SHA1ThumbprintOptionDescription">
         <source>SHA1 thumprint used to access a certificate from a certificate store (VSIX)</source>
-        <target state="new">SHA1 thumprint used to access a certificate from a certificate store (VSIX)</target>
+        <target state="translated">Empreinte SHA-1 utilisée pour accéder à un certificat à partir d’un magasin de certificats (VSIX)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertManagerResources.it.xlf
+++ b/src/Sign.Cli/xlf/CertManagerResources.it.xlf
@@ -4,32 +4,32 @@
     <body>
       <trans-unit id="CSPOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k or /km</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k or /km</target>
+        <target state="translated">Provider del servizio di crittografia contenente il contenitore di chiavi private. Richiede /k o /km</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container in the user store</source>
-        <target state="new">Private key container in the user store</target>
+        <target state="translated">Contenitore di chiavi private nell'archivio utenti</target>
         <note />
       </trans-unit>
       <trans-unit id="MachineKeyContainerOptionDescription">
         <source>Private key container in the machine store</source>
-        <target state="new">Private key container in the machine store</target>
+        <target state="translated">Contenitore di chiavi private nell'archivio computer</target>
         <note />
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores</target>
+        <target state="translated">Sono stati specificati più contenitori di chiavi private. Utilizzare /k per gli archivi utente o /km per gli archivi computer</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Contenitore di chiavi private mancante durante l'utilizzo di /csp. Usare /k o /km per specificare un contenitore di chiavi.</target>
         <note />
       </trans-unit>
       <trans-unit id="SHA1ThumbprintOptionDescription">
         <source>SHA1 thumprint used to access a certificate from a certificate store (VSIX)</source>
-        <target state="new">SHA1 thumprint used to access a certificate from a certificate store (VSIX)</target>
+        <target state="translated">Identificazione personale SHA1 usata per accedere a un certificato da un archivio certificati (VSIX)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertManagerResources.ja.xlf
+++ b/src/Sign.Cli/xlf/CertManagerResources.ja.xlf
@@ -4,32 +4,32 @@
     <body>
       <trans-unit id="CSPOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k or /km</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k or /km</target>
+        <target state="translated">秘密キー コンテナーを含む暗号化サービス プロバイダー。/k または /km が必要です</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container in the user store</source>
-        <target state="new">Private key container in the user store</target>
+        <target state="translated">ユーザー ストア内の秘密キー コンテナー</target>
         <note />
       </trans-unit>
       <trans-unit id="MachineKeyContainerOptionDescription">
         <source>Private key container in the machine store</source>
-        <target state="new">Private key container in the machine store</target>
+        <target state="translated">コンピューター ストア内の秘密キー コンテナー</target>
         <note />
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores</target>
+        <target state="translated">複数の秘密キー コンテナーが提供されています。ユーザー ストアには /k、コンピューター ストアの場合は /km を使用します</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">/csp の使用中に秘密キー コンテナーが見つかりません。キー コンテナーを指定するには、/k または /km を使用します。</target>
         <note />
       </trans-unit>
       <trans-unit id="SHA1ThumbprintOptionDescription">
         <source>SHA1 thumprint used to access a certificate from a certificate store (VSIX)</source>
-        <target state="new">SHA1 thumprint used to access a certificate from a certificate store (VSIX)</target>
+        <target state="translated">証明書ストア (VSIX) から証明書にアクセスするために使用される SHA1 拇印</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertManagerResources.ko.xlf
+++ b/src/Sign.Cli/xlf/CertManagerResources.ko.xlf
@@ -4,32 +4,32 @@
     <body>
       <trans-unit id="CSPOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k or /km</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k or /km</target>
+        <target state="translated">프라이빗 키 컨테이너를 포함하는 암호화 서비스 공급자입니다. /k 또는 /km 필요</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container in the user store</source>
-        <target state="new">Private key container in the user store</target>
+        <target state="translated">사용자 저장소의 프라이빗 키 컨테이너</target>
         <note />
       </trans-unit>
       <trans-unit id="MachineKeyContainerOptionDescription">
         <source>Private key container in the machine store</source>
-        <target state="new">Private key container in the machine store</target>
+        <target state="translated">컴퓨터 저장소의 프라이빗 키 컨테이너</target>
         <note />
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores</target>
+        <target state="translated">여러 프라이빗 키 컨테이너가 제공되었습니다. 사용자 저장소에는 /k를, 컴퓨터 저장소에는 /km 사용</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">/csp를 사용하는 동안 프라이빗 키 컨테이너가 없습니다. /k 또는 /km를 사용하여 키 컨테이너를 제공합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="SHA1ThumbprintOptionDescription">
         <source>SHA1 thumprint used to access a certificate from a certificate store (VSIX)</source>
-        <target state="new">SHA1 thumprint used to access a certificate from a certificate store (VSIX)</target>
+        <target state="translated">VSIX(인증서 저장소)에서 인증서에 액세스하는 데 사용되는 SHA1 지문</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertManagerResources.pl.xlf
+++ b/src/Sign.Cli/xlf/CertManagerResources.pl.xlf
@@ -4,32 +4,32 @@
     <body>
       <trans-unit id="CSPOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k or /km</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k or /km</target>
+        <target state="translated">Dostawca usług kryptograficznych zawierający kontener kluczy prywatnych. Wymaga opcji /k lub /km</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container in the user store</source>
-        <target state="new">Private key container in the user store</target>
+        <target state="translated">Kontener kluczy prywatnych w magazynie użytkowników</target>
         <note />
       </trans-unit>
       <trans-unit id="MachineKeyContainerOptionDescription">
         <source>Private key container in the machine store</source>
-        <target state="new">Private key container in the machine store</target>
+        <target state="translated">Kontener kluczy prywatnych w magazynie komputerów</target>
         <note />
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores</target>
+        <target state="translated">Podano wiele kontenerów kluczy prywatnych. Użyj opcji /k dla magazynów użytkowników lub opcji /km dla magazynów komputerów</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Brak kontenera kluczy prywatnych podczas używania opcji /csp. Użyj opcji /k lub /km, aby podać kontener kluczy.</target>
         <note />
       </trans-unit>
       <trans-unit id="SHA1ThumbprintOptionDescription">
         <source>SHA1 thumprint used to access a certificate from a certificate store (VSIX)</source>
-        <target state="new">SHA1 thumprint used to access a certificate from a certificate store (VSIX)</target>
+        <target state="translated">Odcisk palca SHA1 używany do uzyskiwania dostępu do certyfikatu z magazynu certyfikatów (VSIX)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertManagerResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/CertManagerResources.pt-BR.xlf
@@ -4,32 +4,32 @@
     <body>
       <trans-unit id="CSPOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k or /km</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k or /km</target>
+        <target state="translated">Provedor de Serviços Criptográficos que contém o contêiner de chave privada. Requer /k ou /km</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container in the user store</source>
-        <target state="new">Private key container in the user store</target>
+        <target state="translated">Contêiner de chave privada no repositório do usuário</target>
         <note />
       </trans-unit>
       <trans-unit id="MachineKeyContainerOptionDescription">
         <source>Private key container in the machine store</source>
-        <target state="new">Private key container in the machine store</target>
+        <target state="translated">Contêiner de chave privada no repositório do computador</target>
         <note />
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores</target>
+        <target state="translated">Vários contêineres de chave privada fornecidos. Usar /k para repositórios de usuários ou /km para repositórios de computadores</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Contêiner de chave privada ausente ao usar /csp. Use /k ou /km para fornecer um contêiner de chave.</target>
         <note />
       </trans-unit>
       <trans-unit id="SHA1ThumbprintOptionDescription">
         <source>SHA1 thumprint used to access a certificate from a certificate store (VSIX)</source>
-        <target state="new">SHA1 thumprint used to access a certificate from a certificate store (VSIX)</target>
+        <target state="translated">Impressão digital SHA1 usada para acessar um certificado de um repositório de certificados (VSIX)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertManagerResources.ru.xlf
+++ b/src/Sign.Cli/xlf/CertManagerResources.ru.xlf
@@ -4,32 +4,32 @@
     <body>
       <trans-unit id="CSPOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k or /km</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k or /km</target>
+        <target state="translated">Поставщик служб шифрования, содержащий контейнер закрытого ключа. Требуется /k или /km</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container in the user store</source>
-        <target state="new">Private key container in the user store</target>
+        <target state="translated">Контейнер закрытого ключа в хранилище пользователя</target>
         <note />
       </trans-unit>
       <trans-unit id="MachineKeyContainerOptionDescription">
         <source>Private key container in the machine store</source>
-        <target state="new">Private key container in the machine store</target>
+        <target state="translated">Контейнер закрытого ключа в хранилище компьютера</target>
         <note />
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores</target>
+        <target state="translated">Предоставлено несколько контейнеров закрытых ключей. Используйте /k для хранилищ пользователей или /km для хранилищ компьютеров</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Отсутствует контейнер закрытого ключа при использовании /csp. Используйте /k или /km для предоставления контейнера ключей.</target>
         <note />
       </trans-unit>
       <trans-unit id="SHA1ThumbprintOptionDescription">
         <source>SHA1 thumprint used to access a certificate from a certificate store (VSIX)</source>
-        <target state="new">SHA1 thumprint used to access a certificate from a certificate store (VSIX)</target>
+        <target state="translated">Отпечаток SHA1, используемый для доступа к сертификату из хранилища сертификатов (VSIX)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertManagerResources.tr.xlf
+++ b/src/Sign.Cli/xlf/CertManagerResources.tr.xlf
@@ -4,32 +4,32 @@
     <body>
       <trans-unit id="CSPOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k or /km</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k or /km</target>
+        <target state="translated">Özel anahtar kapsayıcısını içeren Şifreleme Hizmeti Sağlayıcısı. /k veya /km gerektirir</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container in the user store</source>
-        <target state="new">Private key container in the user store</target>
+        <target state="translated">Kullanıcı deposundaki özel anahtar kapsayıcısı</target>
         <note />
       </trans-unit>
       <trans-unit id="MachineKeyContainerOptionDescription">
         <source>Private key container in the machine store</source>
-        <target state="new">Private key container in the machine store</target>
+        <target state="translated">Makine deposundaki özel anahtar kapsayıcısı</target>
         <note />
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores</target>
+        <target state="translated">Birden çok özel anahtar kapsayıcısı sağlandı. Kullanıcı depoları için /k veya makine depoları için /km kullanın</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">/csp kullanılırken özel anahtar kapsayıcısı eksik. Anahtar kapsayıcısı sağlamak için /k veya /km kullanın.</target>
         <note />
       </trans-unit>
       <trans-unit id="SHA1ThumbprintOptionDescription">
         <source>SHA1 thumprint used to access a certificate from a certificate store (VSIX)</source>
-        <target state="new">SHA1 thumprint used to access a certificate from a certificate store (VSIX)</target>
+        <target state="translated">Sertifika deposundan (VSIX) bir sertifikaya erişmek için SHA1 parmak izi kullanıldı</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertManagerResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/CertManagerResources.zh-Hans.xlf
@@ -4,32 +4,32 @@
     <body>
       <trans-unit id="CSPOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k or /km</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k or /km</target>
+        <target state="translated">包含私钥容器的加密服务提供程序。需要 /k 或 /km</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container in the user store</source>
-        <target state="new">Private key container in the user store</target>
+        <target state="translated">用户存储中的私钥容器</target>
         <note />
       </trans-unit>
       <trans-unit id="MachineKeyContainerOptionDescription">
         <source>Private key container in the machine store</source>
-        <target state="new">Private key container in the machine store</target>
+        <target state="translated">计算机存储中的私钥容器</target>
         <note />
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores</target>
+        <target state="translated">提供了多个私钥容器。对用户存储使用 /k，或者对计算机存储使用 /km</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">使用 /csp 时缺少私钥容器。使用 /k 或 /km 提供密钥容器。</target>
         <note />
       </trans-unit>
       <trans-unit id="SHA1ThumbprintOptionDescription">
         <source>SHA1 thumprint used to access a certificate from a certificate store (VSIX)</source>
-        <target state="new">SHA1 thumprint used to access a certificate from a certificate store (VSIX)</target>
+        <target state="translated">用于访问证书存储(VSIX)中的证书的 SHA1 直纹</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertManagerResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/CertManagerResources.zh-Hant.xlf
@@ -4,32 +4,32 @@
     <body>
       <trans-unit id="CSPOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k or /km</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k or /km</target>
+        <target state="translated">包含私密金鑰容器的加密服務提供者。需要 /k 或 /km</target>
         <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container in the user store</source>
-        <target state="new">Private key container in the user store</target>
+        <target state="translated">使用者存放區中的私密金鑰</target>
         <note />
       </trans-unit>
       <trans-unit id="MachineKeyContainerOptionDescription">
         <source>Private key container in the machine store</source>
-        <target state="new">Private key container in the machine store</target>
+        <target state="translated">機器存放區中的私密金鑰</target>
         <note />
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores</target>
+        <target state="translated">已提供多個私密金鑰。使用者存放區使用 /k，機器存放區則使用 /km</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">使用 /csp 時遺漏私密金鑰容器。使用 /k 或 /km 來提供金鑰容器。</target>
         <note />
       </trans-unit>
       <trans-unit id="SHA1ThumbprintOptionDescription">
         <source>SHA1 thumprint used to access a certificate from a certificate store (VSIX)</source>
-        <target state="new">SHA1 thumprint used to access a certificate from a certificate store (VSIX)</target>
+        <target state="translated">用以從憑證存放區 (VSIX) 存取憑證的 SHA1 指紋</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
@@ -4,42 +4,42 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
+        <target state="translated">Soubor PFX, P7B nebo CER obsahující certifikát a potenciálně privátní klíč.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="new">Password for certificate file.</target>
+        <target state="translated">Heslo pro soubor certifikátu.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
+        <target state="translated">Zprostředkovatel kryptografických služeb obsahující kontejner privátního klíče. Vyžaduje /k a volitelně /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="new">Private key container name.</target>
+        <target state="translated">Název kontejneru privátního klíče.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
+        <target state="translated">Chybí zprostředkovatel kryptografických služeb.  K určení zprostředkovatele kryptografických služeb použijte /csp.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
+        <target state="translated">Chybí název kontejneru privátního klíče. Název kontejneru klíče zadejte pomocí /k.</target>
         <note>{Locked="/k"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="Sha1ThumbprintOptionDescription">
         <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="new">SHA-1 thumbprint used to identify a certificate.</target>
+        <target state="translated">Kryptografický otisk SHA-1 sloužící k identifikaci certifikátu.</target>
         <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
+        <target state="translated">Použijte kontejner privátního klíče na úrovni počítače.  (Výchozí hodnota je na úrovni uživatele.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
@@ -7,20 +7,20 @@
         <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
+      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
+        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateFingerprintOptionDescription">
+        <source>SHA fingerprint used to identify a certificate.</source>
+        <target state="new">SHA fingerprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
+      </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
         <target state="new">Password for certificate file.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
-        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintOptionDescription">
-        <source>SHA thumbprint used to identify a certificate.</source>
-        <target state="new">SHA thumbprint used to identify a certificate.</target>
-        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
@@ -8,9 +8,9 @@
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
@@ -4,42 +4,47 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="translated">Soubor PFX, P7B nebo CER obsahující certifikát a potenciálně privátní klíč.</target>
+        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="translated">Heslo pro soubor certifikátu.</target>
+        <target state="new">Password for certificate file.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
+        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintOptionDescription">
+        <source>SHA thumbprint used to identify a certificate.</source>
+        <target state="new">SHA thumbprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="translated">Zprostředkovatel kryptografických služeb obsahující kontejner privátního klíče. Vyžaduje /k a volitelně /km.</target>
+        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="translated">Název kontejneru privátního klíče.</target>
+        <target state="new">Private key container name.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="translated">Chybí zprostředkovatel kryptografických služeb.  K určení zprostředkovatele kryptografických služeb použijte /csp.</target>
+        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="translated">Chybí název kontejneru privátního klíče. Název kontejneru klíče zadejte pomocí /k.</target>
+        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
         <note>{Locked="/k"} is a command line option.</note>
-      </trans-unit>
-      <trans-unit id="Sha1ThumbprintOptionDescription">
-        <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="translated">Kryptografický otisk SHA-1 sloužící k identifikaci certifikátu.</target>
-        <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="translated">Použijte kontejner privátního klíče na úrovni počítače.  (Výchozí hodnota je na úrovni uživatele.)</target>
+        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
@@ -4,42 +4,42 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
+        <target state="translated">PFX-, P7B- oder CER-Datei, die ein Zertifikat und möglicherweise einen privaten Schlüssel enthält.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="new">Password for certificate file.</target>
+        <target state="translated">Kennwort für Zertifikatdatei.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
+        <target state="translated">Kryptografiedienstanbieter, der den privaten Schlüsselcontainer enthält. Erfordert /k und optional /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="new">Private key container name.</target>
+        <target state="translated">Name des privaten Schlüsselcontainers.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
+        <target state="translated">Kryptografiedienstanbieter fehlt.  Verwenden Sie "/csp", um einen CSP anzugeben.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
+        <target state="translated">Der Name des privaten Schlüsselcontainers fehlt. Verwenden Sie /k, um einen Schlüsselcontainernamen anzugeben.</target>
         <note>{Locked="/k"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="Sha1ThumbprintOptionDescription">
         <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="new">SHA-1 thumbprint used to identify a certificate.</target>
+        <target state="translated">SHA-1-Fingerabdruck zum Identifizieren eines Zertifikats.</target>
         <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
+        <target state="translated">Verwenden Sie einen Container mit privatem Schlüssel auf Computerebene.  (Der Standardwert ist Benutzerebene.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
@@ -4,42 +4,47 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="translated">PFX-, P7B- oder CER-Datei, die ein Zertifikat und möglicherweise einen privaten Schlüssel enthält.</target>
+        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="translated">Kennwort für Zertifikatdatei.</target>
+        <target state="new">Password for certificate file.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
+        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintOptionDescription">
+        <source>SHA thumbprint used to identify a certificate.</source>
+        <target state="new">SHA thumbprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="translated">Kryptografiedienstanbieter, der den privaten Schlüsselcontainer enthält. Erfordert /k und optional /km.</target>
+        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="translated">Name des privaten Schlüsselcontainers.</target>
+        <target state="new">Private key container name.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="translated">Kryptografiedienstanbieter fehlt.  Verwenden Sie "/csp", um einen CSP anzugeben.</target>
+        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="translated">Der Name des privaten Schlüsselcontainers fehlt. Verwenden Sie /k, um einen Schlüsselcontainernamen anzugeben.</target>
+        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
         <note>{Locked="/k"} is a command line option.</note>
-      </trans-unit>
-      <trans-unit id="Sha1ThumbprintOptionDescription">
-        <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="translated">SHA-1-Fingerabdruck zum Identifizieren eines Zertifikats.</target>
-        <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="translated">Verwenden Sie einen Container mit privatem Schlüssel auf Computerebene.  (Der Standardwert ist Benutzerebene.)</target>
+        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
@@ -7,20 +7,20 @@
         <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
+      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
+        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateFingerprintOptionDescription">
+        <source>SHA fingerprint used to identify a certificate.</source>
+        <target state="new">SHA fingerprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
+      </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
         <target state="new">Password for certificate file.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
-        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintOptionDescription">
-        <source>SHA thumbprint used to identify a certificate.</source>
-        <target state="new">SHA thumbprint used to identify a certificate.</target>
-        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
@@ -8,9 +8,9 @@
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
@@ -7,20 +7,20 @@
         <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
+      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
+        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateFingerprintOptionDescription">
+        <source>SHA fingerprint used to identify a certificate.</source>
+        <target state="new">SHA fingerprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
+      </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
         <target state="new">Password for certificate file.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
-        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintOptionDescription">
-        <source>SHA thumbprint used to identify a certificate.</source>
-        <target state="new">SHA thumbprint used to identify a certificate.</target>
-        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
@@ -4,42 +4,47 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="translated">Archivo PFX, P7B o CER que contiene un certificado y una clave privada potencialmente.</target>
+        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="translated">Contraseña del archivo de certificado.</target>
+        <target state="new">Password for certificate file.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
+        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintOptionDescription">
+        <source>SHA thumbprint used to identify a certificate.</source>
+        <target state="new">SHA thumbprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="translated">Proveedor de servicios criptográficos que contiene el contenedor de claves privadas. Requiere /k y, opcionalmente, /km.</target>
+        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="translated">Nombre de contenedor de clave privada.</target>
+        <target state="new">Private key container name.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="translated">Falta el proveedor de servicios criptográficos.  Use /csp para especificar un CSP.</target>
+        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="translated">Falta el nombre de contenedor de claves privadas. Use /k para especificar un nombre de contenedor de claves.</target>
+        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
         <note>{Locked="/k"} is a command line option.</note>
-      </trans-unit>
-      <trans-unit id="Sha1ThumbprintOptionDescription">
-        <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="translated">Huella digital SHA-1 usada para identificar certificados.</target>
-        <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="translated">Use un contenedor de claves privadas de nivel de máquina.  (El valor predeterminado es de nivel de usuario).</target>
+        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
@@ -4,42 +4,42 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
+        <target state="translated">Archivo PFX, P7B o CER que contiene un certificado y una clave privada potencialmente.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="new">Password for certificate file.</target>
+        <target state="translated">Contraseña del archivo de certificado.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
+        <target state="translated">Proveedor de servicios criptográficos que contiene el contenedor de claves privadas. Requiere /k y, opcionalmente, /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="new">Private key container name.</target>
+        <target state="translated">Nombre de contenedor de clave privada.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
+        <target state="translated">Falta el proveedor de servicios criptográficos.  Use /csp para especificar un CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
+        <target state="translated">Falta el nombre de contenedor de claves privadas. Use /k para especificar un nombre de contenedor de claves.</target>
         <note>{Locked="/k"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="Sha1ThumbprintOptionDescription">
         <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="new">SHA-1 thumbprint used to identify a certificate.</target>
+        <target state="translated">Huella digital SHA-1 usada para identificar certificados.</target>
         <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
+        <target state="translated">Use un contenedor de claves privadas de nivel de máquina.  (El valor predeterminado es de nivel de usuario).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
@@ -8,9 +8,9 @@
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
@@ -4,42 +4,42 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
+        <target state="translated">Fichier PFX, P7B ou CER contenant un certificat et éventuellement une clé privée.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="new">Password for certificate file.</target>
+        <target state="translated">Mot de passe du fichier du certificat.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
+        <target state="translated">Fournisseur de services de chiffrement contenant le conteneur de clé privée. Nécessite /k et éventuellement /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="new">Private key container name.</target>
+        <target state="translated">Nom de conteneur de clé privée.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
+        <target state="translated">Le fournisseur de services de chiffrement est manquant.  Utilisez /csp pour spécifier un fournisseur de solutions Cloud.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
+        <target state="translated">Le nom de conteneur de clé privée est manquant. Utilisez /k pour spécifier un nom de conteneur de clé.</target>
         <note>{Locked="/k"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="Sha1ThumbprintOptionDescription">
         <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="new">SHA-1 thumbprint used to identify a certificate.</target>
+        <target state="translated">Empreinte SHA-1 utilisée pour identifier un certificat.</target>
         <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
+        <target state="translated">Utilisez un conteneur de clé privée au niveau de l’ordinateur.  (La valeur par défaut est au niveau de l’utilisateur.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
@@ -7,20 +7,20 @@
         <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
+      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
+        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateFingerprintOptionDescription">
+        <source>SHA fingerprint used to identify a certificate.</source>
+        <target state="new">SHA fingerprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
+      </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
         <target state="new">Password for certificate file.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
-        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintOptionDescription">
-        <source>SHA thumbprint used to identify a certificate.</source>
-        <target state="new">SHA thumbprint used to identify a certificate.</target>
-        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
@@ -8,9 +8,9 @@
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
@@ -4,42 +4,47 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="translated">Fichier PFX, P7B ou CER contenant un certificat et éventuellement une clé privée.</target>
+        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="translated">Mot de passe du fichier du certificat.</target>
+        <target state="new">Password for certificate file.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
+        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintOptionDescription">
+        <source>SHA thumbprint used to identify a certificate.</source>
+        <target state="new">SHA thumbprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="translated">Fournisseur de services de chiffrement contenant le conteneur de clé privée. Nécessite /k et éventuellement /km.</target>
+        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="translated">Nom de conteneur de clé privée.</target>
+        <target state="new">Private key container name.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="translated">Le fournisseur de services de chiffrement est manquant.  Utilisez /csp pour spécifier un fournisseur de solutions Cloud.</target>
+        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="translated">Le nom de conteneur de clé privée est manquant. Utilisez /k pour spécifier un nom de conteneur de clé.</target>
+        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
         <note>{Locked="/k"} is a command line option.</note>
-      </trans-unit>
-      <trans-unit id="Sha1ThumbprintOptionDescription">
-        <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="translated">Empreinte SHA-1 utilisée pour identifier un certificat.</target>
-        <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="translated">Utilisez un conteneur de clé privée au niveau de l’ordinateur.  (La valeur par défaut est au niveau de l’utilisateur.)</target>
+        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
@@ -4,42 +4,47 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="translated">PFX, P7B o CER file contenente un certificato e potenzialmente una chiave privata.</target>
+        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="translated">Password per file certificato.</target>
+        <target state="new">Password for certificate file.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
+        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintOptionDescription">
+        <source>SHA thumbprint used to identify a certificate.</source>
+        <target state="new">SHA thumbprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="translated">Provider del servizio di crittografia contenente il contenitore di chiavi private. Richiede /k e facoltativamente /km.</target>
+        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="translated">Nome del contenitore di chiavi private.</target>
+        <target state="new">Private key container name.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="translated">Provider del servizio di crittografia mancante.  Utilizzare /csp per specificare un CSP.</target>
+        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="translated">Nome del contenitore di chiavi private mancante. Usare /k per specificare il nome di un contenitore di chiavi.</target>
+        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
         <note>{Locked="/k"} is a command line option.</note>
-      </trans-unit>
-      <trans-unit id="Sha1ThumbprintOptionDescription">
-        <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="translated">Identificazione personale SHA-1 usata per identificare un certificato.</target>
-        <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="translated">Usare un contenitore di chiavi private a livello di computer.  (Il valore predefinito è a livello di utente).</target>
+        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
@@ -7,20 +7,20 @@
         <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
+      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
+        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateFingerprintOptionDescription">
+        <source>SHA fingerprint used to identify a certificate.</source>
+        <target state="new">SHA fingerprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
+      </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
         <target state="new">Password for certificate file.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
-        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintOptionDescription">
-        <source>SHA thumbprint used to identify a certificate.</source>
-        <target state="new">SHA thumbprint used to identify a certificate.</target>
-        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
@@ -8,9 +8,9 @@
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
@@ -4,42 +4,42 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
+        <target state="translated">PFX, P7B o CER file contenente un certificato e potenzialmente una chiave privata.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="new">Password for certificate file.</target>
+        <target state="translated">Password per file certificato.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
+        <target state="translated">Provider del servizio di crittografia contenente il contenitore di chiavi private. Richiede /k e facoltativamente /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="new">Private key container name.</target>
+        <target state="translated">Nome del contenitore di chiavi private.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
+        <target state="translated">Provider del servizio di crittografia mancante.  Utilizzare /csp per specificare un CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
+        <target state="translated">Nome del contenitore di chiavi private mancante. Usare /k per specificare il nome di un contenitore di chiavi.</target>
         <note>{Locked="/k"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="Sha1ThumbprintOptionDescription">
         <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="new">SHA-1 thumbprint used to identify a certificate.</target>
+        <target state="translated">Identificazione personale SHA-1 usata per identificare un certificato.</target>
         <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
+        <target state="translated">Usare un contenitore di chiavi private a livello di computer.  (Il valore predefinito è a livello di utente).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
@@ -7,20 +7,20 @@
         <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
+      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
+        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateFingerprintOptionDescription">
+        <source>SHA fingerprint used to identify a certificate.</source>
+        <target state="new">SHA fingerprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
+      </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
         <target state="new">Password for certificate file.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
-        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintOptionDescription">
-        <source>SHA thumbprint used to identify a certificate.</source>
-        <target state="new">SHA thumbprint used to identify a certificate.</target>
-        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
@@ -8,9 +8,9 @@
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
@@ -4,42 +4,47 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="translated">証明書と潜在的に秘密キーを含む PFX、P7B、または CER ファイル。</target>
+        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="translated">証明書ファイルのパスワード。</target>
+        <target state="new">Password for certificate file.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
+        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintOptionDescription">
+        <source>SHA thumbprint used to identify a certificate.</source>
+        <target state="new">SHA thumbprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="translated">秘密キー コンテナーを含む暗号化サービス プロバイダー。/k および必要に応じて /km が必要です。</target>
+        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="translated">秘密キー コンテナー名。</target>
+        <target state="new">Private key container name.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="translated">暗号化サービス プロバイダーがありません。/csp を使用して CSP を指定します。</target>
+        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="translated">秘密キー コンテナー名がありません。キー コンテナー名を指定するには、/k を使用します。</target>
+        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
         <note>{Locked="/k"} is a command line option.</note>
-      </trans-unit>
-      <trans-unit id="Sha1ThumbprintOptionDescription">
-        <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="translated">証明書の識別に使用される SHA-1 拇印。</target>
-        <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="translated">コンピューター レベルの秘密キー コンテナーを使用します。(既定値はユーザー レベルです)。</target>
+        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
@@ -4,42 +4,42 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
+        <target state="translated">証明書と潜在的に秘密キーを含む PFX、P7B、または CER ファイル。</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="new">Password for certificate file.</target>
+        <target state="translated">証明書ファイルのパスワード。</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
+        <target state="translated">秘密キー コンテナーを含む暗号化サービス プロバイダー。/k および必要に応じて /km が必要です。</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="new">Private key container name.</target>
+        <target state="translated">秘密キー コンテナー名。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
+        <target state="translated">暗号化サービス プロバイダーがありません。/csp を使用して CSP を指定します。</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
+        <target state="translated">秘密キー コンテナー名がありません。キー コンテナー名を指定するには、/k を使用します。</target>
         <note>{Locked="/k"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="Sha1ThumbprintOptionDescription">
         <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="new">SHA-1 thumbprint used to identify a certificate.</target>
+        <target state="translated">証明書の識別に使用される SHA-1 拇印。</target>
         <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
+        <target state="translated">コンピューター レベルの秘密キー コンテナーを使用します。(既定値はユーザー レベルです)。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
@@ -7,20 +7,20 @@
         <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
+      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
+        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateFingerprintOptionDescription">
+        <source>SHA fingerprint used to identify a certificate.</source>
+        <target state="new">SHA fingerprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
+      </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
         <target state="new">Password for certificate file.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
-        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintOptionDescription">
-        <source>SHA thumbprint used to identify a certificate.</source>
-        <target state="new">SHA thumbprint used to identify a certificate.</target>
-        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
@@ -4,42 +4,47 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="translated">인증서와 잠재적으로 프라이빗 키가 포함된 PFX, P7B 또는 CER 파일입니다.</target>
+        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="translated">인증서 파일의 암호입니다.</target>
+        <target state="new">Password for certificate file.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
+        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintOptionDescription">
+        <source>SHA thumbprint used to identify a certificate.</source>
+        <target state="new">SHA thumbprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="translated">프라이빗 키 컨테이너를 포함하는 암호화 서비스 공급자입니다. /k 및 선택적으로 /km이 필요합니다.</target>
+        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="translated">프라이빗 키 컨테이너 이름입니다.</target>
+        <target state="new">Private key container name.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="translated">암호화 서비스 공급자가 없습니다.  /csp를 사용하여 CSP를 지정합니다.</target>
+        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="translated">프라이빗 키 컨테이너 이름이 없습니다. /k를 사용하여 키 컨테이너 이름을 지정합니다.</target>
+        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
         <note>{Locked="/k"} is a command line option.</note>
-      </trans-unit>
-      <trans-unit id="Sha1ThumbprintOptionDescription">
-        <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="translated">인증서를 식별하는 데 사용되는 SHA-1 지문입니다.</target>
-        <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="translated">컴퓨터 수준 프라이빗 키 컨테이너를 사용합니다.  (기본값은 사용자 수준입니다.)</target>
+        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
@@ -4,42 +4,42 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
+        <target state="translated">인증서와 잠재적으로 프라이빗 키가 포함된 PFX, P7B 또는 CER 파일입니다.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="new">Password for certificate file.</target>
+        <target state="translated">인증서 파일의 암호입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
+        <target state="translated">프라이빗 키 컨테이너를 포함하는 암호화 서비스 공급자입니다. /k 및 선택적으로 /km이 필요합니다.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="new">Private key container name.</target>
+        <target state="translated">프라이빗 키 컨테이너 이름입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
+        <target state="translated">암호화 서비스 공급자가 없습니다.  /csp를 사용하여 CSP를 지정합니다.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
+        <target state="translated">프라이빗 키 컨테이너 이름이 없습니다. /k를 사용하여 키 컨테이너 이름을 지정합니다.</target>
         <note>{Locked="/k"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="Sha1ThumbprintOptionDescription">
         <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="new">SHA-1 thumbprint used to identify a certificate.</target>
+        <target state="translated">인증서를 식별하는 데 사용되는 SHA-1 지문입니다.</target>
         <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
+        <target state="translated">컴퓨터 수준 프라이빗 키 컨테이너를 사용합니다.  (기본값은 사용자 수준입니다.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
@@ -8,9 +8,9 @@
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
@@ -7,20 +7,20 @@
         <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
+      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
+        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateFingerprintOptionDescription">
+        <source>SHA fingerprint used to identify a certificate.</source>
+        <target state="new">SHA fingerprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
+      </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
         <target state="new">Password for certificate file.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
-        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintOptionDescription">
-        <source>SHA thumbprint used to identify a certificate.</source>
-        <target state="new">SHA thumbprint used to identify a certificate.</target>
-        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
@@ -8,9 +8,9 @@
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
@@ -4,42 +4,47 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="translated">Plik PFX, P7B lub CER zawierający certyfikat i potencjalnie klucz prywatny.</target>
+        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="translated">Hasło dla pliku certyfikatu.</target>
+        <target state="new">Password for certificate file.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
+        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintOptionDescription">
+        <source>SHA thumbprint used to identify a certificate.</source>
+        <target state="new">SHA thumbprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="translated">Dostawca usług kryptograficznych zawierający kontener kluczy prywatnych. Wymaga opcji /k i opcjonalnie /km.</target>
+        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="translated">Nazwa kontenera kluczy prywatnych.</target>
+        <target state="new">Private key container name.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="translated">Brak dostawcy usług kryptograficznych.  Użyj /csp, aby określić dostawcę CSP.</target>
+        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="translated">Brak nazwy kontenera kluczy prywatnych. Użyj opcji /k, aby określić nazwę kontenera kluczy.</target>
+        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
         <note>{Locked="/k"} is a command line option.</note>
-      </trans-unit>
-      <trans-unit id="Sha1ThumbprintOptionDescription">
-        <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="translated">SHA-1 odcisk palca używany do identyfikowania certyfikatu.</target>
-        <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="translated">Użyj kontenera kluczy prywatnych na poziomie komputera.  (Wartość domyślna to poziom użytkownika).</target>
+        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
@@ -4,42 +4,42 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
+        <target state="translated">Plik PFX, P7B lub CER zawierający certyfikat i potencjalnie klucz prywatny.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="new">Password for certificate file.</target>
+        <target state="translated">Hasło dla pliku certyfikatu.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
+        <target state="translated">Dostawca usług kryptograficznych zawierający kontener kluczy prywatnych. Wymaga opcji /k i opcjonalnie /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="new">Private key container name.</target>
+        <target state="translated">Nazwa kontenera kluczy prywatnych.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
+        <target state="translated">Brak dostawcy usług kryptograficznych.  Użyj /csp, aby określić dostawcę CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
+        <target state="translated">Brak nazwy kontenera kluczy prywatnych. Użyj opcji /k, aby określić nazwę kontenera kluczy.</target>
         <note>{Locked="/k"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="Sha1ThumbprintOptionDescription">
         <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="new">SHA-1 thumbprint used to identify a certificate.</target>
+        <target state="translated">SHA-1 odcisk palca używany do identyfikowania certyfikatu.</target>
         <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
+        <target state="translated">Użyj kontenera kluczy prywatnych na poziomie komputera.  (Wartość domyślna to poziom użytkownika).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
@@ -4,42 +4,42 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
+        <target state="translated">Arquivos PFX, P7B ou CER que contêm um certificado e, possivelmente, uma chave privada.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="new">Password for certificate file.</target>
+        <target state="translated">Senha do arquivo do certificado.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
+        <target state="translated">Provedor de Serviços Criptográficos que contém o contêiner de chave privada. Requer /k e, opcionalmente, /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="new">Private key container name.</target>
+        <target state="translated">Nome do contêiner de chave privada.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
+        <target state="translated">Provedor de Serviços Criptográficos ausente.  Use /csp para especificar um CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
+        <target state="translated">Nome do contêiner de chave privada ausente. Use /k para especificar um nome de contêiner de chave.</target>
         <note>{Locked="/k"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="Sha1ThumbprintOptionDescription">
         <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="new">SHA-1 thumbprint used to identify a certificate.</target>
+        <target state="translated">Impressão digital SHA-1 usada para identificar um certificado.</target>
         <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
+        <target state="translated">Use um contêiner de chave privada no nível do computador.  (O padrão é o nível do usuário.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
@@ -7,20 +7,20 @@
         <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
+      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
+        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateFingerprintOptionDescription">
+        <source>SHA fingerprint used to identify a certificate.</source>
+        <target state="new">SHA fingerprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
+      </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
         <target state="new">Password for certificate file.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
-        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintOptionDescription">
-        <source>SHA thumbprint used to identify a certificate.</source>
-        <target state="new">SHA thumbprint used to identify a certificate.</target>
-        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
@@ -8,9 +8,9 @@
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
@@ -4,42 +4,47 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="translated">Arquivos PFX, P7B ou CER que contêm um certificado e, possivelmente, uma chave privada.</target>
+        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="translated">Senha do arquivo do certificado.</target>
+        <target state="new">Password for certificate file.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
+        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintOptionDescription">
+        <source>SHA thumbprint used to identify a certificate.</source>
+        <target state="new">SHA thumbprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="translated">Provedor de Serviços Criptográficos que contém o contêiner de chave privada. Requer /k e, opcionalmente, /km.</target>
+        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="translated">Nome do contêiner de chave privada.</target>
+        <target state="new">Private key container name.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="translated">Provedor de Serviços Criptográficos ausente.  Use /csp para especificar um CSP.</target>
+        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="translated">Nome do contêiner de chave privada ausente. Use /k para especificar um nome de contêiner de chave.</target>
+        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
         <note>{Locked="/k"} is a command line option.</note>
-      </trans-unit>
-      <trans-unit id="Sha1ThumbprintOptionDescription">
-        <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="translated">Impressão digital SHA-1 usada para identificar um certificado.</target>
-        <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="translated">Use um contêiner de chave privada no nível do computador.  (O padrão é o nível do usuário.)</target>
+        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
@@ -4,42 +4,47 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="translated">Файл PFX, P7B или CER, содержащий сертификат и, возможно, закрытый ключ.</target>
+        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="translated">Пароль для файла сертификата.</target>
+        <target state="new">Password for certificate file.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
+        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintOptionDescription">
+        <source>SHA thumbprint used to identify a certificate.</source>
+        <target state="new">SHA thumbprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="translated">Поставщик служб шифрования, содержащий контейнер закрытого ключа. Требуется /k и /km (необязательно).</target>
+        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="translated">Имя контейнера закрытого ключа.</target>
+        <target state="new">Private key container name.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="translated">Отсутствует поставщик служб шифрования.  Используйте /csp, чтобы указать CSP.</target>
+        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="translated">Отсутствует имя контейнера закрытого ключа. Используйте /k, чтобы указать имя контейнера ключей.</target>
+        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
         <note>{Locked="/k"} is a command line option.</note>
-      </trans-unit>
-      <trans-unit id="Sha1ThumbprintOptionDescription">
-        <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="translated">Отпечаток SHA-1, используемый для идентификации сертификата.</target>
-        <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="translated">Используйте контейнер закрытого ключа на уровне компьютера.  (По умолчанию используется уровень пользователя.)</target>
+        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
@@ -7,20 +7,20 @@
         <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
+      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
+        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateFingerprintOptionDescription">
+        <source>SHA fingerprint used to identify a certificate.</source>
+        <target state="new">SHA fingerprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
+      </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
         <target state="new">Password for certificate file.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
-        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintOptionDescription">
-        <source>SHA thumbprint used to identify a certificate.</source>
-        <target state="new">SHA thumbprint used to identify a certificate.</target>
-        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
@@ -4,42 +4,42 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
+        <target state="translated">Файл PFX, P7B или CER, содержащий сертификат и, возможно, закрытый ключ.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="new">Password for certificate file.</target>
+        <target state="translated">Пароль для файла сертификата.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
+        <target state="translated">Поставщик служб шифрования, содержащий контейнер закрытого ключа. Требуется /k и /km (необязательно).</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="new">Private key container name.</target>
+        <target state="translated">Имя контейнера закрытого ключа.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
+        <target state="translated">Отсутствует поставщик служб шифрования.  Используйте /csp, чтобы указать CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
+        <target state="translated">Отсутствует имя контейнера закрытого ключа. Используйте /k, чтобы указать имя контейнера ключей.</target>
         <note>{Locked="/k"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="Sha1ThumbprintOptionDescription">
         <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="new">SHA-1 thumbprint used to identify a certificate.</target>
+        <target state="translated">Отпечаток SHA-1, используемый для идентификации сертификата.</target>
         <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
+        <target state="translated">Используйте контейнер закрытого ключа на уровне компьютера.  (По умолчанию используется уровень пользователя.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
@@ -8,9 +8,9 @@
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
@@ -4,42 +4,47 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="translated">Bir sertifika ve potansiyel olarak özel anahtar içeren PFX, P7B veya CER dosyası.</target>
+        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="translated">Sertifika dosyasının parolası.</target>
+        <target state="new">Password for certificate file.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
+        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintOptionDescription">
+        <source>SHA thumbprint used to identify a certificate.</source>
+        <target state="new">SHA thumbprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="translated">Özel anahtar kapsayıcısını içeren Şifreleme Hizmeti Sağlayıcısı. /k ve alternatif olarak /km gerektirir.</target>
+        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="translated">Özel anahtar kapsayıcısı adı.</target>
+        <target state="new">Private key container name.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="translated">Şifreleme Hizmeti Sağlayıcısı eksik.  CSP belirtmek için /csp kullanın.</target>
+        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="translated">Özel anahtar kapsayıcısı adı eksik. Anahtar kapsayıcısı adı belirtmek için /k kullanın.</target>
+        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
         <note>{Locked="/k"} is a command line option.</note>
-      </trans-unit>
-      <trans-unit id="Sha1ThumbprintOptionDescription">
-        <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="translated">Sertifikayı tanımlamak için kullanılan SHA-1 parmak izi.</target>
-        <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="translated">Makine düzeyinde özel anahtar kapsayıcısı kullanın.  (Varsayılan, kullanıcı düzeyidir.)</target>
+        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
@@ -7,20 +7,20 @@
         <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
+      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
+        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateFingerprintOptionDescription">
+        <source>SHA fingerprint used to identify a certificate.</source>
+        <target state="new">SHA fingerprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
+      </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
         <target state="new">Password for certificate file.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
-        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintOptionDescription">
-        <source>SHA thumbprint used to identify a certificate.</source>
-        <target state="new">SHA thumbprint used to identify a certificate.</target>
-        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
@@ -4,42 +4,42 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
+        <target state="translated">Bir sertifika ve potansiyel olarak özel anahtar içeren PFX, P7B veya CER dosyası.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="new">Password for certificate file.</target>
+        <target state="translated">Sertifika dosyasının parolası.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
+        <target state="translated">Özel anahtar kapsayıcısını içeren Şifreleme Hizmeti Sağlayıcısı. /k ve alternatif olarak /km gerektirir.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="new">Private key container name.</target>
+        <target state="translated">Özel anahtar kapsayıcısı adı.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
+        <target state="translated">Şifreleme Hizmeti Sağlayıcısı eksik.  CSP belirtmek için /csp kullanın.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
+        <target state="translated">Özel anahtar kapsayıcısı adı eksik. Anahtar kapsayıcısı adı belirtmek için /k kullanın.</target>
         <note>{Locked="/k"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="Sha1ThumbprintOptionDescription">
         <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="new">SHA-1 thumbprint used to identify a certificate.</target>
+        <target state="translated">Sertifikayı tanımlamak için kullanılan SHA-1 parmak izi.</target>
         <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
+        <target state="translated">Makine düzeyinde özel anahtar kapsayıcısı kullanın.  (Varsayılan, kullanıcı düzeyidir.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
@@ -8,9 +8,9 @@
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
@@ -4,42 +4,42 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
+        <target state="translated">包含证书和可能包含私钥的 PFX、P7B 或 CER 文件。</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="new">Password for certificate file.</target>
+        <target state="translated">证书文件的密码。</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
+        <target state="translated">包含私钥容器的加密服务提供程序。需要 /k 和 /km (可选)。</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="new">Private key container name.</target>
+        <target state="translated">私钥容器名称。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
+        <target state="translated">缺少加密服务提供程序。使用 /csp 指定 CSP。</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
+        <target state="translated">缺少私钥容器名称。使用 /k 指定密钥容器名称。</target>
         <note>{Locked="/k"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="Sha1ThumbprintOptionDescription">
         <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="new">SHA-1 thumbprint used to identify a certificate.</target>
+        <target state="translated">用于标识证书的 SHA-1 指纹。</target>
         <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
+        <target state="translated">使用计算机级私钥容器。(默认值为用户级别。)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
@@ -7,20 +7,20 @@
         <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
+      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
+        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateFingerprintOptionDescription">
+        <source>SHA fingerprint used to identify a certificate.</source>
+        <target state="new">SHA fingerprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
+      </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
         <target state="new">Password for certificate file.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
-        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintOptionDescription">
-        <source>SHA thumbprint used to identify a certificate.</source>
-        <target state="new">SHA thumbprint used to identify a certificate.</target>
-        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
@@ -8,9 +8,9 @@
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
@@ -4,42 +4,47 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="translated">包含证书和可能包含私钥的 PFX、P7B 或 CER 文件。</target>
+        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="translated">证书文件的密码。</target>
+        <target state="new">Password for certificate file.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
+        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintOptionDescription">
+        <source>SHA thumbprint used to identify a certificate.</source>
+        <target state="new">SHA thumbprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="translated">包含私钥容器的加密服务提供程序。需要 /k 和 /km (可选)。</target>
+        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="translated">私钥容器名称。</target>
+        <target state="new">Private key container name.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="translated">缺少加密服务提供程序。使用 /csp 指定 CSP。</target>
+        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="translated">缺少私钥容器名称。使用 /k 指定密钥容器名称。</target>
+        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
         <note>{Locked="/k"} is a command line option.</note>
-      </trans-unit>
-      <trans-unit id="Sha1ThumbprintOptionDescription">
-        <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="translated">用于标识证书的 SHA-1 指纹。</target>
-        <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="translated">使用计算机级私钥容器。(默认值为用户级别。)</target>
+        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
@@ -4,42 +4,47 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="translated">包含憑證和潛在的私用金鑰的 PFX、P7B 或 CER 檔案。</target>
+        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="translated">憑證檔案的密碼。</target>
+        <target state="new">Password for certificate file.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
+        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateThumbprintOptionDescription">
+        <source>SHA thumbprint used to identify a certificate.</source>
+        <target state="new">SHA thumbprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="translated">包含私密金鑰容器的加密服務提供者。需要 /k 並選擇性地 /km。</target>
+        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="translated">私密金鑰容器名稱。</target>
+        <target state="new">Private key container name.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="translated">遺漏密碼編譯服務提供者。使用 /csp 來指定雲端解決方案提供者。</target>
+        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="translated">遺漏私密金鑰容器名稱。使用 /k 來指定金鑰容器名稱。</target>
+        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
         <note>{Locked="/k"} is a command line option.</note>
-      </trans-unit>
-      <trans-unit id="Sha1ThumbprintOptionDescription">
-        <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="translated">SHA-1 用以識別憑證的指紋。</target>
-        <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="translated">使用機器層級私密金鑰容器。(預設為使用者等級。)</target>
+        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
@@ -7,20 +7,20 @@
         <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
+      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
+        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
+        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
+        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+      </trans-unit>
+      <trans-unit id="CertificateFingerprintOptionDescription">
+        <source>SHA fingerprint used to identify a certificate.</source>
+        <target state="new">SHA fingerprint used to identify a certificate.</target>
+        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
+      </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
         <target state="new">Password for certificate file.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintAlgorithmOptionDescription">
-        <source>SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA thumbprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
-      </trans-unit>
-      <trans-unit id="CertificateThumbprintOptionDescription">
-        <source>SHA thumbprint used to identify a certificate.</source>
-        <target state="new">SHA thumbprint used to identify a certificate.</target>
-        <note>{Locked="SHA"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
@@ -8,9 +8,9 @@
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</source>
-        <target state="new">SHA fingerprint algorithm. Only accepts SHA-256, SHA-384, or SHA-512</target>
-        <note>{Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic algorithms.</note>
+        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
+        <target state="new">Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</target>
+        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
@@ -4,42 +4,42 @@
     <body>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
-        <target state="new">PFX, P7B, or CER file containing a certificate and potentially a private key.</target>
+        <target state="translated">包含憑證和潛在的私用金鑰的 PFX、P7B 或 CER 檔案。</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
       <trans-unit id="CertificatePasswordOptionDescription">
         <source>Password for certificate file.</source>
-        <target state="new">Password for certificate file.</target>
+        <target state="translated">憑證檔案的密碼。</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
-        <target state="new">Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</target>
+        <target state="translated">包含私密金鑰容器的加密服務提供者。需要 /k 並選擇性地 /km。</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>
-        <target state="new">Private key container name.</target>
+        <target state="translated">私密金鑰容器名稱。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingCspError">
         <source>Cryptographic Service Provider missing.  Use /csp to specify a CSP.</source>
-        <target state="new">Cryptographic Service Provider missing.  Use /csp to specify a CSP.</target>
+        <target state="translated">遺漏密碼編譯服務提供者。使用 /csp 來指定雲端解決方案提供者。</target>
         <note>{Locked="/csp"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="MissingPrivateKeyContainerError">
         <source>Private key container name missing. Use /k to specify a key container name.</source>
-        <target state="new">Private key container name missing. Use /k to specify a key container name.</target>
+        <target state="translated">遺漏私密金鑰容器名稱。使用 /k 來指定金鑰容器名稱。</target>
         <note>{Locked="/k"} is a command line option.</note>
       </trans-unit>
       <trans-unit id="Sha1ThumbprintOptionDescription">
         <source>SHA-1 thumbprint used to identify a certificate.</source>
-        <target state="new">SHA-1 thumbprint used to identify a certificate.</target>
+        <target state="translated">SHA-1 用以識別憑證的指紋。</target>
         <note>{Locked="SHA-1"} is a cryptographic algorithm.</note>
       </trans-unit>
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
-        <target state="new">Use a machine-level private key container.  (The default is user-level.)</target>
+        <target state="translated">使用機器層級私密金鑰容器。(預設為使用者等級。)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Cesta k souboru obsahujícímu cesty k souborům, které se mají podepsat nebo vyloučit z podepisování.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">Soubor nebo soubory, které se mají podepsat.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být plně kořenová cesta k adresáři.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být sha256, sha384 nebo sha512.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">Cestu k souboru nelze při použití glob zakořenit. Použijte relativní cestu k pracovnímu adresáři (nebo základnímu adresáři, pokud se používá).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Maximální souběžnost.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">Vyžaduje se soubor nebo glob.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">Nenašly se žádné vstupy, které by bylo možné podepsat.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Výstupní soubor nebo adresář. Pokud je tento parametr vynechán, vstupní soubory budou přepsány.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">Podepsat rozhraní příkazového řádku</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Některé soubory neexistují.  Zkuste použít jinou hodnotu {0} nebo plně kvalifikovanou cestu k souboru.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -52,14 +52,14 @@
         <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být plně kořenová cesta k adresáři.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
         <source>File(s) to sign.</source>
-        <target state="translated">Soubor nebo soubory, které se mají podepsat.</target>
+        <target state="new">File(s) to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Cestu k souboru nelze při použití glob zakořenit. Použijte relativní cestu k pracovnímu adresáři (nebo základnímu adresáři, pokud se používá).</target>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -84,12 +84,12 @@
       </trans-unit>
       <trans-unit id="MissingFileValue">
         <source>A file or glob is required.</source>
-        <target state="translated">Vyžaduje se soubor nebo glob.</target>
+        <target state="new">A file or glob is required.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
-        <target state="translated">Nenašly se žádné vstupy, které by bylo možné podepsat.</target>
+        <target state="new">No inputs found to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOptionDescription">
@@ -109,7 +109,7 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Některé soubory neexistují.  Zkuste použít jinou hodnotu {0} nebo plně kvalifikovanou cestu k souboru.</target>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="translated">Použijte úložiště certifikátů systému Windows nebo místní soubor certifikátu.</target>
+        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="translated">Cesta k souboru obsahujícímu cesty k souborům, které se mají podepsat nebo vyloučit z podepisování.</target>
+        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
@@ -51,6 +51,16 @@
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být plně kořenová cesta k adresáři.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
@@ -66,11 +76,6 @@
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
         <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být číselná hodnota větší nebo rovna 1.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="InvalidSha1ThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být kryptografický otisk SHA-1 certifikátu.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -55,12 +55,12 @@
       <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
-        <note />
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
+        <target state="translated">Použijte úložiště certifikátů systému Windows nebo místní soubor certifikátu.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
+        <target state="translated">Cesta k souboru obsahujícímu cesty k souborům, které se mají podepsat nebo vyloučit z podepisování.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbprintValue">
         <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</target>
+        <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být kryptografický otisk SHA-1 certifikátu.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="translated">Verwenden Sie den Windows-Zertifikatspeicher oder eine lokale Zertifikatdatei.</target>
+        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="translated">Pfad zur Datei mit Pfaden von Dateien, die signiert oder von der Signierung ausgeschlossen werden sollen.</target>
+        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
@@ -51,6 +51,16 @@
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Ungültiger Wert für {0}. Der Wert muss ein vollständiger Stammverzeichnispfad sein.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
@@ -66,11 +76,6 @@
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
         <target state="translated">Ungültiger Wert für {0}. Der Wert muss ein Zahlenwert größer oder gleich 1 sein.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="InvalidSha1ThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="translated">Ungültiger Wert für {0}. Der Wert muss der SHA-1-Fingerabdruck des Zertifikats sein.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Pfad zur Datei mit Pfaden von Dateien, die signiert oder von der Signierung ausgeschlossen werden sollen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">Zu signierende Datei(en).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Ungültiger Wert für {0}. Der Wert muss ein vollständiger Stammverzeichnispfad sein.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Ungültiger Wert für {0}. Der Wert muss "sha256", "sha384" oder "sha512" sein.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">Der Dateipfad kann keinem Stamm zugewiesen werden, wenn ein Glob verwendet wird. Verwenden Sie einen Pfad relativ zum Arbeitsverzeichnis (oder Basisverzeichnis, falls verwendet).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Maximale Parallelität.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">Eine Datei oder ein Glob ist erforderlich.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">Es wurden keine Eingaben zum Signieren gefunden.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Ausgabedatei oder -verzeichnis. Wenn dies weggelassen wird, werden Eingabedateien überschrieben.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">CLI signieren</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Einige Dateien sind nicht vorhanden.  Versuchen Sie, einen anderen {0}-Wert oder einen vollqualifizierten Dateipfad zu verwenden.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
+        <target state="translated">Verwenden Sie den Windows-Zertifikatspeicher oder eine lokale Zertifikatdatei.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
+        <target state="translated">Pfad zur Datei mit Pfaden von Dateien, die signiert oder von der Signierung ausgeschlossen werden sollen.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbprintValue">
         <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</target>
+        <target state="translated">Ungültiger Wert für {0}. Der Wert muss der SHA-1-Fingerabdruck des Zertifikats sein.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -52,14 +52,14 @@
         <target state="translated">Ungültiger Wert für {0}. Der Wert muss ein vollständiger Stammverzeichnispfad sein.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
         <source>File(s) to sign.</source>
-        <target state="translated">Zu signierende Datei(en).</target>
+        <target state="new">File(s) to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Der Dateipfad kann keinem Stamm zugewiesen werden, wenn ein Glob verwendet wird. Verwenden Sie einen Pfad relativ zum Arbeitsverzeichnis (oder Basisverzeichnis, falls verwendet).</target>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -84,12 +84,12 @@
       </trans-unit>
       <trans-unit id="MissingFileValue">
         <source>A file or glob is required.</source>
-        <target state="translated">Eine Datei oder ein Glob ist erforderlich.</target>
+        <target state="new">A file or glob is required.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
-        <target state="translated">Es wurden keine Eingaben zum Signieren gefunden.</target>
+        <target state="new">No inputs found to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOptionDescription">
@@ -109,7 +109,7 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Einige Dateien sind nicht vorhanden.  Versuchen Sie, einen anderen {0}-Wert oder einen vollqualifizierten Dateipfad zu verwenden.</target>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -55,12 +55,12 @@
       <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
-        <note />
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -52,14 +52,14 @@
         <target state="translated">Valor no válido para {0}. El valor debe ser una ruta de acceso de directorio totalmente raíz.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Ruta de acceso al archivo que contiene las rutas de acceso de los archivos que se van a firmar o que se van a excluir de la firma.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">Archivos para firmar.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Valor no válido para {0}. El valor debe ser una ruta de acceso de directorio totalmente raíz.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Valor no válido para {0}. El valor debe ser 'sha256', 'sha384' o 'sha512'.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">La ruta de acceso del archivo no se puede rootear cuando se usa un glob. Use una ruta de acceso relativa al directorio de trabajo (o directorio base, si se usa).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Simultaneidad máxima.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">Se requiere un archivo o glob.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">No se encontraron entradas para firmar.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Archivo o directorio de salida. Si se omite, se sobrescribirán los archivos de entrada.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">Firma de la CLI</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Algunos archivos no existen.  Pruebe a usar otro valor {0} o una ruta de acceso de archivo completa.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
+        <target state="translated">Use el Almacén de certificados de Windows o un archivo de certificados local.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
+        <target state="translated">Ruta de acceso al archivo que contiene las rutas de acceso de los archivos que se van a firmar o que se van a excluir de la firma.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbprintValue">
         <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</target>
+        <target state="translated">Valor no válido para {0}. El valor debe ser la huella digital SHA-1 del certificado.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="translated">Use el Almacén de certificados de Windows o un archivo de certificados local.</target>
+        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="translated">Ruta de acceso al archivo que contiene las rutas de acceso de los archivos que se van a firmar o que se van a excluir de la firma.</target>
+        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
@@ -51,6 +51,16 @@
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Valor no válido para {0}. El valor debe ser una ruta de acceso de directorio totalmente raíz.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
@@ -66,11 +76,6 @@
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
         <target state="translated">Valor no válido para {0}. El valor debe ser un valor numérico mayor o igual que 1.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="InvalidSha1ThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="translated">Valor no válido para {0}. El valor debe ser la huella digital SHA-1 del certificado.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
         <source>File(s) to sign.</source>
-        <target state="translated">Archivos para firmar.</target>
+        <target state="new">File(s) to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">La ruta de acceso del archivo no se puede rootear cuando se usa un glob. Use una ruta de acceso relativa al directorio de trabajo (o directorio base, si se usa).</target>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -84,12 +84,12 @@
       </trans-unit>
       <trans-unit id="MissingFileValue">
         <source>A file or glob is required.</source>
-        <target state="translated">Se requiere un archivo o glob.</target>
+        <target state="new">A file or glob is required.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
-        <target state="translated">No se encontraron entradas para firmar.</target>
+        <target state="new">No inputs found to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOptionDescription">
@@ -109,7 +109,7 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Algunos archivos no existen.  Pruebe a usar otro valor {0} o una ruta de acceso de archivo completa.</target>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -55,12 +55,12 @@
       <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
-        <note />
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
+        <target state="translated">Utilisez le magasin de certificats Windows ou un fichier local du certificat.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
+        <target state="translated">Chemin du fichier contenant les chemins des fichiers à signer ou à exclure de la signature.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbprintValue">
         <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</target>
+        <target state="translated">Valeur non valide pour {0}. La valeur doit être l’empreinte SHA-1 du certificat.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="translated">Utilisez le magasin de certificats Windows ou un fichier local du certificat.</target>
+        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="translated">Chemin du fichier contenant les chemins des fichiers à signer ou à exclure de la signature.</target>
+        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
@@ -51,6 +51,16 @@
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Valeur non valide pour {0}. La valeur doit être un chemin d’accès de répertoire entièrement rooté.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
@@ -66,11 +76,6 @@
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
         <target state="translated">Valeur non valide pour {0}. La valeur doit être une valeur numérique supérieure ou égale à 1.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="InvalidSha1ThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="translated">Valeur non valide pour {0}. La valeur doit être l’empreinte SHA-1 du certificat.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
         <source>File(s) to sign.</source>
-        <target state="translated">Fichier(s) à signer.</target>
+        <target state="new">File(s) to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Le chemin d’accès du fichier ne peut pas être rooté lors de l’utilisation d’un glob. Utilisez un chemin d’accès relatif au répertoire de travail (ou au répertoire de base, s’il est utilisé).</target>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -84,12 +84,12 @@
       </trans-unit>
       <trans-unit id="MissingFileValue">
         <source>A file or glob is required.</source>
-        <target state="translated">Un fichier ou un glob est requis.</target>
+        <target state="new">A file or glob is required.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
-        <target state="translated">Aucune entrée à signer.</target>
+        <target state="new">No inputs found to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOptionDescription">
@@ -109,7 +109,7 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Certains fichiers n’existent pas. Essayez d’utiliser une autre valeur {0} ou un chemin de fichier complet.</target>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Chemin du fichier contenant les chemins des fichiers à signer ou à exclure de la signature.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">Fichier(s) à signer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Valeur non valide pour {0}. La valeur doit être un chemin d’accès de répertoire entièrement rooté.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Valeur invalide pour {0}. La valeur doit être 'sha256', 'sha384' ou 'sha512'.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">Le chemin d’accès du fichier ne peut pas être rooté lors de l’utilisation d’un glob. Utilisez un chemin d’accès relatif au répertoire de travail (ou au répertoire de base, s’il est utilisé).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Concurrence maximale.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">Un fichier ou un glob est requis.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">Aucune entrée à signer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Fichier ou répertoire de sortie. En cas d’omission, les fichiers d’entrée sont remplacés.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">Signer l’interface CLI</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Certains fichiers n’existent pas. Essayez d’utiliser une autre valeur {0} ou un chemin de fichier complet.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -55,12 +55,12 @@
       <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
-        <note />
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -52,14 +52,14 @@
         <target state="translated">Valeur non valide pour {0}. La valeur doit être un chemin d’accès de répertoire entièrement rooté.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
+        <target state="translated">Utilizzare l'archivio certificati di Windows o un file di certificato locale.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
+        <target state="translated">Percorso del file contenente i percorsi dei file da firmare o escludere dalla firma.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbprintValue">
         <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</target>
+        <target state="translated">Valore non valido per {0}. Il valore deve essere l'identificazione personale SHA-1 del certificato.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -52,14 +52,14 @@
         <target state="translated">Valore non valido per {0}. Il valore deve essere un percorso di directory completo.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
         <source>File(s) to sign.</source>
-        <target state="translated">File da firmare.</target>
+        <target state="new">File(s) to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Il percorso del file non può avere accesso root quando si utilizza un GLOB. Usare un percorso relativo alla directory di lavoro (o alla directory di base, se usata).</target>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -84,12 +84,12 @@
       </trans-unit>
       <trans-unit id="MissingFileValue">
         <source>A file or glob is required.</source>
-        <target state="translated">È necessario specificare un file o un GLOB.</target>
+        <target state="new">A file or glob is required.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
-        <target state="translated">Non sono stati trovati input da firmare.</target>
+        <target state="new">No inputs found to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOptionDescription">
@@ -109,7 +109,7 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Alcuni file non esistono.  Provare a usare un valore di {0} diverso o un percorso di file completo.</target>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="translated">Utilizzare l'archivio certificati di Windows o un file di certificato locale.</target>
+        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="translated">Percorso del file contenente i percorsi dei file da firmare o escludere dalla firma.</target>
+        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
@@ -51,6 +51,16 @@
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Valore non valido per {0}. Il valore deve essere un percorso di directory completo.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
@@ -66,11 +76,6 @@
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
         <target state="translated">Valore non valido per {0}. Il valore deve essere un numero maggiore o uguale a 1.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="InvalidSha1ThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="translated">Valore non valido per {0}. Il valore deve essere l'identificazione personale SHA-1 del certificato.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Percorso del file contenente i percorsi dei file da firmare o escludere dalla firma.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">File da firmare.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Valore non valido per {0}. Il valore deve essere un percorso di directory completo.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Valore non valido per {0}. Il valore deve essere 'sha256', 'sha384' o 'sha512'.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">Il percorso del file non può avere accesso root quando si utilizza un GLOB. Usare un percorso relativo alla directory di lavoro (o alla directory di base, se usata).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Concorrenza massima.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">È necessario specificare un file o un GLOB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">Non sono stati trovati input da firmare.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">File o directory di output. Se omessi, i file di input verranno sovrascritti.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">Consente di firmare l'interfaccia della riga di comando</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Alcuni file non esistono.  Provare a usare un valore di {0} diverso o un percorso di file completo.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -55,12 +55,12 @@
       <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
-        <note />
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
         <source>File(s) to sign.</source>
-        <target state="translated">署名するファイル。</target>
+        <target state="new">File(s) to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">glob を使用している場合、ファイル パスをルート化できません。作業ディレクトリへの相対パス (または使用されている場合はベース ディレクトリ) を使用してください。</target>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -84,12 +84,12 @@
       </trans-unit>
       <trans-unit id="MissingFileValue">
         <source>A file or glob is required.</source>
-        <target state="translated">ファイルまたは glob が必要です。</target>
+        <target state="new">A file or glob is required.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
-        <target state="translated">署名する入力が見つかりません。</target>
+        <target state="new">No inputs found to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOptionDescription">
@@ -109,7 +109,7 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">一部のファイルが存在しません。別の {0} 値または完全修飾ファイル パスを使用してみてください。</target>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
+        <target state="translated">Windows 証明書ストアまたはローカル証明書ファイルを使用します。</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
+        <target state="translated">署名するファイルまたは署名から除外するファイルのパスを含むファイルへのパス。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbprintValue">
         <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</target>
+        <target state="translated">{0} の値が無効です。値は証明書の SHA-1 拇印である必要があります。</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -52,14 +52,14 @@
         <target state="translated">{0} の値が無効です。値は、完全にルート化されたディレクトリ パスである必要があります。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="translated">Windows 証明書ストアまたはローカル証明書ファイルを使用します。</target>
+        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="translated">署名するファイルまたは署名から除外するファイルのパスを含むファイルへのパス。</target>
+        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
@@ -51,6 +51,16 @@
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0} の値が無効です。値は、完全にルート化されたディレクトリ パスである必要があります。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
@@ -66,11 +76,6 @@
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
         <target state="translated">{0} の値が無効です。値は、1 以上の数値である必要があります。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="InvalidSha1ThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="translated">{0} の値が無効です。値は証明書の SHA-1 拇印である必要があります。</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -55,12 +55,12 @@
       <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
-        <note />
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -42,6 +42,11 @@
         <target state="translated">署名するファイルまたは署名から除外するファイルのパスを含むファイルへのパス。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">署名するファイル。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0} の値が無効です。値は、完全にルート化されたディレクトリ パスである必要があります。</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">{0} の値が無効です。値は 'sha256'、'sha384'、または 'sha512' である必要があります。</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">glob を使用している場合、ファイル パスをルート化できません。作業ディレクトリへの相対パス (または使用されている場合はベース ディレクトリ) を使用してください。</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">最大コンカレンシー。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">ファイルまたは glob が必要です。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">署名する入力が見つかりません。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">出力ファイルまたはディレクトリ。省略すると、入力ファイルが上書きされます。</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">CLI に署名</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">一部のファイルが存在しません。別の {0} 値または完全修飾ファイル パスを使用してみてください。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -42,6 +42,11 @@
         <target state="translated">서명하거나 서명에서 제외할 파일의 경로가 포함된 파일 경로입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">서명할 파일입니다.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 완전한 루트 디렉터리 경로여야 합니다.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 'sha256', 'sha384' 또는 'sha512'.여야 합니다.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">glob을 사용할 때 파일 경로를 루팅할 수 없습니다. 작업 디렉터리(또는 사용되는 경우 기본 디렉터리)에 상대적인 경로를 사용하세요.</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">최대 동시성입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">파일 또는 글로브가 필요합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">서명할 입력이 없습니다.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">출력 파일 또는 디렉터리입니다. 생략하면 입력 파일을 덮어씁니다.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">CLI 서명</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Niektóre pliki nie istnieją.  Spróbuj użyć innej wartości {0} lub w pełni kwalifikowanej ścieżki pliku.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="translated">Windows 인증서 저장소 또는 로컬 인증서 파일을 사용합니다.</target>
+        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="translated">서명하거나 서명에서 제외할 파일의 경로가 포함된 파일 경로입니다.</target>
+        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
@@ -51,6 +51,16 @@
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 완전한 루트 디렉터리 경로여야 합니다.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
@@ -66,11 +76,6 @@
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
         <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 1보다 크거나 같은 숫자 값이어야 합니다.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="InvalidSha1ThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="translated">{0}의 값이 잘못되었습니다. 값은 인증서의 SHA-1 지문이어야 합니다.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
         <source>File(s) to sign.</source>
-        <target state="translated">서명할 파일입니다.</target>
+        <target state="new">File(s) to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">glob을 사용할 때 파일 경로를 루팅할 수 없습니다. 작업 디렉터리(또는 사용되는 경우 기본 디렉터리)에 상대적인 경로를 사용하세요.</target>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -84,12 +84,12 @@
       </trans-unit>
       <trans-unit id="MissingFileValue">
         <source>A file or glob is required.</source>
-        <target state="translated">파일 또는 글로브가 필요합니다.</target>
+        <target state="new">A file or glob is required.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
-        <target state="translated">서명할 입력이 없습니다.</target>
+        <target state="new">No inputs found to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOptionDescription">
@@ -109,7 +109,7 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Niektóre pliki nie istnieją.  Spróbuj użyć innej wartości {0} lub w pełni kwalifikowanej ścieżki pliku.</target>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
+        <target state="translated">Windows 인증서 저장소 또는 로컬 인증서 파일을 사용합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
+        <target state="translated">서명하거나 서명에서 제외할 파일의 경로가 포함된 파일 경로입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbprintValue">
         <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</target>
+        <target state="translated">{0}의 값이 잘못되었습니다. 값은 인증서의 SHA-1 지문이어야 합니다.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -55,12 +55,12 @@
       <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
-        <note />
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -52,14 +52,14 @@
         <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 완전한 루트 디렉터리 경로여야 합니다.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
+        <target state="translated">Użyj magazynu certyfikatów systemu Windows lub lokalnego pliku certyfikatów.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
+        <target state="translated">Ścieżka do pliku zawierającego ścieżki plików do podpisania lub wykluczenia z podpisywania.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbprintValue">
         <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</target>
+        <target state="translated">Nieprawidłowa wartość dla opcji {0}. Wartość musi być odciskiem palca SHA-1 certyfikatu.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
         <source>File(s) to sign.</source>
-        <target state="translated">Pliki do podpisania.</target>
+        <target state="new">File(s) to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Ścieżka pliku nie może być z dostępem do konta root, gdy jest używany element globalny. Użyj ścieżki odnoszącej się do katalogu roboczego (lub katalogu podstawowego, jeśli jest używany).</target>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -84,12 +84,12 @@
       </trans-unit>
       <trans-unit id="MissingFileValue">
         <source>A file or glob is required.</source>
-        <target state="translated">Wymagany jest plik lub element globalny.</target>
+        <target state="new">A file or glob is required.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
-        <target state="translated">Nie znaleziono danych wejściowych do podpisania.</target>
+        <target state="new">No inputs found to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="translated">Użyj magazynu certyfikatów systemu Windows lub lokalnego pliku certyfikatów.</target>
+        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="translated">Ścieżka do pliku zawierającego ścieżki plików do podpisania lub wykluczenia z podpisywania.</target>
+        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
@@ -51,6 +51,16 @@
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Nieprawidłowa wartość dla {0}. Wartość musi być w pełni główną ścieżką katalogu.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
@@ -66,11 +76,6 @@
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
         <target state="translated">Nieprawidłowa wartość dla {0}. Wartość musi być większa lub równa 1.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="InvalidSha1ThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="translated">Nieprawidłowa wartość dla opcji {0}. Wartość musi być odciskiem palca SHA-1 certyfikatu.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -55,12 +55,12 @@
       <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
-        <note />
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Ścieżka do pliku zawierającego ścieżki plików do podpisania lub wykluczenia z podpisywania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">Pliki do podpisania.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Nieprawidłowa wartość dla {0}. Wartość musi być w pełni główną ścieżką katalogu.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Nieprawidłowa wartość dla {0}. Wartością musi być „sha256”, „sha384”, lub „sha512”.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">Ścieżka pliku nie może być z dostępem do konta root, gdy jest używany element globalny. Użyj ścieżki odnoszącej się do katalogu roboczego (lub katalogu podstawowego, jeśli jest używany).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Maksymalna współbieżność.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">Wymagany jest plik lub element globalny.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">Nie znaleziono danych wejściowych do podpisania.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Plik wyjściowy lub katalog. W przypadku pominięcia pliki wejściowe zostaną zastąpione.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">Interfejs wiersza polecenia podpisywania</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -52,14 +52,14 @@
         <target state="translated">Nieprawidłowa wartość dla {0}. Wartość musi być w pełni główną ścieżką katalogu.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
+        <target state="translated">Use o Repositório de Certificados do Windows ou um arquivo de certificado local.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
+        <target state="translated">Caminho para o arquivo que contém os caminhos dos arquivos a serem assinados ou excluídos da assinatura.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbprintValue">
         <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</target>
+        <target state="translated">Valor inválido para {0}. O valor precisa ser a impressão digital SHA-1 do certificado.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Caminho para o arquivo que contém os caminhos dos arquivos a serem assinados ou excluídos da assinatura.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">Arquivo(s) para autenticar.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Valor inválido para {0}. O valor deve ser um caminho de diretório totalmente desbloqueado por rooting.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Valor inválido para {0}. O valor deve ser 'sha256', 'sha384' ou 'sha512'.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">O caminho do arquivo não pode estar desbloqueado por rooting ao usar um glob. Use um caminho relativo ao diretório de trabalho (ou diretório base, se usado).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Simultaneidade máxima.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">É necessário um arquivo ou um glob.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">Nenhuma entrada encontrada para autenticar.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Arquivo ou diretório de saída. Se omitido, os arquivos de entrada serão substituídos.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">Autenticar CLI</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Alguns arquivos não existem.  Tente usar um valor diferente de {0} ou um caminho de arquivo totalmente qualificado.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
         <source>File(s) to sign.</source>
-        <target state="translated">Arquivo(s) para autenticar.</target>
+        <target state="new">File(s) to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">O caminho do arquivo não pode estar desbloqueado por rooting ao usar um glob. Use um caminho relativo ao diretório de trabalho (ou diretório base, se usado).</target>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -84,12 +84,12 @@
       </trans-unit>
       <trans-unit id="MissingFileValue">
         <source>A file or glob is required.</source>
-        <target state="translated">É necessário um arquivo ou um glob.</target>
+        <target state="new">A file or glob is required.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
-        <target state="translated">Nenhuma entrada encontrada para autenticar.</target>
+        <target state="new">No inputs found to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOptionDescription">
@@ -109,7 +109,7 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Alguns arquivos não existem.  Tente usar um valor diferente de {0} ou um caminho de arquivo totalmente qualificado.</target>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -55,12 +55,12 @@
       <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
-        <note />
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -52,14 +52,14 @@
         <target state="translated">Valor inválido para {0}. O valor deve ser um caminho de diretório totalmente desbloqueado por rooting.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="translated">Use o Repositório de Certificados do Windows ou um arquivo de certificado local.</target>
+        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="translated">Caminho para o arquivo que contém os caminhos dos arquivos a serem assinados ou excluídos da assinatura.</target>
+        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
@@ -51,6 +51,16 @@
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Valor inválido para {0}. O valor deve ser um caminho de diretório totalmente desbloqueado por rooting.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
@@ -66,11 +76,6 @@
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
         <target state="translated">Valor inválido para {0}. O valor deve ser um valor numérico maior ou igual a 1.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="InvalidSha1ThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="translated">Valor inválido para {0}. O valor precisa ser a impressão digital SHA-1 do certificado.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
         <source>File(s) to sign.</source>
-        <target state="translated">Файлы для подписи.</target>
+        <target state="new">File(s) to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Путь к файлу не может быть корневым при использовании стандартной маски. Используйте путь относительно рабочего каталога (или базового каталога, если он используется).</target>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -84,12 +84,12 @@
       </trans-unit>
       <trans-unit id="MissingFileValue">
         <source>A file or glob is required.</source>
-        <target state="translated">Требуется файл или стандартная маска.</target>
+        <target state="new">A file or glob is required.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
-        <target state="translated">Не найдены входящие данные для подписи.</target>
+        <target state="new">No inputs found to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOptionDescription">
@@ -109,7 +109,7 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Некоторые файлы не существуют.  Попробуйте использовать другое значение {0} или полный путь к файлу.</target>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -52,14 +52,14 @@
         <target state="translated">Недопустимое значение для {0}. Значение должно быть полным корневым путем к каталогу.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Путь к файлу, содержащему пути к файлам, которые нужно подписать или исключить из подписания.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">Файлы для подписи.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Недопустимое значение для {0}. Значение должно быть полным корневым путем к каталогу.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Недопустимое значение для {0}. Необходимо использовать "sha256", "sha384" или "sha512".</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">Путь к файлу не может быть корневым при использовании стандартной маски. Используйте путь относительно рабочего каталога (или базового каталога, если он используется).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Максимальный параллелизм.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">Требуется файл или стандартная маска.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">Не найдены входящие данные для подписи.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Выходной файл или каталог. Если этот параметр опущен, входные файлы будут перезаписаны.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">Подписывание CLI</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Некоторые файлы не существуют.  Попробуйте использовать другое значение {0} или полный путь к файлу.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
+        <target state="translated">Используйте хранилище сертификатов Windows или локальный файл сертификата.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
+        <target state="translated">Путь к файлу, содержащему пути к файлам, которые нужно подписать или исключить из подписания.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbprintValue">
         <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</target>
+        <target state="translated">Недопустимое значение для {0}. Значение должно быть отпечатком SHA-1 сертификата.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -55,12 +55,12 @@
       <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
-        <note />
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="translated">Используйте хранилище сертификатов Windows или локальный файл сертификата.</target>
+        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="translated">Путь к файлу, содержащему пути к файлам, которые нужно подписать или исключить из подписания.</target>
+        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
@@ -51,6 +51,16 @@
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Недопустимое значение для {0}. Значение должно быть полным корневым путем к каталогу.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
@@ -66,11 +76,6 @@
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
         <target state="translated">Недопустимое значение для "{0}". Значение должно быть числом, большим или равным 1.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="InvalidSha1ThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="translated">Недопустимое значение для {0}. Значение должно быть отпечатком SHA-1 сертификата.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
         <source>File(s) to sign.</source>
-        <target state="translated">İmzalanacak dosyalar.</target>
+        <target state="new">File(s) to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Glob kullanılırken dosya yoluna kök erişim izni verilemez. Çalışma diziniyle (veya kullanılıyorsa, temel dizinle) ilişkili bir yol kullanın.</target>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -84,12 +84,12 @@
       </trans-unit>
       <trans-unit id="MissingFileValue">
         <source>A file or glob is required.</source>
-        <target state="translated">Dosya veya glob gerekiyor.</target>
+        <target state="new">A file or glob is required.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
-        <target state="translated">İmzalanacak giriş dosyası yok.</target>
+        <target state="new">No inputs found to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOptionDescription">
@@ -109,7 +109,7 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Bazı dosyalar mevcut değil. Farklı bir {0} değeri veya tam bir dosya yolu kullanmayı deneyin.</target>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="translated">Windows Sertifika Deposu veya yerel bir sertifika dosyası kullanın.</target>
+        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="translated">İmzalanacak veya imzalamadan dışlanacak dosyaların yollarını içeren dosya yolu.</target>
+        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
@@ -51,6 +51,16 @@
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0} için geçersiz değer. Değer, tam olarak kök erişim izni verilmiş bir dizin yolu olmalıdır.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
@@ -66,11 +76,6 @@
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
         <target state="translated">{0} için geçersiz değer. Değer, 1’den büyük veya buna eşit bir sayı değeri olmalıdır.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="InvalidSha1ThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="translated">{0} için geçersiz değer. Değer, sertifikanın SHA-1 parmak izi olmalıdır.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -52,14 +52,14 @@
         <target state="translated">{0} için geçersiz değer. Değer, tam olarak kök erişim izni verilmiş bir dizin yolu olmalıdır.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
+        <target state="translated">Windows Sertifika Deposu veya yerel bir sertifika dosyası kullanın.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
+        <target state="translated">İmzalanacak veya imzalamadan dışlanacak dosyaların yollarını içeren dosya yolu.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbprintValue">
         <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</target>
+        <target state="translated">{0} için geçersiz değer. Değer, sertifikanın SHA-1 parmak izi olmalıdır.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">İmzalanacak veya imzalamadan dışlanacak dosyaların yollarını içeren dosya yolu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">İmzalanacak dosyalar.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0} için geçersiz değer. Değer, tam olarak kök erişim izni verilmiş bir dizin yolu olmalıdır.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">{0} için geçersiz değer. Değer 'sha256', 'sha384' veya 'sha512' olmalıdır.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">Glob kullanılırken dosya yoluna kök erişim izni verilemez. Çalışma diziniyle (veya kullanılıyorsa, temel dizinle) ilişkili bir yol kullanın.</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Maksimum eşzamanlılık.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">Dosya veya glob gerekiyor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">İmzalanacak giriş dosyası yok.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Çıkış dosyası veya dizini. Atlanırsa, giriş dosyalarının üzerine yazılır.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">CLI’yı imzala</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Bazı dosyalar mevcut değil. Farklı bir {0} değeri veya tam bir dosya yolu kullanmayı deneyin.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -55,12 +55,12 @@
       <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
-        <note />
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
+        <target state="translated">使用 Windows 证书存储或本地证书文件。</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
+        <target state="translated">包含要签名或从签名中排除的文件路径的文件的路径。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbprintValue">
         <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</target>
+        <target state="translated">{0} 的值无效。该值必须是证书的 SHA-1 指纹。</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -52,14 +52,14 @@
         <target state="translated">{0} 的值无效。该值必须是完整的根目录路径。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
         <source>File(s) to sign.</source>
-        <target state="translated">要签名的文件。</target>
+        <target state="new">File(s) to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">使用 glob 时，文件路径不能为根路径。请使用相对于工作目录(或基目录，如果使用)的路径。</target>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -84,12 +84,12 @@
       </trans-unit>
       <trans-unit id="MissingFileValue">
         <source>A file or glob is required.</source>
-        <target state="translated">文件或 glob 是必需的。</target>
+        <target state="new">A file or glob is required.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
-        <target state="translated">找不到要签名的输入。</target>
+        <target state="new">No inputs found to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOptionDescription">
@@ -109,7 +109,7 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">某些文件不存在。请尝试使用其他 {0} 值或完全限定的文件路径。</target>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -42,6 +42,11 @@
         <target state="translated">包含要签名或从签名中排除的文件路径的文件的路径。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">要签名的文件。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0} 的值无效。该值必须是完整的根目录路径。</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">{0} 的值无效。值必须为 "sha256"、"sha384" 或 "sha512"。</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">使用 glob 时，文件路径不能为根路径。请使用相对于工作目录(或基目录，如果使用)的路径。</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">最大并发。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">文件或 glob 是必需的。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">找不到要签名的输入。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">输出文件或目录。如果省略，则输入文件将被覆盖。</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">对 CLI 进行签名</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">某些文件不存在。请尝试使用其他 {0} 值或完全限定的文件路径。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="translated">使用 Windows 证书存储或本地证书文件。</target>
+        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="translated">包含要签名或从签名中排除的文件路径的文件的路径。</target>
+        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
@@ -51,6 +51,16 @@
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0} 的值无效。该值必须是完整的根目录路径。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
@@ -66,11 +76,6 @@
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
         <target state="translated">{0} 的值无效。该值必须是大于或等于 1 的数值。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="InvalidSha1ThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="translated">{0} 的值无效。该值必须是证书的 SHA-1 指纹。</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -55,12 +55,12 @@
       <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
-        <note />
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="translated">使用 Windows 憑證存放區或本機憑證檔案。</target>
+        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="translated">包含要簽署或從簽署排除之檔案路徑的檔案路徑。</target>
+        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
@@ -51,6 +51,16 @@
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0} 的值無效。值必須是完整的根目錄路徑。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
+        <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InvalidCertificateThumbprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
@@ -66,11 +76,6 @@
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
         <target state="translated">{0} 的值無效。值必須是大或等於 1 的數值。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --max-concurrency) and should not be localized.</note>
-      </trans-unit>
-      <trans-unit id="InvalidSha1ThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="translated">{0} 的無效值。值必須是憑證的 SHA-1 指紋。</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">
         <source>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</source>

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -44,7 +44,7 @@
       </trans-unit>
       <trans-unit id="FilesArgumentDescription">
         <source>File(s) to sign.</source>
-        <target state="translated">要簽署的檔案。</target>
+        <target state="new">File(s) to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidFileValue">
         <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">使用 Glob 時，檔案路徑不可為根目錄。請使用工作目錄或基底目錄 (若使用該目錄) 的相對路徑。</target>
+        <target state="new">The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
@@ -84,12 +84,12 @@
       </trans-unit>
       <trans-unit id="MissingFileValue">
         <source>A file or glob is required.</source>
-        <target state="translated">需要檔案或 Glob。</target>
+        <target state="new">A file or glob is required.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
-        <target state="translated">找不到要簽署的輸入。</target>
+        <target state="new">No inputs found to sign.</target>
         <note />
       </trans-unit>
       <trans-unit id="OutputOptionDescription">
@@ -109,7 +109,7 @@
       </trans-unit>
       <trans-unit id="SomeFilesDoNotExist">
         <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">某些檔案不存在。請嘗試使用不同的 {0} 值或完整檔案路徑。</target>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -52,14 +52,14 @@
         <target state="translated">{0} 的值無效。值必須是完整的根目錄路徑。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintAlgorithmValue">
+      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateThumbprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 thumbprint.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -42,6 +42,11 @@
         <target state="translated">包含要簽署或從簽署排除之檔案路徑的檔案路徑。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">要簽署的檔案。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0} 的值無效。值必須是完整的根目錄路徑。</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">{0} 的值無效。值必須是 'sha256'、'sha384' 或 'sha512'。</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">使用 Glob 時，檔案路徑不可為根目錄。請使用工作目錄或基底目錄 (若使用該目錄) 的相對路徑。</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">並行最大值。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">需要檔案或 Glob。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">找不到要簽署的輸入。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">輸出檔案或目錄。如果省略，則會覆寫輸入檔案。</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">簽署 CLI</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">某些檔案不存在。請嘗試使用不同的 {0} 值或完整檔案路徑。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -14,7 +14,7 @@
       </trans-unit>
       <trans-unit id="CertificateStoreCommandDescription">
         <source>Use Windows Certificate Store or a local certificate file.</source>
-        <target state="new">Use Windows Certificate Store or a local certificate file.</target>
+        <target state="translated">使用 Windows 憑證存放區或本機憑證檔案。</target>
         <note />
       </trans-unit>
       <trans-unit id="CodeCommandDescription">
@@ -39,7 +39,7 @@
       </trans-unit>
       <trans-unit id="FileListOptionDescription">
         <source>Path to file containing paths of files to sign or to exclude from signing.</source>
-        <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
+        <target state="translated">包含要簽署或從簽署排除之檔案路徑的檔案路徑。</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
@@ -59,7 +59,7 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbprintValue">
         <source>Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-1 thumbprint.</target>
+        <target state="translated">{0} 的無效值。值必須是憑證的 SHA-1 指紋。</target>
         <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidUrlValue">

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -55,12 +55,12 @@
       <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="new">Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</target>
-        <note />
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</source>
-        <target state="new">Invalid value for {0}. The value must be the certificate's SHA-256, SHA-384, or SHA-512 fingerprint.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --sha1) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
+        <target state="new">Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Core/CertificateServices/CertificateStoreService.cs
+++ b/src/Sign.Core/CertificateServices/CertificateStoreService.cs
@@ -37,10 +37,7 @@ namespace Sign.Core
             string? certificatePassword,
             bool isPrivateMachineKeyContainer)
         {
-            if (string.IsNullOrEmpty(certificateFingerprint))
-            {
-                throw new ArgumentException(Resources.ValueCannotBeEmptyString, nameof(certificateFingerprint));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(certificateFingerprint, nameof(certificateFingerprint));
 
             _certificateFingerprint = certificateFingerprint;
             _certificateFingerprintAlgorithm = certificateFingerprintAlgorithm;
@@ -104,8 +101,8 @@ namespace Sign.Core
         /// <summary>
         /// Gets a certificate from a local (user or machine) certificate store or from a provided certificate file.
         /// </summary>
-        /// <returns>A <see cref="X509Certificate2"/> certificate specified by a SHA1 Fingerprint.</returns>
-        /// <exception cref="ArgumentException">Thrown when the SHA1 fingerprint wasn't found in any store.</exception>
+        /// <returns>A <see cref="X509Certificate2"/> certificate specified by a certificate Fingerprint.</returns>
+        /// <exception cref="ArgumentException">Thrown when the certificate fingerprint wasn't found in any store.</exception>
         public async Task<X509Certificate2> GetCertificateAsync(CancellationToken cancellationToken)
             => await GetStoreCertificateAsync();
 
@@ -131,14 +128,14 @@ namespace Sign.Core
                     }
                 }
 
-                throw new ArgumentException(string.Format(Resources.CertificateNotFoundInFile, Path.GetFileName(_certificatePath)));
+                throw new ArgumentException(string.Format(Resources.CertificateNotFoundInFile, _certificateFingerprintAlgorithm, Path.GetFileName(_certificatePath)));
             }
 
             // Search User or Machine certificate stores.
             if (!string.IsNullOrEmpty(_privateKeyContainer)
                 && _isPrivateMachineKeyContainer
-                    ? TryFindCertificate(StoreLocation.LocalMachine, _certificateFingerprint!, out X509Certificate2? certificate)
-                    : TryFindCertificate(StoreLocation.CurrentUser, _certificateFingerprint!, out certificate))
+                    ? TryFindCertificate(StoreLocation.LocalMachine, _certificateFingerprint, out X509Certificate2? certificate)
+                    : TryFindCertificate(StoreLocation.CurrentUser, _certificateFingerprint, out certificate))
             {
                 _logger.LogTrace(Resources.FetchedCertificate, stopwatch.Elapsed.TotalMilliseconds);
 

--- a/src/Sign.Core/CertificateServices/CertificateStoreService.cs
+++ b/src/Sign.Core/CertificateServices/CertificateStoreService.cs
@@ -17,8 +17,8 @@ namespace Sign.Core
     /// </summary>
     internal sealed class CertificateStoreService : ISignatureAlgorithmProvider, ICertificateProvider
     {
-        private readonly string _certificateThumbprint;
-        private readonly HashAlgorithmName _certificateThumbprintAlgorithm;
+        private readonly string _certificateFingerprint;
+        private readonly HashAlgorithmName _certificateFingerprintAlgorithm;
         private readonly string? _cryptoServiceProvider;
         private readonly string? _privateKeyContainer;
         private readonly string? _certificatePath;
@@ -29,21 +29,21 @@ namespace Sign.Core
 
         internal CertificateStoreService(
             IServiceProvider serviceProvider,
-            string certificateThumbprint,
-            HashAlgorithmName certificateThumbprintAlgorithm,
+            string certificateFingerprint,
+            HashAlgorithmName certificateFingerprintAlgorithm,
             string? cryptoServiceProvider,
             string? privateKeyContainer,
             string? certificatePath,
             string? certificatePassword,
             bool isPrivateMachineKeyContainer)
         {
-            if (string.IsNullOrEmpty(certificateThumbprint))
+            if (string.IsNullOrEmpty(certificateFingerprint))
             {
-                throw new ArgumentException(Resources.ValueCannotBeEmptyString, nameof(certificateThumbprint));
+                throw new ArgumentException(Resources.ValueCannotBeEmptyString, nameof(certificateFingerprint));
             }
 
-            _certificateThumbprint = certificateThumbprint;
-            _certificateThumbprintAlgorithm = certificateThumbprintAlgorithm;
+            _certificateFingerprint = certificateFingerprint;
+            _certificateFingerprintAlgorithm = certificateFingerprintAlgorithm;
             _cryptoServiceProvider = cryptoServiceProvider;
             _privateKeyContainer = privateKeyContainer;
             _isPrivateMachineKeyContainer = isPrivateMachineKeyContainer;
@@ -104,8 +104,8 @@ namespace Sign.Core
         /// <summary>
         /// Gets a certificate from a local (user or machine) certificate store or from a provided certificate file.
         /// </summary>
-        /// <returns>A <see cref="X509Certificate2"/> certificate specified by a SHA1 Thumbprint.</returns>
-        /// <exception cref="ArgumentException">Thrown when the SHA1 thumbprint wasn't found in any store.</exception>
+        /// <returns>A <see cref="X509Certificate2"/> certificate specified by a SHA1 Fingerprint.</returns>
+        /// <exception cref="ArgumentException">Thrown when the SHA1 fingerprint wasn't found in any store.</exception>
         public async Task<X509Certificate2> GetCertificateAsync(CancellationToken cancellationToken)
             => await GetStoreCertificateAsync();
 
@@ -123,7 +123,7 @@ namespace Sign.Core
 
                 foreach (var cert in certCollection)
                 {
-                    if (string.Equals(cert.GetCertHashString(_certificateThumbprintAlgorithm), _certificateThumbprint, StringComparison.InvariantCultureIgnoreCase))
+                    if (string.Equals(cert.GetCertHashString(_certificateFingerprintAlgorithm), _certificateFingerprint, StringComparison.InvariantCultureIgnoreCase))
                     {
                         _logger.LogTrace(Resources.FetchedCertificate, stopwatch.Elapsed.TotalMilliseconds);
 
@@ -137,8 +137,8 @@ namespace Sign.Core
             // Search User or Machine certificate stores.
             if (!string.IsNullOrEmpty(_privateKeyContainer)
                 && _isPrivateMachineKeyContainer
-                    ? TryFindCertificate(StoreLocation.LocalMachine, _certificateThumbprint!, out X509Certificate2? certificate)
-                    : TryFindCertificate(StoreLocation.CurrentUser, _certificateThumbprint!, out certificate))
+                    ? TryFindCertificate(StoreLocation.LocalMachine, _certificateFingerprint!, out X509Certificate2? certificate)
+                    : TryFindCertificate(StoreLocation.CurrentUser, _certificateFingerprint!, out certificate))
             {
                 _logger.LogTrace(Resources.FetchedCertificate, stopwatch.Elapsed.TotalMilliseconds);
 
@@ -160,7 +160,7 @@ namespace Sign.Core
 
                 foreach (var cert in certificates)
                 {
-                    if (string.Equals(cert.GetCertHashString(_certificateThumbprintAlgorithm), certificateFingerprint, StringComparison.InvariantCultureIgnoreCase))
+                    if (string.Equals(cert.GetCertHashString(_certificateFingerprintAlgorithm), certificateFingerprint, StringComparison.InvariantCultureIgnoreCase))
                     {
                         certificate = cert;
 

--- a/src/Sign.Core/CertificateServices/CertificateStoreServiceProvider.cs
+++ b/src/Sign.Core/CertificateServices/CertificateStoreServiceProvider.cs
@@ -95,14 +95,14 @@ namespace Sign.Core
                 }
 
                 _certificateStoreService = new CertificateStoreService(
-                                            serviceProvider,
-                                            _certificateFingerprint,
-                                            _certificateFingerprintAlgorithm,
-                                            _cryptoServiceProvider,
-                                            _privateKeyContainer,
-                                            _certificateFilePath,
-                                            _certificateFilePassword,
-                                            _isMachineKeyContainer);
+                    serviceProvider,
+                    _certificateFingerprint,
+                    _certificateFingerprintAlgorithm,
+                    _cryptoServiceProvider,
+                    _privateKeyContainer,
+                    _certificateFilePath,
+                    _certificateFilePassword,
+                    _isMachineKeyContainer);
             }
 
             return _certificateStoreService;

--- a/src/Sign.Core/CertificateServices/CertificateStoreServiceProvider.cs
+++ b/src/Sign.Core/CertificateServices/CertificateStoreServiceProvider.cs
@@ -11,8 +11,8 @@ namespace Sign.Core
     /// </summary>
     internal class CertificateStoreServiceProvider
     {
-        private readonly string _certificateThumbprint;
-        private readonly HashAlgorithmName _certificateThumbprintAlgorithm;
+        private readonly string _certificateFingerprint;
+        private readonly HashAlgorithmName _certificateFingerprintAlgorithm;
         private readonly string? _cryptoServiceProvider;
         private readonly string? _privateKeyContainer;
         private readonly string? _certificateFilePath;
@@ -25,8 +25,8 @@ namespace Sign.Core
         /// <summary>
         /// Creates a new service provider for accessing certificates within a store.
         /// </summary>
-        /// <param name="certificateThumbprint">Required thumbprint used to identify the certificate in the store.</param>
-        /// <param name="certificateThumbprintAlgorithm">Thumbprint algorithm used to identify the algorithm type of the thumbprint.</param>
+        /// <param name="certificateFingerprint">Required fingerprint used to identify the certificate in the store.</param>
+        /// <param name="certificateFingerprintAlgorithm">Fingerprint algorithm used to identify the algorithm type of the fingerprint.</param>
         /// <param name="cryptoServiceProvider">Optional Cryptographic service provider used to access 3rd party certificate stores.</param>
         /// <param name="privateKeyContainer">Optional Key Container stored in either the per-user or per-machine location.</param>
         /// <param name="certificateFilePath">Optional path to the PFX, P7B, or CER file with the certificate.</param>
@@ -34,19 +34,19 @@ namespace Sign.Core
         /// <param name="isMachineKeyContainer">Optional Flag used to denote per-machine key container should be used.</param>
         /// <exception cref="ArgumentException">Thrown when a required argument is empty not valid.</exception>
         internal CertificateStoreServiceProvider(
-            string certificateThumbprint,
-            HashAlgorithmName certificateThumbprintAlgorithm,
+            string certificateFingerprint,
+            HashAlgorithmName certificateFingerprintAlgorithm,
             string? cryptoServiceProvider,
             string? privateKeyContainer,
             string? certificateFilePath,
             string? certificateFilePassword,
             bool isMachineKeyContainer)
         {
-            ArgumentNullException.ThrowIfNull(certificateThumbprint, nameof(certificateThumbprint));
+            ArgumentNullException.ThrowIfNull(certificateFingerprint, nameof(certificateFingerprint));
 
-            if (string.IsNullOrEmpty(certificateThumbprint))
+            if (string.IsNullOrEmpty(certificateFingerprint))
             {
-                throw new ArgumentException(Resources.ValueCannotBeEmptyString, nameof(certificateThumbprint));
+                throw new ArgumentException(Resources.ValueCannotBeEmptyString, nameof(certificateFingerprint));
             }
 
             // Both or neither can be provided when accessing a certificate.
@@ -57,8 +57,8 @@ namespace Sign.Core
                     string.IsNullOrEmpty(cryptoServiceProvider) ? nameof(cryptoServiceProvider) : nameof(privateKeyContainer));
             }
 
-            _certificateThumbprint = certificateThumbprint;
-            _certificateThumbprintAlgorithm = certificateThumbprintAlgorithm;
+            _certificateFingerprint = certificateFingerprint;
+            _certificateFingerprintAlgorithm = certificateFingerprintAlgorithm;
             _cryptoServiceProvider = cryptoServiceProvider;
             _privateKeyContainer = privateKeyContainer;
             _isMachineKeyContainer = isMachineKeyContainer;
@@ -96,8 +96,8 @@ namespace Sign.Core
 
                 _certificateStoreService = new CertificateStoreService(
                                             serviceProvider,
-                                            _certificateThumbprint,
-                                            _certificateThumbprintAlgorithm,
+                                            _certificateFingerprint,
+                                            _certificateFingerprintAlgorithm,
                                             _cryptoServiceProvider,
                                             _privateKeyContainer,
                                             _certificateFilePath,

--- a/src/Sign.Core/Resources.Designer.cs
+++ b/src/Sign.Core/Resources.Designer.cs
@@ -97,7 +97,7 @@ namespace Sign.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to find a certificate with a matching SHA-1 thumbprint in {0}..
+        ///   Looks up a localized string similar to Unable to find a certificate with a matching {0} fingerprint in {1}..
         /// </summary>
         internal static string CertificateNotFoundInFile {
             get {
@@ -241,11 +241,11 @@ namespace Sign.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store..
+        ///   Looks up a localized string similar to Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store..
         /// </summary>
-        internal static string InvalidSha1ThumbrpintValue {
+        internal static string InvalidCertificateFingerprintValue {
             get {
-                return ResourceManager.GetString("InvalidSha1ThumbrpintValue", resourceCulture);
+                return ResourceManager.GetString("InvalidCertificateFingerprintValue", resourceCulture);
             }
         }
         

--- a/src/Sign.Core/Resources.Designer.cs
+++ b/src/Sign.Core/Resources.Designer.cs
@@ -241,15 +241,6 @@ namespace Sign.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store..
-        /// </summary>
-        internal static string InvalidCertificateFingerprintValue {
-            get {
-                return ResourceManager.GetString("InvalidCertificateFingerprintValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Multiple private key containers provided. Use either /k for user stores or /km for machine stores..
         /// </summary>
         internal static string MultiplePrivateKeyContainersError {

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -133,7 +133,7 @@
   </data>
   <data name="CertificateNotFoundInFile" xml:space="preserve">
     <value>Unable to find a certificate with a matching {0} fingerprint in {1}.</value>
-    <comment>{NumberedPlaceholder="{0}"} is a file path.</comment>
+    <comment>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</comment>
   </data>
   <data name="CertificateNotFoundInMachineStore" xml:space="preserve">
     <value>Unable to find a matching certificate in machine certificate store.</value>
@@ -192,7 +192,7 @@
   </data>
   <data name="InvalidCertificateFingerprintValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</value>
-    <comment>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</comment>
+    <comment>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</comment>
   </data>
   <data name="MultiplePrivateKeyContainersError" xml:space="preserve">
     <value>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</value>

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -132,7 +132,7 @@
     <value>Unable to find a matching certificate.</value>
   </data>
   <data name="CertificateNotFoundInFile" xml:space="preserve">
-    <value>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</value>
+    <value>Unable to find a certificate with a matching {0} fingerprint in {1}.</value>
     <comment>{NumberedPlaceholder="{0}"} is a file path.</comment>
   </data>
   <data name="CertificateNotFoundInMachineStore" xml:space="preserve">
@@ -190,8 +190,8 @@
   <data name="FetchingCertificate" xml:space="preserve">
     <value>Fetching certificate from Azure Key Vault.</value>
   </data>
-  <data name="InvalidSha1ThumbrpintValue" xml:space="preserve">
-    <value>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</value>
+  <data name="InvalidCertificateFingerprintValue" xml:space="preserve">
+    <value>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</value>
     <comment>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</comment>
   </data>
   <data name="MultiplePrivateKeyContainersError" xml:space="preserve">

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -133,7 +133,7 @@
   </data>
   <data name="CertificateNotFoundInFile" xml:space="preserve">
     <value>Unable to find a certificate with a matching {0} fingerprint in {1}.</value>
-    <comment>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</comment>
+    <comment>{NumberedPlaceholder="{0}"} is a cryptographic algorithm.  {NumberedPlaceholder="{1}"} is a file path.</comment>
   </data>
   <data name="CertificateNotFoundInMachineStore" xml:space="preserve">
     <value>Unable to find a matching certificate in machine certificate store.</value>

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -190,10 +190,6 @@
   <data name="FetchingCertificate" xml:space="preserve">
     <value>Fetching certificate from Azure Key Vault.</value>
   </data>
-  <data name="InvalidCertificateFingerprintValue" xml:space="preserve">
-    <value>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</value>
-    <comment>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</comment>
-  </data>
   <data name="MultiplePrivateKeyContainersError" xml:space="preserve">
     <value>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</value>
   </data>

--- a/src/Sign.Core/Sign.Core.csproj
+++ b/src/Sign.Core/Sign.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -6,8 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" />
-    <PackageReference Include="Azure.Security.KeyVault.Certificates" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="AzureSign.Core" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
@@ -17,7 +15,6 @@
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="NuGetKeyVaultSignTool.Core" PrivateAssets="analyzers;build;compile;contentfiles" />
-    <PackageReference Include="RSAKeyVaultProvider" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="System.Security.Cryptography.Xml" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="System.Text.Json" PrivateAssets="analyzers;build;compile;contentfiles" />
@@ -34,7 +31,13 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Sign.Core.Test,PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
     </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Sign.SignatureProviders.KeyVault,PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Sign.SignatureProviders.KeyVault.Test,PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>DynamicProxyGenAssembly2,PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a cryptographic algorithm.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
@@ -105,7 +105,7 @@
       <trans-unit id="InvalidCertificateFingerprintValue">
         <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
         <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="new">Unable to find a matching certificate.</target>
+        <target state="translated">Nepovedlo se najít odpovídající certifikát.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="new">Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</target>
+        <target state="translated">V {0} nebylo možné najít certifikát s odpovídajícím kryptografickým otiskem SHA-1.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
+        <target state="translated">V úložišti certifikátů počítače nebylo možné najít odpovídající certifikát.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="new">Unable to find a matching certificate in user certificate store.</target>
+        <target state="translated">V úložišti certifikátů uživatele nebylo možné najít odpovídající certifikát.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
+        <target state="translated">Pro poskytnutý certifikát se nepovedlo získat privátní klíč RSA.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -104,17 +104,17 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbrpintValue">
         <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</target>
+        <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být kryptografický otisk SHA-1 certifikátu v úložišti certifikátů Windows.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
+        <target state="translated">Poskytlo se několik kontejnerů privátních klíčů. Pro úložiště uživatele použijte /k a pro úložiště počítače použijte /km.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Při použití /csp chybí kontejner privátního klíče. K poskytnutí kontejneru klíčů použijte /k nebo /km.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="new">Signing {filePath} succeeded.</target>
+        <target state="translated">Podepisování souboru {filePath} proběhlo úspěšně.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="new">The certificate has an unsupported public key algorithm.</target>
+        <target state="translated">Certifikát má nepodporovaný algoritmus veřejného klíče.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="new">Specified {0} is invalid.</target>
+        <target state="translated">Zadaný režim {0} je neplatný.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="new">Unknown signing algorithm.</target>
+        <target state="translated">Neznámý podpisový algoritmus.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="new">The algorithm selected is not supported.</target>
+        <target state="translated">Vybraný algoritmus se nepodporuje.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="new">Signing VsixSignTool job with {count} files.</target>
+        <target state="translated">Podepisování úlohy VsixSignTool pomocí tohoto počtu souborů: {count}.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -102,11 +102,6 @@
         <target state="translated">Načítá se certifikát z Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
-      </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="translated">Nepovedlo se najít odpovídající certifikát.</target>
+        <target state="new">Unable to find a matching certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
-        <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="translated">V {0} nebylo možné najít certifikát s odpovídajícím kryptografickým otiskem SHA-1.</target>
+        <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
+        <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="translated">V úložišti certifikátů počítače nebylo možné najít odpovídající certifikát.</target>
+        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="translated">V úložišti certifikátů uživatele nebylo možné najít odpovídající certifikát.</target>
+        <target state="new">Unable to find a matching certificate in user certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="translated">Pro poskytnutý certifikát se nepovedlo získat privátní klíč RSA.</target>
+        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -102,19 +102,19 @@
         <target state="translated">Načítá se certifikát z Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidSha1ThumbrpintValue">
-        <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být kryptografický otisk SHA-1 certifikátu v úložišti certifikátů Windows.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
+        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="translated">Poskytlo se několik kontejnerů privátních klíčů. Pro úložiště uživatele použijte /k a pro úložiště počítače použijte /km.</target>
+        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="translated">Při použití /csp chybí kontejner privátního klíče. K poskytnutí kontejneru klíčů použijte /k nebo /km.</target>
+        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="translated">Podepisování souboru {filePath} proběhlo úspěšně.</target>
+        <target state="new">Signing {filePath} succeeded.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="translated">Certifikát má nepodporovaný algoritmus veřejného klíče.</target>
+        <target state="new">The certificate has an unsupported public key algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="translated">Zadaný režim {0} je neplatný.</target>
+        <target state="new">Specified {0} is invalid.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="translated">Neznámý podpisový algoritmus.</target>
+        <target state="new">Unknown signing algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="translated">Vybraný algoritmus se nepodporuje.</target>
+        <target state="new">The algorithm selected is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="translated">Podepisování úlohy VsixSignTool pomocí tohoto počtu souborů: {count}.</target>
+        <target state="new">Signing VsixSignTool job with {count} files.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="translated">Es wurde kein übereinstimmendes Zertifikat gefunden.</target>
+        <target state="new">Unable to find a matching certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
-        <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="translated">Es wurde kein Zertifikat mit einem übereinstimmenden SHA-1-Fingerabdruck in {0} gefunden.</target>
+        <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
+        <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="translated">Im Computerzertifikatspeicher wurde kein übereinstimmendes Zertifikat gefunden.</target>
+        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="translated">Im Benutzerzertifikatspeicher wurde kein übereinstimmendes Zertifikat gefunden.</target>
+        <target state="new">Unable to find a matching certificate in user certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="translated">Der private RSA-Schlüssel für das angegebene Zertifikat kann nicht abgerufen werden.</target>
+        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -102,19 +102,19 @@
         <target state="translated">Zertifikat wird von Azure Key Vault abgerufen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidSha1ThumbrpintValue">
-        <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="translated">Ungültiger Wert für {0}. Der Wert muss der SHA-1-Fingerabdruck eines Zertifikats in einem Windows-Zertifikatspeicher sein.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
+        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="translated">Es wurden mehrere Container mit privatem Schlüssel bereitgestellt. Verwenden Sie entweder "/k" für Benutzerspeicher oder "/km" für Computerspeicher.</target>
+        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="translated">Der Container für den privaten Schlüssel fehlt bei Verwendung von "/csp". Verwenden Sie "/k" oder "/km", um einen Schlüsselcontainer bereitzustellen.</target>
+        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="translated">Signieren von {filePath} erfolgreich.</target>
+        <target state="new">Signing {filePath} succeeded.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="translated">Das Zertifikat verfügt über einen nicht unterstützten Algorithmus für öffentliche Schlüssel.</target>
+        <target state="new">The certificate has an unsupported public key algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="translated">Der angegebene {0} ist ungültig.</target>
+        <target state="new">Specified {0} is invalid.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="translated">Unbekannter Signaturalgorithmus.</target>
+        <target state="new">Unknown signing algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="translated">Der ausgewählte Algorithmus wird nicht unterstützt.</target>
+        <target state="new">The algorithm selected is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="translated">VsixSignTool-Auftrag wird mit {count} Dateien signiert.</target>
+        <target state="new">Signing VsixSignTool job with {count} files.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a cryptographic algorithm.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
@@ -105,7 +105,7 @@
       <trans-unit id="InvalidCertificateFingerprintValue">
         <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
         <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -102,11 +102,6 @@
         <target state="translated">Zertifikat wird von Azure Key Vault abgerufen.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
-      </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="new">Unable to find a matching certificate.</target>
+        <target state="translated">Es wurde kein übereinstimmendes Zertifikat gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="new">Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</target>
+        <target state="translated">Es wurde kein Zertifikat mit einem übereinstimmenden SHA-1-Fingerabdruck in {0} gefunden.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
+        <target state="translated">Im Computerzertifikatspeicher wurde kein übereinstimmendes Zertifikat gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="new">Unable to find a matching certificate in user certificate store.</target>
+        <target state="translated">Im Benutzerzertifikatspeicher wurde kein übereinstimmendes Zertifikat gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
+        <target state="translated">Der private RSA-Schlüssel für das angegebene Zertifikat kann nicht abgerufen werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -104,17 +104,17 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbrpintValue">
         <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</target>
+        <target state="translated">Ungültiger Wert für {0}. Der Wert muss der SHA-1-Fingerabdruck eines Zertifikats in einem Windows-Zertifikatspeicher sein.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
+        <target state="translated">Es wurden mehrere Container mit privatem Schlüssel bereitgestellt. Verwenden Sie entweder "/k" für Benutzerspeicher oder "/km" für Computerspeicher.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Der Container für den privaten Schlüssel fehlt bei Verwendung von "/csp". Verwenden Sie "/k" oder "/km", um einen Schlüsselcontainer bereitzustellen.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="new">Signing {filePath} succeeded.</target>
+        <target state="translated">Signieren von {filePath} erfolgreich.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="new">The certificate has an unsupported public key algorithm.</target>
+        <target state="translated">Das Zertifikat verfügt über einen nicht unterstützten Algorithmus für öffentliche Schlüssel.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="new">Specified {0} is invalid.</target>
+        <target state="translated">Der angegebene {0} ist ungültig.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="new">Unknown signing algorithm.</target>
+        <target state="translated">Unbekannter Signaturalgorithmus.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="new">The algorithm selected is not supported.</target>
+        <target state="translated">Der ausgewählte Algorithmus wird nicht unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="new">Signing VsixSignTool job with {count} files.</target>
+        <target state="translated">VsixSignTool-Auftrag wird mit {count} Dateien signiert.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="translated">No se pudo encontrar ningún certificado que coincida.</target>
+        <target state="new">Unable to find a matching certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
-        <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="translated">No se pudo encontrar ningún certificado con una huella digital SHA-1 coincidente en {0}.</target>
+        <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
+        <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="translated">No se pudo encontrar un certificado correspondiente en el almacén de certificados de máquina.</target>
+        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="translated">No se pudo encontrar un certificado correspondiente en el almacén de certificados de usuario.</target>
+        <target state="new">Unable to find a matching certificate in user certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="translated">No se puede adquirir la clave privada RSA para el certificado proporcionado.</target>
+        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -102,19 +102,19 @@
         <target state="translated">Capturando certificado de Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidSha1ThumbrpintValue">
-        <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="translated">Valor no válido para {0}. El valor debe ser la huella digital SHA-1 de un certificado en un Almacén de certificados de Windows.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
+        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="translated">Se proporcionaron varios contenedores de clave privada. Use /k para almacenes de usuarios o /km para almacenes de máquinas.</target>
+        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="translated">Falta el contenedor de clave privada al usar /csp. Use /k o /km para proporcionar un contenedor de claves.</target>
+        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="translated">Se firmó {filePath} correctamente.</target>
+        <target state="new">Signing {filePath} succeeded.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="translated">El certificado tiene un algoritmo de clave pública no admitido.</target>
+        <target state="new">The certificate has an unsupported public key algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="translated">El modo {0} especificado no es válido.</target>
+        <target state="new">Specified {0} is invalid.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="translated">Algoritmo de firma desconocido.</target>
+        <target state="new">Unknown signing algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="translated">No se admite el algoritmo seleccionado.</target>
+        <target state="new">The algorithm selected is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="translated">Firmando el trabajo de VsixSignTool con {count} archivos.</target>
+        <target state="new">Signing VsixSignTool job with {count} files.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a cryptographic algorithm.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
@@ -105,7 +105,7 @@
       <trans-unit id="InvalidCertificateFingerprintValue">
         <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
         <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="new">Unable to find a matching certificate.</target>
+        <target state="translated">No se pudo encontrar ningún certificado que coincida.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="new">Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</target>
+        <target state="translated">No se pudo encontrar ningún certificado con una huella digital SHA-1 coincidente en {0}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
+        <target state="translated">No se pudo encontrar un certificado correspondiente en el almacén de certificados de máquina.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="new">Unable to find a matching certificate in user certificate store.</target>
+        <target state="translated">No se pudo encontrar un certificado correspondiente en el almacén de certificados de usuario.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
+        <target state="translated">No se puede adquirir la clave privada RSA para el certificado proporcionado.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -104,17 +104,17 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbrpintValue">
         <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</target>
+        <target state="translated">Valor no válido para {0}. El valor debe ser la huella digital SHA-1 de un certificado en un Almacén de certificados de Windows.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
+        <target state="translated">Se proporcionaron varios contenedores de clave privada. Use /k para almacenes de usuarios o /km para almacenes de máquinas.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Falta el contenedor de clave privada al usar /csp. Use /k o /km para proporcionar un contenedor de claves.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="new">Signing {filePath} succeeded.</target>
+        <target state="translated">Se firmó {filePath} correctamente.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="new">The certificate has an unsupported public key algorithm.</target>
+        <target state="translated">El certificado tiene un algoritmo de clave pública no admitido.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="new">Specified {0} is invalid.</target>
+        <target state="translated">El modo {0} especificado no es válido.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="new">Unknown signing algorithm.</target>
+        <target state="translated">Algoritmo de firma desconocido.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="new">The algorithm selected is not supported.</target>
+        <target state="translated">No se admite el algoritmo seleccionado.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="new">Signing VsixSignTool job with {count} files.</target>
+        <target state="translated">Firmando el trabajo de VsixSignTool con {count} archivos.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -102,11 +102,6 @@
         <target state="translated">Capturando certificado de Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
-      </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a cryptographic algorithm.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
@@ -105,7 +105,7 @@
       <trans-unit id="InvalidCertificateFingerprintValue">
         <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
         <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="translated">Désolé... Nous ne pouvons pas trouver un certificat correspondant.</target>
+        <target state="new">Unable to find a matching certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
-        <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="translated">Désolé... Nous ne pouvons pas trouver un certificat avec une empreinte SHA-1 correspondante dans {0}.</target>
+        <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
+        <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="translated">Désolé... Nous ne pouvons pas trouver un certificat correspondant dans le magasin de certificats de machine.</target>
+        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="translated">Désolé... Nous ne pouvons pas trouver un certificat correspondant dans le magasin de certificats d’utilisateur.</target>
+        <target state="new">Unable to find a matching certificate in user certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="translated">Désolé.... Nous ne pouvons pas acquérir la clé privée RSA pour le certificat fourni.</target>
+        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -102,19 +102,19 @@
         <target state="translated">Récupération du certificat à partir d’Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidSha1ThumbrpintValue">
-        <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="translated">Valeur non valide pour {0}. La valeur doit être l’empreinte SHA-1 d’un certificat dans un magasin de certificats Windows.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
+        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="translated">Plusieurs conteneurs de clé privée ont été fournis. Utilisez /k pour les magasins d’utilisateurs ou /km pour les magasins d’ordinateurs.</target>
+        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="translated">Le conteneur de clé privée est manquant lors de l’utilisation de /csp. Utilisez /k ou /km pour fournir un conteneur de clé.</target>
+        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="translated">La signature de {filePath} a réussi.</target>
+        <target state="new">Signing {filePath} succeeded.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="translated">Le certificat possède un algorithme de clé publique non pris en charge.</target>
+        <target state="new">The certificate has an unsupported public key algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="translated">Le mode {0} spécifié n’est pas valide.</target>
+        <target state="new">Specified {0} is invalid.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="translated">Algorithme de signature inconnu.</target>
+        <target state="new">Unknown signing algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="translated">L’algorithme sélectionné n’est pas pris en charge.</target>
+        <target state="new">The algorithm selected is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="translated">Signature du travail VsixSignTool avec {count} fichiers.</target>
+        <target state="new">Signing VsixSignTool job with {count} files.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -102,11 +102,6 @@
         <target state="translated">Récupération du certificat à partir d’Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
-      </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="new">Unable to find a matching certificate.</target>
+        <target state="translated">Désolé... Nous ne pouvons pas trouver un certificat correspondant.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="new">Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</target>
+        <target state="translated">Désolé... Nous ne pouvons pas trouver un certificat avec une empreinte SHA-1 correspondante dans {0}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
+        <target state="translated">Désolé... Nous ne pouvons pas trouver un certificat correspondant dans le magasin de certificats de machine.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="new">Unable to find a matching certificate in user certificate store.</target>
+        <target state="translated">Désolé... Nous ne pouvons pas trouver un certificat correspondant dans le magasin de certificats d’utilisateur.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
+        <target state="translated">Désolé.... Nous ne pouvons pas acquérir la clé privée RSA pour le certificat fourni.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -104,17 +104,17 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbrpintValue">
         <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</target>
+        <target state="translated">Valeur non valide pour {0}. La valeur doit être l’empreinte SHA-1 d’un certificat dans un magasin de certificats Windows.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
+        <target state="translated">Plusieurs conteneurs de clé privée ont été fournis. Utilisez /k pour les magasins d’utilisateurs ou /km pour les magasins d’ordinateurs.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Le conteneur de clé privée est manquant lors de l’utilisation de /csp. Utilisez /k ou /km pour fournir un conteneur de clé.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="new">Signing {filePath} succeeded.</target>
+        <target state="translated">La signature de {filePath} a réussi.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="new">The certificate has an unsupported public key algorithm.</target>
+        <target state="translated">Le certificat possède un algorithme de clé publique non pris en charge.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="new">Specified {0} is invalid.</target>
+        <target state="translated">Le mode {0} spécifié n’est pas valide.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="new">Unknown signing algorithm.</target>
+        <target state="translated">Algorithme de signature inconnu.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="new">The algorithm selected is not supported.</target>
+        <target state="translated">L’algorithme sélectionné n’est pas pris en charge.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="new">Signing VsixSignTool job with {count} files.</target>
+        <target state="translated">Signature du travail VsixSignTool avec {count} fichiers.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="translated">Impossibile trovare un certificato corrispondente.</target>
+        <target state="new">Unable to find a matching certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
-        <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="translated">Impossibile trovare un certificato con un'identificazione personale SHA-1 corrispondente nel {0}.</target>
+        <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
+        <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="translated">Impossibile trovare un certificato corrispondente nell'archivio certificati del computer.</target>
+        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="translated">Impossibile trovare un certificato corrispondente nell'archivio certificati dell'utente.</target>
+        <target state="new">Unable to find a matching certificate in user certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="translated">Impossibile acquisire la chiave privata RSA per il certificato fornito.</target>
+        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -102,19 +102,19 @@
         <target state="translated">Recupero certificato da Azure Key Vault in corso.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidSha1ThumbrpintValue">
-        <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="translated">Valore non valido per {0}. Il valore deve essere l'identificazione personale SHA-1 di un certificato in un archivio certificati Windows.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
+        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="translated">Sono stati specificati più contenitori di chiavi private. Utilizzare /k per gli archivi utente o /km per gli archivi computer.</target>
+        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="translated">Contenitore di chiavi private mancante durante l'utilizzo di /csp. Usare /k o /km per specificare un contenitore di chiavi.</target>
+        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="translated">Firma di {filePath} completata.</target>
+        <target state="new">Signing {filePath} succeeded.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="translated">Il certificato contiene un algoritmo a chiave pubblica non supportato.</target>
+        <target state="new">The certificate has an unsupported public key algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="translated">{0} specificato non valido.</target>
+        <target state="new">Specified {0} is invalid.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="translated">Algoritmo di firma sconosciuto.</target>
+        <target state="new">Unknown signing algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="translated">L'algoritmo selezionato non è supportato.</target>
+        <target state="new">The algorithm selected is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="translated">Firma del processo VsixSignTool con {count} file.</target>
+        <target state="new">Signing VsixSignTool job with {count} files.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a cryptographic algorithm.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
@@ -105,7 +105,7 @@
       <trans-unit id="InvalidCertificateFingerprintValue">
         <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
         <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -102,11 +102,6 @@
         <target state="translated">Recupero certificato da Azure Key Vault in corso.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
-      </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="new">Unable to find a matching certificate.</target>
+        <target state="translated">Impossibile trovare un certificato corrispondente.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="new">Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</target>
+        <target state="translated">Impossibile trovare un certificato con un'identificazione personale SHA-1 corrispondente nel {0}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
+        <target state="translated">Impossibile trovare un certificato corrispondente nell'archivio certificati del computer.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="new">Unable to find a matching certificate in user certificate store.</target>
+        <target state="translated">Impossibile trovare un certificato corrispondente nell'archivio certificati dell'utente.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
+        <target state="translated">Impossibile acquisire la chiave privata RSA per il certificato fornito.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -104,17 +104,17 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbrpintValue">
         <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</target>
+        <target state="translated">Valore non valido per {0}. Il valore deve essere l'identificazione personale SHA-1 di un certificato in un archivio certificati Windows.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
+        <target state="translated">Sono stati specificati più contenitori di chiavi private. Utilizzare /k per gli archivi utente o /km per gli archivi computer.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Contenitore di chiavi private mancante durante l'utilizzo di /csp. Usare /k o /km per specificare un contenitore di chiavi.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="new">Signing {filePath} succeeded.</target>
+        <target state="translated">Firma di {filePath} completata.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="new">The certificate has an unsupported public key algorithm.</target>
+        <target state="translated">Il certificato contiene un algoritmo a chiave pubblica non supportato.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="new">Specified {0} is invalid.</target>
+        <target state="translated">{0} specificato non valido.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="new">Unknown signing algorithm.</target>
+        <target state="translated">Algoritmo di firma sconosciuto.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="new">The algorithm selected is not supported.</target>
+        <target state="translated">L'algoritmo selezionato non è supportato.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="new">Signing VsixSignTool job with {count} files.</target>
+        <target state="translated">Firma del processo VsixSignTool con {count} file.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="new">Unable to find a matching certificate.</target>
+        <target state="translated">一致する証明書が見つかりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="new">Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</target>
+        <target state="translated">{0} で SHA-1 拇印が一致する証明書が見つかりません。</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
+        <target state="translated">コンピューター証明書ストアに一致する証明書が見つかりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="new">Unable to find a matching certificate in user certificate store.</target>
+        <target state="translated">ユーザー証明書ストアに一致する証明書が見つかりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
+        <target state="translated">指定された証明書の RSA 秘密キーを取得できません。</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -104,17 +104,17 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbrpintValue">
         <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</target>
+        <target state="translated">{0} の値が無効です。値は、Windows 証明書ストア内の証明書の SHA-1 拇印である必要があります。</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
+        <target state="translated">複数の秘密キー コンテナーが提供されています。ユーザー ストアの場合は /k、コンピューター ストアの場合は /km を使用します。</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">/csp の使用中に秘密キー コンテナーが見つかりません。キー コンテナーを指定するには、/k または /km を使用します。</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="new">Signing {filePath} succeeded.</target>
+        <target state="translated">{filePath} の署名に成功しました。</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="new">The certificate has an unsupported public key algorithm.</target>
+        <target state="translated">証明書にサポートされていない公開キー アルゴリズムがあります。</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="new">Specified {0} is invalid.</target>
+        <target state="translated">指定された {0} は無効です。</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="new">Unknown signing algorithm.</target>
+        <target state="translated">不明な署名アルゴリズムです。</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="new">The algorithm selected is not supported.</target>
+        <target state="translated">選択したアルゴリズムはサポートされていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="new">Signing VsixSignTool job with {count} files.</target>
+        <target state="translated">{count} 個のファイルを使用して VsixSignTool ジョブに署名しています。</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a cryptographic algorithm.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
@@ -105,7 +105,7 @@
       <trans-unit id="InvalidCertificateFingerprintValue">
         <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
         <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="translated">一致する証明書が見つかりません。</target>
+        <target state="new">Unable to find a matching certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
-        <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="translated">{0} で SHA-1 拇印が一致する証明書が見つかりません。</target>
+        <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
+        <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="translated">コンピューター証明書ストアに一致する証明書が見つかりません。</target>
+        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="translated">ユーザー証明書ストアに一致する証明書が見つかりません。</target>
+        <target state="new">Unable to find a matching certificate in user certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="translated">指定された証明書の RSA 秘密キーを取得できません。</target>
+        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -102,19 +102,19 @@
         <target state="translated">Azure Key Vault から証明書をフェッチしています。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidSha1ThumbrpintValue">
-        <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="translated">{0} の値が無効です。値は、Windows 証明書ストア内の証明書の SHA-1 拇印である必要があります。</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
+        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="translated">複数の秘密キー コンテナーが提供されています。ユーザー ストアの場合は /k、コンピューター ストアの場合は /km を使用します。</target>
+        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="translated">/csp の使用中に秘密キー コンテナーが見つかりません。キー コンテナーを指定するには、/k または /km を使用します。</target>
+        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="translated">{filePath} の署名に成功しました。</target>
+        <target state="new">Signing {filePath} succeeded.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="translated">証明書にサポートされていない公開キー アルゴリズムがあります。</target>
+        <target state="new">The certificate has an unsupported public key algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="translated">指定された {0} は無効です。</target>
+        <target state="new">Specified {0} is invalid.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="translated">不明な署名アルゴリズムです。</target>
+        <target state="new">Unknown signing algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="translated">選択したアルゴリズムはサポートされていません。</target>
+        <target state="new">The algorithm selected is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="translated">{count} 個のファイルを使用して VsixSignTool ジョブに署名しています。</target>
+        <target state="new">Signing VsixSignTool job with {count} files.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -102,11 +102,6 @@
         <target state="translated">Azure Key Vault から証明書をフェッチしています。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
-      </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="translated">일치하는 인증서를 찾을 수 없습니다.</target>
+        <target state="new">Unable to find a matching certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
-        <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="translated">{0}의 SHA-1 지문이 일치하는 인증서를 찾을 수 없습니다.</target>
+        <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
+        <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="translated">컴퓨터 인증서 저장소에서 일치하는 인증서를 찾을 수 없습니다.</target>
+        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="translated">사용자 인증서 저장소에서 일치하는 인증서를 찾을 수 없습니다.</target>
+        <target state="new">Unable to find a matching certificate in user certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="translated">제공된 인증서의 RSA 프라이빗 키를 가져올 수 없습니다.</target>
+        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -102,19 +102,19 @@
         <target state="translated">Azure Key Vault에서 인증서를 가져오는 중입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidSha1ThumbrpintValue">
-        <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="translated">{0}의 값이 잘못되었습니다. 값은 Windows 인증서 저장소에 있는 인증서의 SHA-1 지문이어야 합니다.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
+        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="translated">여러 프라이빗 키 컨테이너가 제공되었습니다. 사용자 저장소에는 /k를, 컴퓨터 저장소에는 /km를 사용합니다.</target>
+        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="translated">/csp를 사용하는 동안 프라이빗 키 컨테이너가 없습니다. /k 또는 /km를 사용하여 키 컨테이너를 제공합니다.</target>
+        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="translated">{filePath} 서명에 성공했습니다.</target>
+        <target state="new">Signing {filePath} succeeded.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="translated">인증서에 지원되지 않는 공개 키 알고리즘이 있습니다.</target>
+        <target state="new">The certificate has an unsupported public key algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="translated">지정한 {0} 값이 잘못되었습니다.</target>
+        <target state="new">Specified {0} is invalid.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="translated">알 수 없는 서명 알고리즘입니다.</target>
+        <target state="new">Unknown signing algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="translated">선택한 알고리즘은 지원되지 않습니다.</target>
+        <target state="new">The algorithm selected is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="translated">{count}개의 파일을 사용하여 VsixSignTool 작업에 서명합니다.</target>
+        <target state="new">Signing VsixSignTool job with {count} files.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a cryptographic algorithm.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="new">Unable to find a matching certificate.</target>
+        <target state="translated">일치하는 인증서를 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="new">Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</target>
+        <target state="translated">{0}의 SHA-1 지문이 일치하는 인증서를 찾을 수 없습니다.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
+        <target state="translated">컴퓨터 인증서 저장소에서 일치하는 인증서를 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="new">Unable to find a matching certificate in user certificate store.</target>
+        <target state="translated">사용자 인증서 저장소에서 일치하는 인증서를 찾을 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
+        <target state="translated">제공된 인증서의 RSA 프라이빗 키를 가져올 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -104,17 +104,17 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbrpintValue">
         <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</target>
+        <target state="translated">{0}의 값이 잘못되었습니다. 값은 Windows 인증서 저장소에 있는 인증서의 SHA-1 지문이어야 합니다.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
+        <target state="translated">여러 프라이빗 키 컨테이너가 제공되었습니다. 사용자 저장소에는 /k를, 컴퓨터 저장소에는 /km를 사용합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">/csp를 사용하는 동안 프라이빗 키 컨테이너가 없습니다. /k 또는 /km를 사용하여 키 컨테이너를 제공합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="new">Signing {filePath} succeeded.</target>
+        <target state="translated">{filePath} 서명에 성공했습니다.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="new">The certificate has an unsupported public key algorithm.</target>
+        <target state="translated">인증서에 지원되지 않는 공개 키 알고리즘이 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="new">Specified {0} is invalid.</target>
+        <target state="translated">지정한 {0} 값이 잘못되었습니다.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="new">Unknown signing algorithm.</target>
+        <target state="translated">알 수 없는 서명 알고리즘입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="new">The algorithm selected is not supported.</target>
+        <target state="translated">선택한 알고리즘은 지원되지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="new">Signing VsixSignTool job with {count} files.</target>
+        <target state="translated">{count}개의 파일을 사용하여 VsixSignTool 작업에 서명합니다.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
@@ -105,7 +105,7 @@
       <trans-unit id="InvalidCertificateFingerprintValue">
         <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
         <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -102,11 +102,6 @@
         <target state="translated">Azure Key Vault에서 인증서를 가져오는 중입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
-      </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -102,11 +102,6 @@
         <target state="translated">Pobieranie certyfikatu z usługi Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
-      </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a cryptographic algorithm.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
@@ -105,7 +105,7 @@
       <trans-unit id="InvalidCertificateFingerprintValue">
         <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
         <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="new">Unable to find a matching certificate.</target>
+        <target state="translated">Nie można znaleźć zgodnego certyfikatu.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="new">Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</target>
+        <target state="translated">Nie można odnaleźć certyfikatu ze zgodnym odciskiem palca SHA-1 w ścieżce pliku {0}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
+        <target state="translated">Nie można znaleźć zgodnego certyfikatu w magazynie certyfikatów komputera.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="new">Unable to find a matching certificate in user certificate store.</target>
+        <target state="translated">Nie można znaleźć zgodnego certyfikatu w magazynie certyfikatów użytkownika.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
+        <target state="translated">Nie można uzyskać klucza prywatnego RSA dla podanego certyfikatu.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -104,17 +104,17 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbrpintValue">
         <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</target>
+        <target state="translated">Nieprawidłowa wartość dla opcji {0}. Wartość musi być odciskiem palca SHA-1 certyfikatu w Magazynie certyfikatów systemu Windows.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
+        <target state="translated">Podano wiele kontenerów kluczy prywatnych. Użyj opcji /k dla magazynów użytkowników lub opcji /km dla magazynów komputerów.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Brak kontenera kluczy prywatnych podczas używania opcji /csp. Użyj opcji /k lub /km, aby podać kontener kluczy.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="new">Signing {filePath} succeeded.</target>
+        <target state="translated">Podpisywanie ścieżki {filePath} powiodło się.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="new">The certificate has an unsupported public key algorithm.</target>
+        <target state="translated">Certyfikat zawiera nieobsługiwany algorytmu kluczy publicznych.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="new">Specified {0} is invalid.</target>
+        <target state="translated">Określony tryb {0} jest nieprawidłowy.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="new">Unknown signing algorithm.</target>
+        <target state="translated">Nieznany algorytm podpisywania.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="new">The algorithm selected is not supported.</target>
+        <target state="translated">Wybrany algorytm nie jest obsługiwany.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="new">Signing VsixSignTool job with {count} files.</target>
+        <target state="translated">Podpisywanie zadania VsixSignTool przy użyciu {count} plików.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="translated">Nie można znaleźć zgodnego certyfikatu.</target>
+        <target state="new">Unable to find a matching certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
-        <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="translated">Nie można odnaleźć certyfikatu ze zgodnym odciskiem palca SHA-1 w ścieżce pliku {0}.</target>
+        <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
+        <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="translated">Nie można znaleźć zgodnego certyfikatu w magazynie certyfikatów komputera.</target>
+        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="translated">Nie można znaleźć zgodnego certyfikatu w magazynie certyfikatów użytkownika.</target>
+        <target state="new">Unable to find a matching certificate in user certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="translated">Nie można uzyskać klucza prywatnego RSA dla podanego certyfikatu.</target>
+        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -102,19 +102,19 @@
         <target state="translated">Pobieranie certyfikatu z usługi Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidSha1ThumbrpintValue">
-        <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="translated">Nieprawidłowa wartość dla opcji {0}. Wartość musi być odciskiem palca SHA-1 certyfikatu w Magazynie certyfikatów systemu Windows.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
+        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="translated">Podano wiele kontenerów kluczy prywatnych. Użyj opcji /k dla magazynów użytkowników lub opcji /km dla magazynów komputerów.</target>
+        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="translated">Brak kontenera kluczy prywatnych podczas używania opcji /csp. Użyj opcji /k lub /km, aby podać kontener kluczy.</target>
+        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="translated">Podpisywanie ścieżki {filePath} powiodło się.</target>
+        <target state="new">Signing {filePath} succeeded.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="translated">Certyfikat zawiera nieobsługiwany algorytmu kluczy publicznych.</target>
+        <target state="new">The certificate has an unsupported public key algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="translated">Określony tryb {0} jest nieprawidłowy.</target>
+        <target state="new">Specified {0} is invalid.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="translated">Nieznany algorytm podpisywania.</target>
+        <target state="new">Unknown signing algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="translated">Wybrany algorytm nie jest obsługiwany.</target>
+        <target state="new">The algorithm selected is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="translated">Podpisywanie zadania VsixSignTool przy użyciu {count} plików.</target>
+        <target state="new">Signing VsixSignTool job with {count} files.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -102,11 +102,6 @@
         <target state="translated">Buscando certificado no Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
-      </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a cryptographic algorithm.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
@@ -105,7 +105,7 @@
       <trans-unit id="InvalidCertificateFingerprintValue">
         <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
         <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="new">Unable to find a matching certificate.</target>
+        <target state="translated">Não foi possível localizar um certificado correspondente.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="new">Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</target>
+        <target state="translated">Não foi possível localizar um certificado com uma impressão digital SHA-1 correspondente no {0}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
+        <target state="translated">Não foi possível localizar um certificado correspondente no repositório de certificados do computador.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="new">Unable to find a matching certificate in user certificate store.</target>
+        <target state="translated">Não foi possível localizar um certificado correspondente no repositório de certificados do usuário.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
+        <target state="translated">Não foi possível adquirir a chave privada RSA para o certificado fornecido.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -104,17 +104,17 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbrpintValue">
         <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</target>
+        <target state="translated">Valor inválido para {0}. O valor precisa ser a impressão digital SHA-1 de um certificado em um Repositório de Certificados do Windows.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
+        <target state="translated">Vários contêineres de chave privada fornecidos. Use /k para repositórios de usuários ou /km para repositórios de computadores.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Contêiner de chave privada ausente ao usar /csp. Use /k ou /km para fornecer um contêiner de chave.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="new">Signing {filePath} succeeded.</target>
+        <target state="translated">A assinatura do {filePath} foi bem-sucedida.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="new">The certificate has an unsupported public key algorithm.</target>
+        <target state="translated">O certificado tem um algoritmo de chave pública sem suporte.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="new">Specified {0} is invalid.</target>
+        <target state="translated">O {0} especificado é inválido.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="new">Unknown signing algorithm.</target>
+        <target state="translated">Algoritmo de assinatura desconhecido.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="new">The algorithm selected is not supported.</target>
+        <target state="translated">O algoritmo selecionado não tem suporte.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="new">Signing VsixSignTool job with {count} files.</target>
+        <target state="translated">Assinando o trabalho VsixSignTool com {count} arquivos.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="translated">Não foi possível localizar um certificado correspondente.</target>
+        <target state="new">Unable to find a matching certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
-        <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="translated">Não foi possível localizar um certificado com uma impressão digital SHA-1 correspondente no {0}.</target>
+        <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
+        <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="translated">Não foi possível localizar um certificado correspondente no repositório de certificados do computador.</target>
+        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="translated">Não foi possível localizar um certificado correspondente no repositório de certificados do usuário.</target>
+        <target state="new">Unable to find a matching certificate in user certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="translated">Não foi possível adquirir a chave privada RSA para o certificado fornecido.</target>
+        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -102,19 +102,19 @@
         <target state="translated">Buscando certificado no Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidSha1ThumbrpintValue">
-        <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="translated">Valor inválido para {0}. O valor precisa ser a impressão digital SHA-1 de um certificado em um Repositório de Certificados do Windows.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
+        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="translated">Vários contêineres de chave privada fornecidos. Use /k para repositórios de usuários ou /km para repositórios de computadores.</target>
+        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="translated">Contêiner de chave privada ausente ao usar /csp. Use /k ou /km para fornecer um contêiner de chave.</target>
+        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="translated">A assinatura do {filePath} foi bem-sucedida.</target>
+        <target state="new">Signing {filePath} succeeded.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="translated">O certificado tem um algoritmo de chave pública sem suporte.</target>
+        <target state="new">The certificate has an unsupported public key algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="translated">O {0} especificado é inválido.</target>
+        <target state="new">Specified {0} is invalid.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="translated">Algoritmo de assinatura desconhecido.</target>
+        <target state="new">Unknown signing algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="translated">O algoritmo selecionado não tem suporte.</target>
+        <target state="new">The algorithm selected is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="translated">Assinando o trabalho VsixSignTool com {count} arquivos.</target>
+        <target state="new">Signing VsixSignTool job with {count} files.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="new">Unable to find a matching certificate.</target>
+        <target state="translated">Не удается найти соответствующий сертификат.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="new">Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</target>
+        <target state="translated">Не удалось найти сертификат с соответствующим отпечатком SHA-1 в {0}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
+        <target state="translated">Не удается найти соответствующий сертификат в хранилище сертификатов компьютера.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="new">Unable to find a matching certificate in user certificate store.</target>
+        <target state="translated">Не удается найти соответствующий сертификат в хранилище сертификатов пользователя.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
+        <target state="translated">Не удалось получить закрытый ключ RSA для предоставленного сертификата.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -104,17 +104,17 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbrpintValue">
         <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</target>
+        <target state="translated">Недопустимое значение для {0}. Значение должно быть отпечатком SHA-1 сертификата в хранилище сертификатов Windows.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
+        <target state="translated">Предоставлено несколько контейнеров закрытых ключей. Используйте /k для хранилищ пользователей или /km для хранилищ компьютеров.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">Отсутствует контейнер закрытого ключа при использовании /csp. Используйте /k или /km для предоставления контейнера ключей.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="new">Signing {filePath} succeeded.</target>
+        <target state="translated">Подписание {filePath} выполнено.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="new">The certificate has an unsupported public key algorithm.</target>
+        <target state="translated">Сертификат содержит неподдерживаемый алгоритм открытого ключа.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="new">Specified {0} is invalid.</target>
+        <target state="translated">Указанный параметр ({0}) недопустим.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="new">Unknown signing algorithm.</target>
+        <target state="translated">Неизвестный алгоритм подписывания.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="new">The algorithm selected is not supported.</target>
+        <target state="translated">Выбранный алгоритм не поддерживается.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="new">Signing VsixSignTool job with {count} files.</target>
+        <target state="translated">Подписывание задания VsixSignTool с несколькими файлами ({count}).</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a cryptographic algorithm.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
@@ -105,7 +105,7 @@
       <trans-unit id="InvalidCertificateFingerprintValue">
         <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
         <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -102,11 +102,6 @@
         <target state="translated">Идет получение сертификата из Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
-      </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="translated">Не удается найти соответствующий сертификат.</target>
+        <target state="new">Unable to find a matching certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
-        <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="translated">Не удалось найти сертификат с соответствующим отпечатком SHA-1 в {0}.</target>
+        <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
+        <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="translated">Не удается найти соответствующий сертификат в хранилище сертификатов компьютера.</target>
+        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="translated">Не удается найти соответствующий сертификат в хранилище сертификатов пользователя.</target>
+        <target state="new">Unable to find a matching certificate in user certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="translated">Не удалось получить закрытый ключ RSA для предоставленного сертификата.</target>
+        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -102,19 +102,19 @@
         <target state="translated">Идет получение сертификата из Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidSha1ThumbrpintValue">
-        <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="translated">Недопустимое значение для {0}. Значение должно быть отпечатком SHA-1 сертификата в хранилище сертификатов Windows.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
+        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="translated">Предоставлено несколько контейнеров закрытых ключей. Используйте /k для хранилищ пользователей или /km для хранилищ компьютеров.</target>
+        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="translated">Отсутствует контейнер закрытого ключа при использовании /csp. Используйте /k или /km для предоставления контейнера ключей.</target>
+        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="translated">Подписание {filePath} выполнено.</target>
+        <target state="new">Signing {filePath} succeeded.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="translated">Сертификат содержит неподдерживаемый алгоритм открытого ключа.</target>
+        <target state="new">The certificate has an unsupported public key algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="translated">Указанный параметр ({0}) недопустим.</target>
+        <target state="new">Specified {0} is invalid.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="translated">Неизвестный алгоритм подписывания.</target>
+        <target state="new">Unknown signing algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="translated">Выбранный алгоритм не поддерживается.</target>
+        <target state="new">The algorithm selected is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="translated">Подписывание задания VsixSignTool с несколькими файлами ({count}).</target>
+        <target state="new">Signing VsixSignTool job with {count} files.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -102,11 +102,6 @@
         <target state="translated">Sertifika Azure Key Vault’tan getiriliyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
-      </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a cryptographic algorithm.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
@@ -105,7 +105,7 @@
       <trans-unit id="InvalidCertificateFingerprintValue">
         <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
         <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="translated">Eşleşen sertifika bulunamadı.</target>
+        <target state="new">Unable to find a matching certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
-        <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="translated">{0} dosya yolunda eşleşen SHA-1 parmak izine sahip sertifika bulunamadı.</target>
+        <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
+        <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="translated">Makine sertifikası deposunda eşleşen bir sertifika bulunamadı.</target>
+        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="translated">Kullanıcı sertifikası deposunda eşleşen bir sertifika bulunamadı.</target>
+        <target state="new">Unable to find a matching certificate in user certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="translated">Sağlanan sertifika için RSA özel anahtarı alınamıyor.</target>
+        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -102,19 +102,19 @@
         <target state="translated">Sertifika Azure Key Vault’tan getiriliyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidSha1ThumbrpintValue">
-        <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="translated">{0} için geçersiz değer. Değer, Windows Sertifika Deposundaki bir sertifikanın SHA-1 parmak izi olmalıdır.</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
+        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="translated">Birden çok özel anahtar kapsayıcısı sağlandı. Kullanıcı depoları için /k veya makine depoları için /km kullanın.</target>
+        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="translated">/csp kullanılırken özel anahtar kapsayıcısı eksik. Anahtar kapsayıcısı sağlamak için /k veya /km kullanın.</target>
+        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="translated">{filePath} imzalama işlemi başarılı oldu.</target>
+        <target state="new">Signing {filePath} succeeded.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="translated">Sertifika, desteklenmeyen ortak anahtar algoritmasına sahip.</target>
+        <target state="new">The certificate has an unsupported public key algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="translated">Belirtilen {0} geçersiz.</target>
+        <target state="new">Specified {0} is invalid.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="translated">Bilinmeyen imzalama algoritması.</target>
+        <target state="new">Unknown signing algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="translated">Seçilen algoritma desteklenmiyor.</target>
+        <target state="new">The algorithm selected is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="translated">VsixSignTool işi {count} dosya ile imzalanıyor.</target>
+        <target state="new">Signing VsixSignTool job with {count} files.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="new">Unable to find a matching certificate.</target>
+        <target state="translated">Eşleşen sertifika bulunamadı.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="new">Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</target>
+        <target state="translated">{0} dosya yolunda eşleşen SHA-1 parmak izine sahip sertifika bulunamadı.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
+        <target state="translated">Makine sertifikası deposunda eşleşen bir sertifika bulunamadı.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="new">Unable to find a matching certificate in user certificate store.</target>
+        <target state="translated">Kullanıcı sertifikası deposunda eşleşen bir sertifika bulunamadı.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
+        <target state="translated">Sağlanan sertifika için RSA özel anahtarı alınamıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -104,17 +104,17 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbrpintValue">
         <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</target>
+        <target state="translated">{0} için geçersiz değer. Değer, Windows Sertifika Deposundaki bir sertifikanın SHA-1 parmak izi olmalıdır.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
+        <target state="translated">Birden çok özel anahtar kapsayıcısı sağlandı. Kullanıcı depoları için /k veya makine depoları için /km kullanın.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">/csp kullanılırken özel anahtar kapsayıcısı eksik. Anahtar kapsayıcısı sağlamak için /k veya /km kullanın.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="new">Signing {filePath} succeeded.</target>
+        <target state="translated">{filePath} imzalama işlemi başarılı oldu.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="new">The certificate has an unsupported public key algorithm.</target>
+        <target state="translated">Sertifika, desteklenmeyen ortak anahtar algoritmasına sahip.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="new">Specified {0} is invalid.</target>
+        <target state="translated">Belirtilen {0} geçersiz.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="new">Unknown signing algorithm.</target>
+        <target state="translated">Bilinmeyen imzalama algoritması.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="new">The algorithm selected is not supported.</target>
+        <target state="translated">Seçilen algoritma desteklenmiyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="new">Signing VsixSignTool job with {count} files.</target>
+        <target state="translated">VsixSignTool işi {count} dosya ile imzalanıyor.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -102,11 +102,6 @@
         <target state="translated">正在从 Azure Key Vault 提取证书。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
-      </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a cryptographic algorithm.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
@@ -105,7 +105,7 @@
       <trans-unit id="InvalidCertificateFingerprintValue">
         <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
         <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="new">Unable to find a matching certificate.</target>
+        <target state="translated">找不到匹配的证书。</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="new">Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</target>
+        <target state="translated">在 {0} 中找不到具有匹配 SHA-1 指纹的证书。</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
+        <target state="translated">在计算机证书存储中找不到匹配的证书。</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="new">Unable to find a matching certificate in user certificate store.</target>
+        <target state="translated">在用户证书存储中找不到匹配的证书。</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
+        <target state="translated">无法获取所提供的证书的 RSA 私钥。</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -104,17 +104,17 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbrpintValue">
         <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</target>
+        <target state="translated">{0} 的值无效。该值必须是 Windows 证书存储中证书的 SHA-1 指纹。</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
+        <target state="translated">提供了多个私钥容器。对用户存储使用 /k，或者对计算机存储使用 /km。</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">使用 /csp 时缺少私钥容器。使用 /k 或 /km 提供密钥容器。</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="new">Signing {filePath} succeeded.</target>
+        <target state="translated">已成功对 {filePath} 签名。</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="new">The certificate has an unsupported public key algorithm.</target>
+        <target state="translated">证书具有不受支持的公钥算法。</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="new">Specified {0} is invalid.</target>
+        <target state="translated">指定的 {0} 无效。</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="new">Unknown signing algorithm.</target>
+        <target state="translated">未知签名算法。</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="new">The algorithm selected is not supported.</target>
+        <target state="translated">不支持所选算法。</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="new">Signing VsixSignTool job with {count} files.</target>
+        <target state="translated">正在对包含 {count} 个文件的 VsixSignTool 作业进行签名。</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="translated">找不到匹配的证书。</target>
+        <target state="new">Unable to find a matching certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
-        <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="translated">在 {0} 中找不到具有匹配 SHA-1 指纹的证书。</target>
+        <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
+        <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="translated">在计算机证书存储中找不到匹配的证书。</target>
+        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="translated">在用户证书存储中找不到匹配的证书。</target>
+        <target state="new">Unable to find a matching certificate in user certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="translated">无法获取所提供的证书的 RSA 私钥。</target>
+        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -102,19 +102,19 @@
         <target state="translated">正在从 Azure Key Vault 提取证书。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidSha1ThumbrpintValue">
-        <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="translated">{0} 的值无效。该值必须是 Windows 证书存储中证书的 SHA-1 指纹。</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
+        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="translated">提供了多个私钥容器。对用户存储使用 /k，或者对计算机存储使用 /km。</target>
+        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="translated">使用 /csp 时缺少私钥容器。使用 /k 或 /km 提供密钥容器。</target>
+        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="translated">已成功对 {filePath} 签名。</target>
+        <target state="new">Signing {filePath} succeeded.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="translated">证书具有不受支持的公钥算法。</target>
+        <target state="new">The certificate has an unsupported public key algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="translated">指定的 {0} 无效。</target>
+        <target state="new">Specified {0} is invalid.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="translated">未知签名算法。</target>
+        <target state="new">Unknown signing algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="translated">不支持所选算法。</target>
+        <target state="new">The algorithm selected is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="translated">正在对包含 {count} 个文件的 VsixSignTool 作业进行签名。</target>
+        <target state="new">Signing VsixSignTool job with {count} files.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a cryptographic algorithm.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="translated">找不到相符的憑證。</target>
+        <target state="new">Unable to find a matching certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
-        <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="translated">在 {0} 中找不到具有相符 SHA-1 指紋的憑證。</target>
+        <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
+        <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="translated">無法在機器憑證存放區中找到相符的憑證。</target>
+        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="translated">無法在使用者憑證存放區中找到相符的憑證。</target>
+        <target state="new">Unable to find a matching certificate in user certificate store.</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="translated">無法取得所提供憑證的 RSA 私密金鑰。</target>
+        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -102,19 +102,19 @@
         <target state="translated">正在從 Azure Key Vault 擷取憑證。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidSha1ThumbrpintValue">
-        <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="translated">{0} 的無效值。值必須是 Windows 憑證存放區中憑證的 SHA-1 指紋。</target>
+      <trans-unit id="InvalidCertificateFingerprintValue">
+        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
+        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="translated">已提供多個私密金鑰。使用者存放區使用 /k，機器存放區則使用 /km。</target>
+        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="translated">使用 /csp 時遺漏私密金鑰容器。使用 /k 或 /km 來提供金鑰容器。</target>
+        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="translated">簽署 {filePath} 成功。</target>
+        <target state="new">Signing {filePath} succeeded.</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="translated">憑證具有不支援的公開金鑰演算法。</target>
+        <target state="new">The certificate has an unsupported public key algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="translated">指定的 {0} 無效。</target>
+        <target state="new">Specified {0} is invalid.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="translated">未知的簽署演算法。</target>
+        <target state="new">Unknown signing algorithm.</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="translated">不支持選取的演算法。</target>
+        <target state="new">The algorithm selected is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="translated">正在簽署具有 {count} 個檔案的 OpenVsixSignTool 工作。</target>
+        <target state="new">Signing VsixSignTool job with {count} files.</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -25,7 +25,7 @@
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching {0} fingerprint in {1}.</source>
         <target state="new">Unable to find a certificate with a matching {0} fingerprint in {1}.</target>
-        <note>{NumberedPlaceholder="{0}"} is a file path.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint.  {NumberedPlaceholder="{1}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
@@ -105,7 +105,7 @@
       <trans-unit id="InvalidCertificateFingerprintValue">
         <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
         <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
+        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -102,11 +102,6 @@
         <target state="translated">正在從 Azure Key Vault 擷取憑證。</target>
         <note />
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be a {1} fingerprint of a certificate in a Windows Certificate Store.</target>
-        <note>{NumberedPlaceholder="{0}"} is a certificate fingerprint, and {NumberedPlaceholder="{1}"} is a cryptographic hash algorithm.</note>
-      </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -19,27 +19,27 @@
       </trans-unit>
       <trans-unit id="CertificateNotFound">
         <source>Unable to find a matching certificate.</source>
-        <target state="new">Unable to find a matching certificate.</target>
+        <target state="translated">找不到相符的憑證。</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInFile">
         <source>Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</source>
-        <target state="new">Unable to find a certificate with a matching SHA-1 thumbprint in {0}.</target>
+        <target state="translated">在 {0} 中找不到具有相符 SHA-1 指紋的憑證。</target>
         <note>{NumberedPlaceholder="{0}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="CertificateNotFoundInMachineStore">
         <source>Unable to find a matching certificate in machine certificate store.</source>
-        <target state="new">Unable to find a matching certificate in machine certificate store.</target>
+        <target state="translated">無法在機器憑證存放區中找到相符的憑證。</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateNotFoundInUserStore">
         <source>Unable to find a matching certificate in user certificate store.</source>
-        <target state="new">Unable to find a matching certificate in user certificate store.</target>
+        <target state="translated">無法在使用者憑證存放區中找到相符的憑證。</target>
         <note />
       </trans-unit>
       <trans-unit id="CertificateRSANotFound">
         <source>Unable to acquire RSA private key for the provided certificate.</source>
-        <target state="new">Unable to acquire RSA private key for the provided certificate.</target>
+        <target state="translated">無法取得所提供憑證的 RSA 私密金鑰。</target>
         <note />
       </trans-unit>
       <trans-unit id="CliStandardError">
@@ -104,17 +104,17 @@
       </trans-unit>
       <trans-unit id="InvalidSha1ThumbrpintValue">
         <source>Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</source>
-        <target state="new">Invalid value for {0}. The value must be the SHA-1 thumbprint of a certificate in a Windows Certificate Store.</target>
+        <target state="translated">{0} 的無效值。值必須是 Windows 憑證存放區中憑證的 SHA-1 指紋。</target>
         <note>{NumberedPlaceholder="{0}"} is a a SHA-1 thumbprint and shouldn't be translated.</note>
       </trans-unit>
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
-        <target state="new">Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</target>
+        <target state="translated">已提供多個私密金鑰。使用者存放區使用 /k，機器存放區則使用 /km。</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">
         <source>Private key container missing while using /csp. Use /k or /km to provide a key container.</source>
-        <target state="new">Private key container missing while using /csp. Use /k or /km to provide a key container.</target>
+        <target state="translated">使用 /csp 時遺漏私密金鑰容器。使用 /k 或 /km 來提供金鑰容器。</target>
         <note />
       </trans-unit>
       <trans-unit id="OpeningContainer">
@@ -179,7 +179,7 @@
       </trans-unit>
       <trans-unit id="SigningSucceeded">
         <source>Signing {filePath} succeeded.</source>
-        <target state="new">Signing {filePath} succeeded.</target>
+        <target state="translated">簽署 {filePath} 成功。</target>
         <note>{Placeholder="{filePath}"} is a file path.</note>
       </trans-unit>
       <trans-unit id="SigningSucceededWithTimeElapsed">
@@ -194,22 +194,22 @@
       </trans-unit>
       <trans-unit id="UnsupportedPublicKeyAlgorithm">
         <source>The certificate has an unsupported public key algorithm.</source>
-        <target state="new">The certificate has an unsupported public key algorithm.</target>
+        <target state="translated">憑證具有不支援的公開金鑰演算法。</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolOpcContentTypeInvalid">
         <source>Specified {0} is invalid.</source>
-        <target state="new">Specified {0} is invalid.</target>
+        <target state="translated">指定的 {0} 無效。</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
-        <target state="new">Unknown signing algorithm.</target>
+        <target state="translated">未知的簽署演算法。</target>
         <note />
       </trans-unit>
       <trans-unit id="VSIXSignToolUnsupportedAlgorithm">
         <source>The algorithm selected is not supported.</source>
-        <target state="new">The algorithm selected is not supported.</target>
+        <target state="translated">不支持選取的演算法。</target>
         <note />
       </trans-unit>
       <trans-unit id="ValueCannotBeEmptyString">
@@ -219,7 +219,7 @@
       </trans-unit>
       <trans-unit id="VsixSignatureProviderSigning">
         <source>Signing VsixSignTool job with {count} files.</source>
-        <target state="new">Signing VsixSignTool job with {count} files.</target>
+        <target state="translated">正在簽署具有 {count} 個檔案的 OpenVsixSignTool 工作。</target>
         <note>{Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
     </body>

--- a/src/Sign.SignatureProviders.KeyVault/KeyVaultService.cs
+++ b/src/Sign.SignatureProviders.KeyVault/KeyVaultService.cs
@@ -11,8 +11,9 @@ using Azure.Security.KeyVault.Certificates;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using RSAKeyVaultProvider;
+using Sign.Core;
 
-namespace Sign.Core
+namespace Sign.SignatureProviders.KeyVault
 {
     internal sealed class KeyVaultService : ISignatureAlgorithmProvider, ICertificateProvider
     {
@@ -29,12 +30,7 @@ namespace Sign.Core
             ArgumentNullException.ThrowIfNull(serviceProvider, nameof(serviceProvider));
             ArgumentNullException.ThrowIfNull(tokenCredential, nameof(tokenCredential));
             ArgumentNullException.ThrowIfNull(keyVaultUrl, nameof(keyVaultUrl));
-            ArgumentNullException.ThrowIfNull(certificateName, nameof(certificateName));
-
-            if (string.IsNullOrEmpty(certificateName))
-            {
-                throw new ArgumentException(Resources.ValueCannotBeEmptyString, nameof(certificateName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(certificateName, nameof(certificateName));
 
             _tokenCredential = tokenCredential;
             _logger = serviceProvider.GetRequiredService<ILogger<KeyVaultService>>();

--- a/src/Sign.SignatureProviders.KeyVault/KeyVaultServiceProvider.cs
+++ b/src/Sign.SignatureProviders.KeyVault/KeyVaultServiceProvider.cs
@@ -3,8 +3,9 @@
 // See the LICENSE.txt file in the project root for more information.
 
 using Azure.Core;
+using Sign.Core;
 
-namespace Sign.Core
+namespace Sign.SignatureProviders.KeyVault
 {
     internal sealed class KeyVaultServiceProvider
     {
@@ -21,12 +22,7 @@ namespace Sign.Core
         {
             ArgumentNullException.ThrowIfNull(tokenCredential, nameof(tokenCredential));
             ArgumentNullException.ThrowIfNull(keyVaultUrl, nameof(keyVaultUrl));
-            ArgumentNullException.ThrowIfNull(certificateName, nameof(certificateName));
-
-            if (string.IsNullOrEmpty(certificateName))
-            {
-                throw new ArgumentException(Resources.ValueCannotBeEmptyString, nameof(certificateName));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(certificateName, nameof(certificateName));
 
             _tokenCredential = tokenCredential;
             _keyVaultUrl = keyVaultUrl;

--- a/src/Sign.SignatureProviders.KeyVault/Sign.SignatureProviders.KeyVault.csproj
+++ b/src/Sign.SignatureProviders.KeyVault/Sign.SignatureProviders.KeyVault.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsShipping>true</IsShipping>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="Azure.Security.KeyVault.Certificates" PrivateAssets="analyzers;build;compile;contentfiles" />
+    <PackageReference Include="RSAKeyVaultProvider" PrivateAssets="analyzers;build;compile;contentfiles" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Sign.Core\Sign.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>sign,PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Sign.SignatureProviders.KeyVault.Test,PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>DynamicProxyGenAssembly2,PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+</Project>

--- a/test/Sign.Cli.Test/CertificateStoreCommandTests.cs
+++ b/test/Sign.Cli.Test/CertificateStoreCommandTests.cs
@@ -33,15 +33,21 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
-        public void Sha1ThumbprintOption_Always_IsRequired()
+        public void CertificateThumbprintOption_Always_IsRequired()
         {
-            Assert.True(_command.Sha1ThumbprintOption.IsRequired);
+            Assert.True(_command.CertificateThumbprintOption.IsRequired);
         }
 
         [Fact]
-        public void Sha1ThumbprintOption_Always_HasArityOfExactlyOne()
+        public void CertificateThumbprintOption_Always_HasArityOfExactlyOne()
         {
-            Assert.Equal(ArgumentArity.ExactlyOne, _command.Sha1ThumbprintOption.Arity);
+            Assert.Equal(ArgumentArity.ExactlyOne, _command.CertificateThumbprintOption.Arity);
+        }
+
+        [Fact]
+        public void CertificateThumbprintAlgorithmOption_Always_HasArityOfExactlyOne()
+        {
+            Assert.Equal(ArgumentArity.ExactlyOne, _command.CertificateThumbprintAlgorithmOption.Arity);
         }
 
         [Fact]
@@ -81,13 +87,15 @@ namespace Sign.Cli.Test
 
             [Theory]
             [InlineData("certificate-store a")]
-            [InlineData("certificate-store a -s")]
-            [InlineData("certificate-store a -s sha1 -cf")]
-            [InlineData("certificate-store a -s sha1 -cf filePath -p")]
-            [InlineData("certificate-store a -s sha1 -cf filePath -csp ")]
-            [InlineData("certificate-store a -s sha1 -cf filePath -csp sampleCSP -k")]
-            [InlineData("certificate-store a -s sha1 -csp")]
-            [InlineData("certificate-store a -s sha1 -csp sampleCSP -k")]
+            [InlineData("certificate-store a -cfp")]
+            [InlineData("certificate-store a -cfp -cfpa -cf")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -cf")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-333 -cf")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa -cf filePath -p")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -cf filePath -csp")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -cf filePath -csp sampleCSP -k")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -csp")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -csp sampleCSP -k")]
             public void Command_WhenRequiredArgumentOrOptionsAreMissing_HasError(string command)
             {
                 ParseResult result = _parser.Parse(command);
@@ -96,14 +104,14 @@ namespace Sign.Cli.Test
             }
 
             [Theory]
-            [InlineData("certificate-store a -s sha1")]
-            [InlineData("certificate-store a -s sha1 -cf filePath")]
-            [InlineData("certificate-store a -s sha1 -cf filePath -p password")]
-            [InlineData("certificate-store a -s sha1 -csp sampleCSP -k keyContainer ")]
-            [InlineData("certificate-store a -s sha1 -csp sampleCSP -k machineKeyContainer -km")]
-            [InlineData("certificate-store a -s sha1 -cf filePath -csp sampleCSP -k keyContainer ")]
-            [InlineData("certificate-store a -s sha1 -cf filePath -p password -csp sampleCSP -k keyContainer")]
-            [InlineData("certificate-store a -s sha1 -cf filePath -csp sampleCSP -k keyContainer -km")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-384 -cf filePath")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-512 -cf filePath -p password")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -csp sampleCSP -k keyContainer ")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -csp sampleCSP -k machineKeyContainer -km")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -cf filePath -csp sampleCSP -k keyContainer ")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -cf filePath -p password -csp sampleCSP -k keyContainer")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -cf filePath -csp sampleCSP -k keyContainer -km")]
             public void Command_WhenRequiredArgumentsArePresent_HasNoError(string command)
             {
                 ParseResult result = _parser.Parse(command);

--- a/test/Sign.Cli.Test/CertificateStoreCommandTests.cs
+++ b/test/Sign.Cli.Test/CertificateStoreCommandTests.cs
@@ -33,21 +33,21 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
-        public void CertificateThumbprintOption_Always_IsRequired()
+        public void CertificateFingerprintOption_Always_IsRequired()
         {
-            Assert.True(_command.CertificateThumbprintOption.IsRequired);
+            Assert.True(_command.CertificateFingerprintOption.IsRequired);
         }
 
         [Fact]
-        public void CertificateThumbprintOption_Always_HasArityOfExactlyOne()
+        public void CertificateFingerprintOption_Always_HasArityOfExactlyOne()
         {
-            Assert.Equal(ArgumentArity.ExactlyOne, _command.CertificateThumbprintOption.Arity);
+            Assert.Equal(ArgumentArity.ExactlyOne, _command.CertificateFingerprintOption.Arity);
         }
 
         [Fact]
-        public void CertificateThumbprintAlgorithmOption_Always_HasArityOfExactlyOne()
+        public void CertificateFingerprintAlgorithmOption_Always_HasArityOfExactlyOne()
         {
-            Assert.Equal(ArgumentArity.ExactlyOne, _command.CertificateThumbprintAlgorithmOption.Arity);
+            Assert.Equal(ArgumentArity.ExactlyOne, _command.CertificateFingerprintAlgorithmOption.Arity);
         }
 
         [Fact]

--- a/test/Sign.Cli.Test/CertificateStoreCommandTests.cs
+++ b/test/Sign.Cli.Test/CertificateStoreCommandTests.cs
@@ -92,10 +92,10 @@ namespace Sign.Cli.Test
             [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -cf")]
             [InlineData("certificate-store a -cfp fingerprint -cfpa sha-333 -cf")]
             [InlineData("certificate-store a -cfp fingerprint -cfpa -cf filePath -p")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -cf filePath -csp")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -cf filePath -csp sampleCSP -k")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -csp")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -csp sampleCSP -k")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -cf filePath -csp")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -cf filePath -csp sampleCSP -k")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -csp")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -csp sampleCSP -k")]
             public void Command_WhenRequiredArgumentOrOptionsAreMissing_HasError(string command)
             {
                 ParseResult result = _parser.Parse(command);
@@ -104,14 +104,14 @@ namespace Sign.Cli.Test
             }
 
             [Theory]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-384 -cf filePath")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-512 -cf filePath -p password")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -csp sampleCSP -k keyContainer ")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -csp sampleCSP -k machineKeyContainer -km")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -cf filePath -csp sampleCSP -k keyContainer ")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -cf filePath -p password -csp sampleCSP -k keyContainer")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-256 -cf filePath -csp sampleCSP -k keyContainer -km")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha384 -cf filePath")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha512 -cf filePath -p password")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -csp sampleCSP -k keyContainer ")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -csp sampleCSP -k machineKeyContainer -km")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -cf filePath -csp sampleCSP -k keyContainer ")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -cf filePath -p password -csp sampleCSP -k keyContainer")]
+            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -cf filePath -csp sampleCSP -k keyContainer -km")]
             public void Command_WhenRequiredArgumentsArePresent_HasNoError(string command)
             {
                 ParseResult result = _parser.Parse(command);

--- a/test/Sign.Core.Test/SignerTests.cs
+++ b/test/Sign.Core.Test/SignerTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualBasic;
 using Moq;
 using NuGet.Packaging;
+using Sign.TestInfrastructure;
 
 namespace Sign.Core.Test
 {

--- a/test/Sign.Core.Test/TestInfrastructure/CertificateStoreServiceStub.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/CertificateStoreServiceStub.cs
@@ -33,7 +33,7 @@ namespace Sign.Core.Test
             return Task.FromResult(rsa);
         }
 
-        public void Initialize(string sha1Thumbprint, string? cryptoServiceProvider, string? privateKeyContainer, string? privateMachineKeyContainer)
+        public void Initialize(string certificateFingerprint, string? cryptoServiceProvider, string? privateKeyContainer, string? privateMachineKeyContainer)
         {
             _rsa = RSA.Create(keySizeInBits: 4096);
 

--- a/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceProviderTests.cs
+++ b/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceProviderTests.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using Azure.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Sign.Core;
+using Sign.TestInfrastructure;
+
+namespace Sign.SignatureProviders.KeyVault.Test
+{
+    public class KeyVaultServiceProviderTests
+    {
+        private readonly static Uri KeyVaultUrl = new("https://keyvault.test");
+        private const string CertificateName = "a";
+        private readonly TokenCredential tokenCredential = Mock.Of<TokenCredential>();
+        private readonly IServiceProvider serviceProvider;
+
+        public KeyVaultServiceProviderTests()
+        {
+            ServiceCollection services = new();
+            services.AddSingleton<ILogger<KeyVaultService>>(new TestLogger<KeyVaultService>());
+            serviceProvider = services.BuildServiceProvider();
+        }
+
+        [Fact]
+        public void Constructor_WhenTokenCredentialIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new KeyVaultServiceProvider(tokenCredential: null!, KeyVaultUrl, CertificateName));
+
+            Assert.Equal("tokenCredential", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenTokenKeyVaultUrlIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new KeyVaultServiceProvider(tokenCredential, keyVaultUrl: null!, CertificateName));
+
+            Assert.Equal("keyVaultUrl", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenTokenCertificateNameIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new KeyVaultServiceProvider(tokenCredential, KeyVaultUrl, certificateName: null!));
+
+            Assert.Equal("certificateName", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenTokenCertificateNameIsEmpty_Throws()
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(
+                () => new KeyVaultServiceProvider(tokenCredential, KeyVaultUrl, certificateName: string.Empty));
+
+            Assert.Equal("certificateName", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetSignatureAlgorithmProvider_WhenServiceProviderIsNull_Throws()
+        {
+            KeyVaultServiceProvider provider = new(tokenCredential, KeyVaultUrl, CertificateName);
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => provider.GetSignatureAlgorithmProvider(serviceProvider: null!));
+
+            Assert.Equal("serviceProvider", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetSignatureAlgorithmProvider_ReturnsSameInstance()
+        {
+            KeyVaultServiceProvider provider = new(tokenCredential, KeyVaultUrl, CertificateName);
+
+            List<ISignatureAlgorithmProvider> signatureAlgorithmProviders = [];
+            Parallel.For(0, 2, (_, _) =>
+            {
+                signatureAlgorithmProviders.Add(provider.GetSignatureAlgorithmProvider(serviceProvider));
+            });
+
+            Assert.Equal(2, signatureAlgorithmProviders.Count);
+            Assert.Same(signatureAlgorithmProviders[0], signatureAlgorithmProviders[1]);
+        }
+
+        [Fact]
+        public void GetCertificateProvider_WhenServiceProviderIsNull_Throws()
+        {
+            KeyVaultServiceProvider provider = new(tokenCredential, KeyVaultUrl, CertificateName);
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => provider.GetSignatureAlgorithmProvider(serviceProvider: null!));
+
+            Assert.Equal("serviceProvider", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetCertificateProvider_ReturnsSameInstance()
+        {
+            KeyVaultServiceProvider provider = new(tokenCredential, KeyVaultUrl, CertificateName);
+
+            List<ICertificateProvider> certificateProviders = [];
+            Parallel.For(0, 2, (_, _) =>
+            {
+                certificateProviders.Add(provider.GetCertificateProvider(serviceProvider));
+            });
+
+            Assert.Equal(2, certificateProviders.Count);
+            Assert.Same(certificateProviders[0], certificateProviders[1]);
+        }
+    }
+}

--- a/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceTests.cs
+++ b/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceTests.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using Azure.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Sign.TestInfrastructure;
+
+namespace Sign.SignatureProviders.KeyVault.Test
+{
+    public class KeyVaultServiceTests
+    {
+        private readonly static Uri KeyVaultUrl = new("https://keyvault.test");
+        private const string CertificateName = "a";
+        private readonly TokenCredential tokenCredential = Mock.Of<TokenCredential>();
+        private readonly IServiceProvider serviceProvider;
+
+        public KeyVaultServiceTests()
+        {
+            ServiceCollection services = new();
+            services.AddSingleton<ILogger<KeyVaultService>>(new TestLogger<KeyVaultService>());
+            serviceProvider = services.BuildServiceProvider();
+        }
+
+        [Fact]
+        public void Constructor_WhenServiceProviderIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new KeyVaultService(serviceProvider: null!, tokenCredential, KeyVaultUrl, CertificateName));
+
+            Assert.Equal("serviceProvider", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenTokenCredentialIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new KeyVaultService(serviceProvider, tokenCredential: null!, KeyVaultUrl, CertificateName));
+
+            Assert.Equal("tokenCredential", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenTokenKeyVaultUrlIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new KeyVaultService(serviceProvider, tokenCredential, keyVaultUrl: null!, CertificateName));
+
+            Assert.Equal("keyVaultUrl", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenTokenCertificateNameIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new KeyVaultService(serviceProvider, tokenCredential, KeyVaultUrl, certificateName: null!));
+
+            Assert.Equal("certificateName", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenTokenCertificateNameIsEmpty_Throws()
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(
+                () => new KeyVaultService(serviceProvider, tokenCredential, KeyVaultUrl, certificateName: string.Empty));
+
+            Assert.Equal("certificateName", exception.ParamName);
+        }
+    }
+}

--- a/test/Sign.SignatureProviders.KeyVault.Test/Sign.SignatureProviders.KeyVault.Test.csproj
+++ b/test/Sign.SignatureProviders.KeyVault.Test/Sign.SignatureProviders.KeyVault.Test.csproj
@@ -5,7 +5,6 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <IsUnitTestProject>true</IsUnitTestProject>
-    <NoWarn>$(NoWarn);NU1605</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,21 +12,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" />
-    <!-- Microsoft.AspNetCore.Server.Kestrel is old and requires an older version of Microsoft.Extensions.Primitives to function. -->
-    <PackageReference Include="Microsoft.Extensions.Primitives" VersionOverride="2.2.0" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Sign.Core\Sign.Core.csproj" />
+    <ProjectReference Include="..\..\src\Sign.SignatureProviders.KeyVault\Sign.SignatureProviders.KeyVault.csproj" />
     <ProjectReference Include="..\Sign.TestInfrastructure\Sign.TestInfrastructure.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="TestAssets\**\*.*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 </Project>

--- a/test/Sign.SignatureProviders.KeyVault.Test/Usings.cs
+++ b/test/Sign.SignatureProviders.KeyVault.Test/Usings.cs
@@ -1,0 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+global using Xunit;

--- a/test/Sign.TestInfrastructure/Sign.TestInfrastructure.csproj
+++ b/test/Sign.TestInfrastructure/Sign.TestInfrastructure.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(RepositoryRootDirectory)\SdkTools.props" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <IsUnitTestProject>true</IsUnitTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sign.SignatureProviders.KeyVault\Sign.SignatureProviders.KeyVault.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/Sign.TestInfrastructure/TestLogEntry.cs
+++ b/test/Sign.TestInfrastructure/TestLogEntry.cs
@@ -4,12 +4,12 @@
 
 using Microsoft.Extensions.Logging;
 
-namespace Sign.Core.Test
+namespace Sign.TestInfrastructure
 {
-    internal sealed class TestLogEntry
+    public sealed class TestLogEntry
     {
-        internal LogLevel LogLevel { get; }
-        internal string Message { get; }
+        public LogLevel LogLevel { get; }
+        public string Message { get; }
 
         internal TestLogEntry(LogLevel logLevel, string message)
         {

--- a/test/Sign.TestInfrastructure/TestLogger.cs
+++ b/test/Sign.TestInfrastructure/TestLogger.cs
@@ -5,13 +5,13 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 
-namespace Sign.Core.Test
+namespace Sign.TestInfrastructure
 {
-    internal sealed class TestLogger<T> : ILogger<T>
+    public sealed class TestLogger<T> : ILogger<T>
     {
         private readonly ConcurrentQueue<TestLogEntry> _entries = new();
 
-        internal IEnumerable<TestLogEntry> Entries
+        public IEnumerable<TestLogEntry> Entries
         {
             get => _entries;
         }


### PR DESCRIPTION
- Renames `--sha1` argument to a more generic `-cfp`/`--certificate-fingerprint` argument to allow the use of various RSA algorithms when searching for a matching certificate.
- Adds a new CLI argument `-cfpa`/`--certificate-fingerprint-algorithm` which allows specifying the certificate fingerprint algorithm used to find a matching certificate within the provided CSP
- Adds new tests for `-cfpa`
- Removes support for insecure algorithms (SHA 1 to 128)