### PR TITLE
Added extension method that replaces FormatMessage in the two command classes.

### DIFF
--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -5,7 +5,6 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
-using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using Azure.Core;
@@ -82,7 +81,7 @@ namespace Sign.Cli
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
                 }
-                
+
                 // this check exists as a courtesy to users who may have been signing .clickonce files via the old workaround.
                 // at some point we should remove this check, probably once we hit v1.0
                 if (fileArgument.EndsWith(".clickonce", StringComparison.OrdinalIgnoreCase))
@@ -111,14 +110,12 @@ namespace Sign.Cli
                         string.IsNullOrEmpty(clientId) ||
                         string.IsNullOrEmpty(secret))
                     {
-                        context.Console.Error.WriteLine(
-                            FormatMessage(
-                                AzureKeyVaultResources.InvalidClientSecretCredential,
-                                TenantIdOption,
-                                ClientIdOption,
-                                ClientSecretOption));
+                        context.Console.Error.WriteFormattedLine(
+                            AzureKeyVaultResources.InvalidClientSecretCredential,
+                            TenantIdOption,
+                            ClientIdOption,
+                            ClientSecretOption);
                         context.ExitCode = ExitCode.NoInputsFound;
-
                         return;
                     }
 
@@ -128,10 +125,9 @@ namespace Sign.Cli
                 // Make sure this is rooted
                 if (!Path.IsPathRooted(baseDirectory.FullName))
                 {
-                    context.Console.Error.WriteLine(
-                        FormatMessage(
-                            Resources.InvalidBaseDirectoryValue,
-                            _codeCommand.BaseDirectoryOption));
+                    context.Console.Error.WriteFormattedLine(
+                        Resources.InvalidBaseDirectoryValue,
+                        _codeCommand.BaseDirectoryOption);
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
                 }
@@ -160,7 +156,6 @@ namespace Sign.Cli
                     {
                         context.Console.Error.WriteLine(Resources.InvalidFileValue);
                         context.ExitCode = ExitCode.InvalidOptions;
-
                         return;
                     }
 
@@ -215,10 +210,9 @@ namespace Sign.Cli
 
                 if (inputFiles.Any(file => !file.Exists))
                 {
-                    context.Console.Error.WriteLine(
-                        FormatMessage(
-                            Resources.SomeFilesDoNotExist,
-                            _codeCommand.BaseDirectoryOption));
+                    context.Console.Error.WriteFormattedLine(
+                        Resources.SomeFilesDoNotExist,
+                        _codeCommand.BaseDirectoryOption);
 
                     foreach (FileInfo file in inputFiles.Where(file => !file.Exists))
                     {
@@ -255,15 +249,6 @@ namespace Sign.Cli
             }
 
             return Path.Combine(baseDirectory.FullName, file);
-        }
-
-        private static string FormatMessage(string format, params IdentifierSymbol[] symbols)
-        {
-            string[] formattedSymbols = symbols
-                .Select(symbol => $"--{symbol.Name}")
-                .ToArray();
-
-            return string.Format(CultureInfo.CurrentCulture, format, formattedSymbols);
         }
     }
 }

--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -5,7 +5,6 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
-using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
@@ -87,10 +86,10 @@ namespace Sign.Cli
                 // SHA-1 Thumbprint is required in case the provided certificate container contains multiple certificates.
                 if (string.IsNullOrEmpty(sha1Thumbprint))
                 {
-                    context.Console.Error.WriteLine(
-                        FormatMessage(Resources.InvalidSha1ThumbprintValue, Sha1ThumbprintOption));
+                    context.Console.Error.WriteFormattedLine(
+                        Resources.InvalidSha1ThumbprintValue,
+                        Sha1ThumbprintOption);
                     context.ExitCode = ExitCode.NoInputsFound;
-
                     return;
                 }
 
@@ -114,10 +113,9 @@ namespace Sign.Cli
                 // Make sure this is rooted
                 if (!Path.IsPathRooted(baseDirectory.FullName))
                 {
-                    context.Console.Error.WriteLine(
-                        FormatMessage(
-                            Resources.InvalidBaseDirectoryValue,
-                            _codeCommand.BaseDirectoryOption));
+                    context.Console.Error.WriteFormattedLine(
+                        Resources.InvalidBaseDirectoryValue,
+                        _codeCommand.BaseDirectoryOption);
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
                 }
@@ -152,7 +150,6 @@ namespace Sign.Cli
                     {
                         context.Console.Error.WriteLine(Resources.InvalidFileValue);
                         context.ExitCode = ExitCode.InvalidOptions;
-
                         return;
                     }
 
@@ -207,10 +204,9 @@ namespace Sign.Cli
 
                 if (inputFiles.Any(file => !file.Exists))
                 {
-                    context.Console.Error.WriteLine(
-                        FormatMessage(
-                            Resources.SomeFilesDoNotExist,
-                            _codeCommand.BaseDirectoryOption));
+                    context.Console.Error.WriteFormattedLine(
+                        Resources.SomeFilesDoNotExist,
+                        _codeCommand.BaseDirectoryOption);
 
                     foreach (FileInfo file in inputFiles.Where(file => !file.Exists))
                     {
@@ -247,15 +243,6 @@ namespace Sign.Cli
             }
 
             return Path.Combine(baseDirectory.FullName, file);
-        }
-
-        private static string FormatMessage(string format, params IdentifierSymbol[] symbols)
-        {
-            string[] formattedSymbols = symbols
-                .Select(symbol => $"--{symbol.Name}")
-                .ToArray();
-
-            return string.Format(CultureInfo.CurrentCulture, format, formattedSymbols);
         }
     }
 }

--- a/src/Sign.Cli/StandardStreamWriterExtensions.cs
+++ b/src/Sign.Cli/StandardStreamWriterExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System.CommandLine;
+using System.CommandLine.IO;
+using System.Globalization;
+
+namespace Sign.Cli
+{
+    internal static class StandardStreamWriterExtensions
+    {
+        internal static void WriteFormattedLine(this IStandardStreamWriter writer, string format, params IdentifierSymbol[] symbols)
+        {
+            string[] formattedSymbols = symbols
+                .Select(symbol => $"--{symbol.Name}")
+                .ToArray();
+
+            writer.WriteLine(string.Format(CultureInfo.CurrentCulture, format, formattedSymbols));
+        }
+    }
+}

--- a/src/Sign.Cli/StandardStreamWriterExtensions.cs
+++ b/src/Sign.Cli/StandardStreamWriterExtensions.cs
@@ -16,7 +16,7 @@ namespace Sign.Cli
                 .Select(symbol => $"--{symbol.Name}")
                 .ToArray();
 
-            writer.WriteLine(string.Format(CultureInfo.CurrentCulture, format, formattedSymbols));
+            writer.WriteLine(string.Format(CultureInfo.InvariantCulture, format, formattedSymbols));
         }
     }
 }


### PR DESCRIPTION
This avoids the code duplication of the FormatMessage method. This is a first step in removing some of the duplication of the `AzureKeyVaultCommand` and `CertificateStoreCommand` that is also needed by a new `TrustedSigningCommand`.