### PR TITLE
Move shared resources to Resources class.

### DIFF
--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -25,7 +25,7 @@ namespace Sign.Cli
         internal Option<string> CertificateOption { get; } = new(new[] { "-kvc", "--azure-key-vault-certificate" }, AzureKeyVaultResources.CertificateOptionDescription);
         internal Option<string?> ClientIdOption { get; } = new(new[] { "-kvi", "--azure-key-vault-client-id" }, AzureKeyVaultResources.ClientIdOptionDescription);
         internal Option<string?> ClientSecretOption { get; } = new(new[] { "-kvs", "--azure-key-vault-client-secret" }, AzureKeyVaultResources.ClientSecretOptionDescription);
-        internal Argument<string?> FileArgument { get; } = new("file(s)", AzureKeyVaultResources.FilesArgumentDescription);
+        internal Argument<string?> FileArgument { get; } = new("file(s)", Resources.FilesArgumentDescription);
         internal Option<bool> ManagedIdentityOption { get; } = new(new[] { "-kvm", "--azure-key-vault-managed-identity" }, getDefaultValue: () => false, AzureKeyVaultResources.ManagedIdentityOptionDescription);
         internal Option<string?> TenantIdOption { get; } = new(new[] { "-kvt", "--azure-key-vault-tenant-id" }, AzureKeyVaultResources.TenantIdOptionDescription);
         internal Option<Uri> UrlOption { get; } = new(new[] { "-kvu", "--azure-key-vault-url" }, AzureKeyVaultResources.UrlOptionDescription);
@@ -77,7 +77,7 @@ namespace Sign.Cli
 
                 if (string.IsNullOrEmpty(fileArgument))
                 {
-                    context.Console.Error.WriteLine(AzureKeyVaultResources.MissingFileValue);
+                    context.Console.Error.WriteLine(Resources.MissingFileValue);
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
                 }
@@ -129,7 +129,7 @@ namespace Sign.Cli
                 {
                     context.Console.Error.WriteLine(
                         FormatMessage(
-                            AzureKeyVaultResources.InvalidBaseDirectoryValue,
+                            Resources.InvalidBaseDirectoryValue,
                             _codeCommand.BaseDirectoryOption));
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
@@ -157,7 +157,7 @@ namespace Sign.Cli
                 {
                     if (Path.IsPathRooted(fileArgument))
                     {
-                        context.Console.Error.WriteLine(AzureKeyVaultResources.InvalidFileValue);
+                        context.Console.Error.WriteLine(Resources.InvalidFileValue);
                         context.ExitCode = ExitCode.InvalidOptions;
 
                         return;
@@ -207,7 +207,7 @@ namespace Sign.Cli
 
                 if (inputFiles.Count == 0)
                 {
-                    context.Console.Error.WriteLine(AzureKeyVaultResources.NoFilesToSign);
+                    context.Console.Error.WriteLine(Resources.NoFilesToSign);
                     context.ExitCode = ExitCode.NoInputsFound;
                     return;
                 }
@@ -216,7 +216,7 @@ namespace Sign.Cli
                 {
                     context.Console.Error.WriteLine(
                         FormatMessage(
-                            AzureKeyVaultResources.SomeFilesDoNotExist,
+                            Resources.SomeFilesDoNotExist,
                             _codeCommand.BaseDirectoryOption));
 
                     foreach (FileInfo file in inputFiles.Where(file => !file.Exists))

--- a/src/Sign.Cli/AzureKeyVaultResources.Designer.cs
+++ b/src/Sign.Cli/AzureKeyVaultResources.Designer.cs
@@ -106,24 +106,6 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File(s) to sign..
-        /// </summary>
-        internal static string FilesArgumentDescription {
-            get {
-                return ResourceManager.GetString("FilesArgumentDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid value for {0}. The value must be a fully rooted directory path..
-        /// </summary>
-        internal static string InvalidBaseDirectoryValue {
-            get {
-                return ResourceManager.GetString("InvalidBaseDirectoryValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to If not using a managed identity, all of these options are required: {0}, {1}, and {2}..
         /// </summary>
         internal static string InvalidClientSecretCredential {
@@ -133,47 +115,11 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used)..
-        /// </summary>
-        internal static string InvalidFileValue {
-            get {
-                return ResourceManager.GetString("InvalidFileValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Managed identity to authenticate to Azure Key Vault..
         /// </summary>
         internal static string ManagedIdentityOptionDescription {
             get {
                 return ResourceManager.GetString("ManagedIdentityOptionDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to A file or glob is required..
-        /// </summary>
-        internal static string MissingFileValue {
-            get {
-                return ResourceManager.GetString("MissingFileValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to No inputs found to sign..
-        /// </summary>
-        internal static string NoFilesToSign {
-            get {
-                return ResourceManager.GetString("NoFilesToSign", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Some files do not exist.  Try using a different {0} value or a fully qualified file path..
-        /// </summary>
-        internal static string SomeFilesDoNotExist {
-            get {
-                return ResourceManager.GetString("SomeFilesDoNotExist", resourceCulture);
             }
         }
         

--- a/src/Sign.Cli/AzureKeyVaultResources.resx
+++ b/src/Sign.Cli/AzureKeyVaultResources.resx
@@ -132,32 +132,12 @@
   <data name="CommandDescription" xml:space="preserve">
     <value>Use Azure Key Vault.</value>
   </data>
-  <data name="FilesArgumentDescription" xml:space="preserve">
-    <value>File(s) to sign.</value>
-  </data>
-  <data name="InvalidBaseDirectoryValue" xml:space="preserve">
-    <value>Invalid value for {0}. The value must be a fully rooted directory path.</value>
-    <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
-  </data>
   <data name="InvalidClientSecretCredential" xml:space="preserve">
     <value>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</value>
     <comment>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</comment>
   </data>
-  <data name="InvalidFileValue" xml:space="preserve">
-    <value>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</value>
-  </data>
   <data name="ManagedIdentityOptionDescription" xml:space="preserve">
     <value>Managed identity to authenticate to Azure Key Vault.</value>
-  </data>
-  <data name="MissingFileValue" xml:space="preserve">
-    <value>A file or glob is required.</value>
-  </data>
-  <data name="NoFilesToSign" xml:space="preserve">
-    <value>No inputs found to sign.</value>
-  </data>
-  <data name="SomeFilesDoNotExist" xml:space="preserve">
-    <value>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</value>
-    <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
   </data>
   <data name="TenantIdOptionDescription" xml:space="preserve">
     <value>Tenant ID to authenticate to Azure Key Vault.</value>

--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -27,7 +27,7 @@ namespace Sign.Cli
         internal Option<string?> PrivateKeyContainerOption { get; } = new(new[] { "-k", "--key-container" }, CertificateStoreResources.KeyContainerOptionDescription);
         internal Option<bool> UseMachineKeyContainerOption { get; } = new(new[] { "-km", "--use-machine-key-container" }, getDefaultValue: () => false, description: CertificateStoreResources.UseMachineKeyContainerOptionDescription);
 
-        internal Argument<string?> FileArgument { get; } = new("file(s)", AzureKeyVaultResources.FilesArgumentDescription);
+        internal Argument<string?> FileArgument { get; } = new("file(s)", Resources.FilesArgumentDescription);
 
         internal CertificateStoreCommand(CodeCommand codeCommand, IServiceProviderFactory serviceProviderFactory)
             : base("certificate-store", Resources.CertificateStoreCommandDescription)
@@ -79,7 +79,7 @@ namespace Sign.Cli
 
                 if (string.IsNullOrEmpty(fileArgument))
                 {
-                    context.Console.Error.WriteLine(AzureKeyVaultResources.MissingFileValue);
+                    context.Console.Error.WriteLine(Resources.MissingFileValue);
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
                 }
@@ -116,7 +116,7 @@ namespace Sign.Cli
                 {
                     context.Console.Error.WriteLine(
                         FormatMessage(
-                            AzureKeyVaultResources.InvalidBaseDirectoryValue,
+                            Resources.InvalidBaseDirectoryValue,
                             _codeCommand.BaseDirectoryOption));
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
@@ -150,7 +150,7 @@ namespace Sign.Cli
                 {
                     if (Path.IsPathRooted(fileArgument))
                     {
-                        context.Console.Error.WriteLine(AzureKeyVaultResources.InvalidFileValue);
+                        context.Console.Error.WriteLine(Resources.InvalidFileValue);
                         context.ExitCode = ExitCode.InvalidOptions;
 
                         return;
@@ -200,7 +200,7 @@ namespace Sign.Cli
 
                 if (inputFiles.Count == 0)
                 {
-                    context.Console.Error.WriteLine(AzureKeyVaultResources.NoFilesToSign);
+                    context.Console.Error.WriteLine(Resources.NoFilesToSign);
                     context.ExitCode = ExitCode.NoInputsFound;
                     return;
                 }
@@ -209,7 +209,7 @@ namespace Sign.Cli
                 {
                     context.Console.Error.WriteLine(
                         FormatMessage(
-                            AzureKeyVaultResources.SomeFilesDoNotExist,
+                            Resources.SomeFilesDoNotExist,
                             _codeCommand.BaseDirectoryOption));
 
                     foreach (FileInfo file in inputFiles.Where(file => !file.Exists))

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -115,7 +115,7 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Digest algorithm to hash files with. Allowed values are &apos;Sha256&apos;, &apos;Sha384&apos;, and &apos;Sha512&apos;..
+        ///   Looks up a localized string similar to Digest algorithm to hash files with. Allowed values are &apos;sha256&apos;, &apos;sha384&apos;, and &apos;sha512&apos;..
         /// </summary>
         internal static string FileDigestOptionDescription {
             get {
@@ -133,6 +133,15 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to File(s) to sign..
+        /// </summary>
+        internal static string FilesArgumentDescription {
+            get {
+                return ResourceManager.GetString("FilesArgumentDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid value for {0}. The value must be a fully rooted directory path..
         /// </summary>
         internal static string InvalidBaseDirectoryValue {
@@ -142,11 +151,20 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid value for {0}. The value must be &apos;Sha256&apos;, &apos;Sha384&apos;, or &apos;Sha512&apos;..
+        ///   Looks up a localized string similar to Invalid value for {0}. The value must be &apos;sha256&apos;, &apos;sha384&apos;, or &apos;sha512&apos;..
         /// </summary>
         internal static string InvalidDigestValue {
             get {
                 return ResourceManager.GetString("InvalidDigestValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used)..
+        /// </summary>
+        internal static string InvalidFileValue {
+            get {
+                return ResourceManager.GetString("InvalidFileValue", resourceCulture);
             }
         }
         
@@ -187,6 +205,24 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A file or glob is required..
+        /// </summary>
+        internal static string MissingFileValue {
+            get {
+                return ResourceManager.GetString("MissingFileValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No inputs found to sign..
+        /// </summary>
+        internal static string NoFilesToSign {
+            get {
+                return ResourceManager.GetString("NoFilesToSign", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Output file or directory. If omitted, input files will be overwritten..
         /// </summary>
         internal static string OutputOptionDescription {
@@ -214,7 +250,16 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Digest algorithm for the RFC 3161 timestamp server. Allowed values are Sha256, Sha384, and Sha512..
+        ///   Looks up a localized string similar to Some files do not exist.  Try using a different {0} value or a fully qualified file path..
+        /// </summary>
+        internal static string SomeFilesDoNotExist {
+            get {
+                return ResourceManager.GetString("SomeFilesDoNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512..
         /// </summary>
         internal static string TimestampDigestOptionDescription {
             get {

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -142,6 +142,9 @@
   <data name="FileListOptionDescription" xml:space="preserve">
     <value>Path to file containing paths of files to sign or to exclude from signing.</value>
   </data>
+  <data name="FilesArgumentDescription" xml:space="preserve">
+    <value>File(s) to sign.</value>
+  </data>
   <data name="InvalidBaseDirectoryValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be a fully rooted directory path.</value>
     <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
@@ -149,6 +152,9 @@
   <data name="InvalidDigestValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</value>
     <comment>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</comment>
+  </data>
+  <data name="InvalidFileValue" xml:space="preserve">
+    <value>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</value>
   </data>
   <data name="InvalidMaxConcurrencyValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be a number value greater than or equal to 1.</value>
@@ -165,6 +171,12 @@
   <data name="MaxConcurrencyOptionDescription" xml:space="preserve">
     <value>Maximum concurrency.</value>
   </data>
+  <data name="MissingFileValue" xml:space="preserve">
+    <value>A file or glob is required.</value>
+  </data>
+  <data name="NoFilesToSign" xml:space="preserve">
+    <value>No inputs found to sign.</value>
+  </data>
   <data name="OutputOptionDescription" xml:space="preserve">
     <value>Output file or directory. If omitted, input files will be overwritten.</value>
   </data>
@@ -174,6 +186,10 @@
   </data>
   <data name="SignCommandDescription" xml:space="preserve">
     <value>Sign CLI</value>
+  </data>
+  <data name="SomeFilesDoNotExist" xml:space="preserve">
+    <value>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</value>
+    <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
   </data>
   <data name="TimestampDigestOptionDescription" xml:space="preserve">
     <value>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</value>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Použijte Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">Soubor nebo soubory, které se mají podepsat.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být plně kořenová cesta k adresáři.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Pokud se nepoužívá spravovaná identita, vyžadují se všechny tyto možnosti: {0}, {1}a {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Cestu k souboru nelze při použití glob zakořenit. Použijte relativní cestu k pracovnímu adresáři (nebo základnímu adresáři, pokud se používá).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Spravovaná identita pro ověření pro Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">Vyžaduje se soubor nebo glob.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">Nenašly se žádné vstupy, které by bylo možné podepsat.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Některé soubory neexistují.  Zkuste použít jinou hodnotu {0} nebo plně kvalifikovanou cestu k souboru.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Verwenden Sie Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">Zu signierende Datei(en).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Ungültiger Wert für {0}. Der Wert muss ein vollständiger Stammverzeichnispfad sein.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Wenn Sie keine verwaltete Identität verwenden, sind alle diese Optionen erforderlich: {0}, {1} und {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Der Dateipfad kann keinem Stamm zugewiesen werden, wenn ein Glob verwendet wird. Verwenden Sie einen Pfad relativ zum Arbeitsverzeichnis (oder Basisverzeichnis, falls verwendet).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Verwaltete Identität für die Authentifizierung bei Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">Eine Datei oder ein Glob ist erforderlich.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">Es wurden keine Eingaben zum Signieren gefunden.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Einige Dateien sind nicht vorhanden.  Versuchen Sie, einen anderen {0}-Wert oder einen vollqualifizierten Dateipfad zu verwenden.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Use Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">Archivos para firmar.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valor no válido para {0}. El valor debe ser una ruta de acceso de directorio totalmente raíz.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Si no usa una identidad administrada, se requieren todas estas opciones: {0}, {1} y {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">La ruta de acceso del archivo no se puede rootear cuando se usa un glob. Use una ruta de acceso relativa al directorio de trabajo (o directorio base, si se usa).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Identidad administrada para autenticarse en Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">Se requiere un archivo o glob.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">No se encontraron entradas para firmar.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Algunos archivos no existen.  Pruebe a usar otro valor {0} o una ruta de acceso de archivo completa.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Utilisez Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">Fichier(s) à signer.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valeur non valide pour {0}. La valeur doit être un chemin d’accès de répertoire entièrement rooté.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Si vous n’utilisez pas d’identité managée, toutes ces options sont requises : {0}, {1} et {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Le chemin d’accès du fichier ne peut pas être rooté lors de l’utilisation d’un glob. Utilisez un chemin d’accès relatif au répertoire de travail (ou au répertoire de base, s’il est utilisé).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Identité managée à authentifier auprès d’Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">Un fichier ou un glob est requis.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">Aucune entrée à signer.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Certains fichiers n’existent pas. Essayez d’utiliser une autre valeur {0} ou un chemin de fichier complet.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Usare Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">File da firmare.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valore non valido per {0}. Il valore deve essere un percorso di directory completo.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Se non si usa un'identità gestita, saranno necessarie tutte le opzioni seguenti: {0}, {1} e {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Il percorso del file non può avere accesso root quando si utilizza un GLOB. Usare un percorso relativo alla directory di lavoro (o alla directory di base, se usata).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Identità gestita da autenticare in Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">È necessario specificare un file o un GLOB.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">Non sono stati trovati input da firmare.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Alcuni file non esistono.  Provare a usare un valore di {0} diverso o un percorso di file completo.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Azure Key Vault を使用してください。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">署名するファイル。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} の値が無効です。値は、完全にルート化されたディレクトリ パスである必要があります。</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">マネージド ID を使用しない場合は、{0}、{1}、{2} のオプションがすべて必要です。</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">glob を使用している場合、ファイル パスをルート化できません。作業ディレクトリへの相対パス (または使用されている場合はベース ディレクトリ) を使用してください。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Azure Key Vault に対して認証するマネージド ID。</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">ファイルまたは glob が必要です。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">署名する入力が見つかりません。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">一部のファイルが存在しません。別の {0} 値または完全修飾ファイル パスを使用してみてください。</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Azure Key Vault를 사용합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">서명할 파일입니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 완전한 루트 디렉터리 경로여야 합니다.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">관리 ID를 사용하고 있지 않은 경우 {0}, {1} 및 {2} 옵션이 모두 필요합니다.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">glob을 사용할 때 파일 경로를 루팅할 수 없습니다. 작업 디렉터리(또는 사용되는 경우 기본 디렉터리)에 상대적인 경로를 사용하세요.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Azure Key Vault에 인증하기 위한 관리 ID입니다.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">파일 또는 글로브가 필요합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">서명할 입력이 없습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">일부 파일이 존재하지 않습니다.  다른 {0} 값 또는 정규화된 파일 경로를 사용해 보세요.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Użyj usługi Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">Pliki do podpisania.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Nieprawidłowa wartość dla {0}. Wartość musi być w pełni główną ścieżką katalogu.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Jeśli tożsamość zarządzana nie jest używana, wymagane są wszystkie następujące opcje: {0}, {1} i {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Ścieżka pliku nie może być z dostępem do konta root, gdy jest używany element globalny. Użyj ścieżki odnoszącej się do katalogu roboczego (lub katalogu podstawowego, jeśli jest używany).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Tożsamość zarządzana do uwierzytelnienia w usłudze Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">Wymagany jest plik lub element globalny.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">Nie znaleziono danych wejściowych do podpisania.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Niektóre pliki nie istnieją.  Spróbuj użyć innej wartości {0} lub w pełni kwalifikowanej ścieżki pliku.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Use o Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">Arquivo(s) para autenticar.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Valor inválido para {0}. O valor deve ser um caminho de diretório totalmente desbloqueado por rooting.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Se não estiver usando uma identidade gerenciada, todas essas opções serão necessárias: {0}, {1} e {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">O caminho do arquivo não pode estar desbloqueado por rooting ao usar um glob. Use um caminho relativo ao diretório de trabalho (ou diretório base, se usado).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Identidade gerenciada a ser autenticada no Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">É necessário um arquivo ou um glob.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">Nenhuma entrada encontrada para autenticar.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Alguns arquivos não existem.  Tente usar um valor diferente de {0} ou um caminho de arquivo totalmente qualificado.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Использование Azure Key Vault.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">Файлы для подписи.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">Недопустимое значение для {0}. Значение должно быть полным корневым путем к каталогу.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Если управляемое удостоверение не используется, требуются все следующие параметры: {0}, {1} и {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Путь к файлу не может быть корневым при использовании стандартной маски. Используйте путь относительно рабочего каталога (или базового каталога, если он используется).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Управляемое удостоверение для проверки подлинности в Azure Key Vault.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">Требуется файл или стандартная маска.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">Не найдены входящие данные для подписи.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Некоторые файлы не существуют.  Попробуйте использовать другое значение {0} или полный путь к файлу.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
@@ -27,45 +27,15 @@
         <target state="translated">Azure Key Vault’u kullanın.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">İmzalanacak dosyalar.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} için geçersiz değer. Değer, tam olarak kök erişim izni verilmiş bir dizin yolu olmalıdır.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">Bir yönetilen kimlik kullanılmıyorsa bu seçeneklerin tümü gereklidir: {0}, {1} ve {2}.</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">Glob kullanılırken dosya yoluna kök erişim izni verilemez. Çalışma diziniyle (veya kullanılıyorsa, temel dizinle) ilişkili bir yol kullanın.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">Azure Key Vault için kimlik doğrulamak amacıyla kullanılan yönetilen kimlik.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">Dosya veya glob gerekiyor.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">İmzalanacak giriş dosyası yok.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">Bazı dosyalar mevcut değil. Farklı bir {0} değeri veya tam bir dosya yolu kullanmayı deneyin.</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
@@ -27,45 +27,15 @@
         <target state="translated">使用 Azure Key Vault。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">要签名的文件。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} 的值无效。该值必须是完整的根目录路径。</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">如果不使用托管标识，则需要以下所有选项: {0}、{1} 和 {2}。</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">使用 glob 时，文件路径不能为根路径。请使用相对于工作目录(或基目录，如果使用)的路径。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">要向 Azure Key Vault 进行身份验证的托管标识。</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">文件或 glob 是必需的。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">找不到要签名的输入。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">某些文件不存在。请尝试使用其他 {0} 值或完全限定的文件路径。</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
@@ -27,45 +27,15 @@
         <target state="translated">使用 Azure Key Vault。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FilesArgumentDescription">
-        <source>File(s) to sign.</source>
-        <target state="translated">要簽署的檔案。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidBaseDirectoryValue">
-        <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
-        <target state="translated">{0} 的值無效。值必須是完整的根目錄路徑。</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
-      </trans-unit>
       <trans-unit id="InvalidClientSecretCredential">
         <source>If not using a managed identity, all of these options are required: {0}, {1}, and {2}.</source>
         <target state="translated">如果未使用受控識別，則需要下列所有選項: {0}、{1} 和 {2}。</target>
         <note>{NumberedPlaceholder="{0}", "{1}", "{2}"} are option names and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidFileValue">
-        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
-        <target state="translated">使用 Glob 時，檔案路徑不可為根目錄。請使用工作目錄或基底目錄 (若使用該目錄) 的相對路徑。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key Vault.</source>
         <target state="translated">要向 Azure Key Vault 進行驗證的受控識別。</target>
         <note />
-      </trans-unit>
-      <trans-unit id="MissingFileValue">
-        <source>A file or glob is required.</source>
-        <target state="translated">需要檔案或 Glob。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoFilesToSign">
-        <source>No inputs found to sign.</source>
-        <target state="translated">找不到要簽署的輸入。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SomeFilesDoNotExist">
-        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
-        <target state="translated">某些檔案不存在。請嘗試使用不同的 {0} 值或完整檔案路徑。</target>
-        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TenantIdOptionDescription">
         <source>Tenant ID to authenticate to Azure Key Vault.</source>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -42,6 +42,11 @@
         <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">Soubor nebo soubory, které se mají podepsat.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být plně kořenová cesta k adresáři.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být sha256, sha384 nebo sha512.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">Cestu k souboru nelze při použití glob zakořenit. Použijte relativní cestu k pracovnímu adresáři (nebo základnímu adresáři, pokud se používá).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Maximální souběžnost.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">Vyžaduje se soubor nebo glob.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">Nenašly se žádné vstupy, které by bylo možné podepsat.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Výstupní soubor nebo adresář. Pokud je tento parametr vynechán, vstupní soubory budou přepsány.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">Podepsat rozhraní příkazového řádku</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Některé soubory neexistují.  Zkuste použít jinou hodnotu {0} nebo plně kvalifikovanou cestu k souboru.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -42,6 +42,11 @@
         <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">Zu signierende Datei(en).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Ungültiger Wert für {0}. Der Wert muss ein vollständiger Stammverzeichnispfad sein.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Ungültiger Wert für {0}. Der Wert muss "sha256", "sha384" oder "sha512" sein.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">Der Dateipfad kann keinem Stamm zugewiesen werden, wenn ein Glob verwendet wird. Verwenden Sie einen Pfad relativ zum Arbeitsverzeichnis (oder Basisverzeichnis, falls verwendet).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Maximale Parallelität.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">Eine Datei oder ein Glob ist erforderlich.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">Es wurden keine Eingaben zum Signieren gefunden.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Ausgabedatei oder -verzeichnis. Wenn dies weggelassen wird, werden Eingabedateien überschrieben.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">CLI signieren</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Einige Dateien sind nicht vorhanden.  Versuchen Sie, einen anderen {0}-Wert oder einen vollqualifizierten Dateipfad zu verwenden.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -42,6 +42,11 @@
         <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">Archivos para firmar.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Valor no válido para {0}. El valor debe ser una ruta de acceso de directorio totalmente raíz.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Valor no válido para {0}. El valor debe ser 'sha256', 'sha384' o 'sha512'.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">La ruta de acceso del archivo no se puede rootear cuando se usa un glob. Use una ruta de acceso relativa al directorio de trabajo (o directorio base, si se usa).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Simultaneidad máxima.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">Se requiere un archivo o glob.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">No se encontraron entradas para firmar.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Archivo o directorio de salida. Si se omite, se sobrescribirán los archivos de entrada.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">Firma de la CLI</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Algunos archivos no existen.  Pruebe a usar otro valor {0} o una ruta de acceso de archivo completa.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -42,6 +42,11 @@
         <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">Fichier(s) à signer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Valeur non valide pour {0}. La valeur doit être un chemin d’accès de répertoire entièrement rooté.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Valeur invalide pour {0}. La valeur doit être 'sha256', 'sha384' ou 'sha512'.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">Le chemin d’accès du fichier ne peut pas être rooté lors de l’utilisation d’un glob. Utilisez un chemin d’accès relatif au répertoire de travail (ou au répertoire de base, s’il est utilisé).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Concurrence maximale.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">Un fichier ou un glob est requis.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">Aucune entrée à signer.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Fichier ou répertoire de sortie. En cas d’omission, les fichiers d’entrée sont remplacés.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">Signer l’interface CLI</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Certains fichiers n’existent pas. Essayez d’utiliser une autre valeur {0} ou un chemin de fichier complet.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -42,6 +42,11 @@
         <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">File da firmare.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Valore non valido per {0}. Il valore deve essere un percorso di directory completo.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Valore non valido per {0}. Il valore deve essere 'sha256', 'sha384' o 'sha512'.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">Il percorso del file non può avere accesso root quando si utilizza un GLOB. Usare un percorso relativo alla directory di lavoro (o alla directory di base, se usata).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Concorrenza massima.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">È necessario specificare un file o un GLOB.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">Non sono stati trovati input da firmare.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">File o directory di output. Se omessi, i file di input verranno sovrascritti.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">Consente di firmare l'interfaccia della riga di comando</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Alcuni file non esistono.  Provare a usare un valore di {0} diverso o un percorso di file completo.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -42,6 +42,11 @@
         <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">署名するファイル。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0} の値が無効です。値は、完全にルート化されたディレクトリ パスである必要があります。</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">{0} の値が無効です。値は 'sha256'、'sha384'、または 'sha512' である必要があります。</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">glob を使用している場合、ファイル パスをルート化できません。作業ディレクトリへの相対パス (または使用されている場合はベース ディレクトリ) を使用してください。</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">最大コンカレンシー。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">ファイルまたは glob が必要です。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">署名する入力が見つかりません。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">出力ファイルまたはディレクトリ。省略すると、入力ファイルが上書きされます。</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">CLI に署名</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">一部のファイルが存在しません。別の {0} 値または完全修飾ファイル パスを使用してみてください。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -42,6 +42,11 @@
         <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">서명할 파일입니다.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 완전한 루트 디렉터리 경로여야 합니다.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 'sha256', 'sha384' 또는 'sha512'.여야 합니다.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">glob을 사용할 때 파일 경로를 루팅할 수 없습니다. 작업 디렉터리(또는 사용되는 경우 기본 디렉터리)에 상대적인 경로를 사용하세요.</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">최대 동시성입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">파일 또는 글로브가 필요합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">서명할 입력이 없습니다.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">출력 파일 또는 디렉터리입니다. 생략하면 입력 파일을 덮어씁니다.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">CLI 서명</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Niektóre pliki nie istnieją.  Spróbuj użyć innej wartości {0} lub w pełni kwalifikowanej ścieżki pliku.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -42,6 +42,11 @@
         <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">Pliki do podpisania.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Nieprawidłowa wartość dla {0}. Wartość musi być w pełni główną ścieżką katalogu.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Nieprawidłowa wartość dla {0}. Wartością musi być „sha256”, „sha384”, lub „sha512”.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">Ścieżka pliku nie może być z dostępem do konta root, gdy jest używany element globalny. Użyj ścieżki odnoszącej się do katalogu roboczego (lub katalogu podstawowego, jeśli jest używany).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Maksymalna współbieżność.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">Wymagany jest plik lub element globalny.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">Nie znaleziono danych wejściowych do podpisania.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Plik wyjściowy lub katalog. W przypadku pominięcia pliki wejściowe zostaną zastąpione.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">Interfejs wiersza polecenia podpisywania</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="new">Some files do not exist.  Try using a different {0} value or a fully qualified file path.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -42,6 +42,11 @@
         <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">Arquivo(s) para autenticar.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Valor inválido para {0}. O valor deve ser um caminho de diretório totalmente desbloqueado por rooting.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Valor inválido para {0}. O valor deve ser 'sha256', 'sha384' ou 'sha512'.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">O caminho do arquivo não pode estar desbloqueado por rooting ao usar um glob. Use um caminho relativo ao diretório de trabalho (ou diretório base, se usado).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Simultaneidade máxima.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">É necessário um arquivo ou um glob.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">Nenhuma entrada encontrada para autenticar.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Arquivo ou diretório de saída. Se omitido, os arquivos de entrada serão substituídos.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">Autenticar CLI</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Alguns arquivos não existem.  Tente usar um valor diferente de {0} ou um caminho de arquivo totalmente qualificado.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -42,6 +42,11 @@
         <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">Файлы для подписи.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">Недопустимое значение для {0}. Значение должно быть полным корневым путем к каталогу.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">Недопустимое значение для {0}. Необходимо использовать "sha256", "sha384" или "sha512".</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">Путь к файлу не может быть корневым при использовании стандартной маски. Используйте путь относительно рабочего каталога (или базового каталога, если он используется).</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Максимальный параллелизм.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">Требуется файл или стандартная маска.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">Не найдены входящие данные для подписи.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Выходной файл или каталог. Если этот параметр опущен, входные файлы будут перезаписаны.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">Подписывание CLI</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Некоторые файлы не существуют.  Попробуйте использовать другое значение {0} или полный путь к файлу.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -42,6 +42,11 @@
         <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">İmzalanacak dosyalar.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0} için geçersiz değer. Değer, tam olarak kök erişim izni verilmiş bir dizin yolu olmalıdır.</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">{0} için geçersiz değer. Değer 'sha256', 'sha384' veya 'sha512' olmalıdır.</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">Glob kullanılırken dosya yoluna kök erişim izni verilemez. Çalışma diziniyle (veya kullanılıyorsa, temel dizinle) ilişkili bir yol kullanın.</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">Maksimum eşzamanlılık.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">Dosya veya glob gerekiyor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">İmzalanacak giriş dosyası yok.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">Çıkış dosyası veya dizini. Atlanırsa, giriş dosyalarının üzerine yazılır.</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">CLI’yı imzala</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">Bazı dosyalar mevcut değil. Farklı bir {0} değeri veya tam bir dosya yolu kullanmayı deneyin.</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -42,6 +42,11 @@
         <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">要签名的文件。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0} 的值无效。该值必须是完整的根目录路径。</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">{0} 的值无效。值必须为 "sha256"、"sha384" 或 "sha512"。</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">使用 glob 时，文件路径不能为根路径。请使用相对于工作目录(或基目录，如果使用)的路径。</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">最大并发。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">文件或 glob 是必需的。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">找不到要签名的输入。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">输出文件或目录。如果省略，则输入文件将被覆盖。</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">对 CLI 进行签名</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">某些文件不存在。请尝试使用其他 {0} 值或完全限定的文件路径。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -42,6 +42,11 @@
         <target state="new">Path to file containing paths of files to sign or to exclude from signing.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FilesArgumentDescription">
+        <source>File(s) to sign.</source>
+        <target state="translated">要簽署的檔案。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="InvalidBaseDirectoryValue">
         <source>Invalid value for {0}. The value must be a fully rooted directory path.</source>
         <target state="translated">{0} 的值無效。值必須是完整的根目錄路徑。</target>
@@ -51,6 +56,11 @@
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
         <target state="translated">{0} 的值無效。值必須是 'sha256'、'sha384' 或 'sha512'。</target>
         <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithm names and should not be localized.  {NumberedPlaceholder="{0}"} is an option name (e.g.:  --file-digest) and should not be localized.</note>
+      </trans-unit>
+      <trans-unit id="InvalidFileValue">
+        <source>The file path cannot be rooted when using a glob. Use a path relative to the working directory (or base directory, if used).</source>
+        <target state="translated">使用 Glob 時，檔案路徑不可為根目錄。請使用工作目錄或基底目錄 (若使用該目錄) 的相對路徑。</target>
+        <note />
       </trans-unit>
       <trans-unit id="InvalidMaxConcurrencyValue">
         <source>Invalid value for {0}. The value must be a number value greater than or equal to 1.</source>
@@ -72,6 +82,16 @@
         <target state="translated">並行最大值。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MissingFileValue">
+        <source>A file or glob is required.</source>
+        <target state="translated">需要檔案或 Glob。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoFilesToSign">
+        <source>No inputs found to sign.</source>
+        <target state="translated">找不到要簽署的輸入。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OutputOptionDescription">
         <source>Output file or directory. If omitted, input files will be overwritten.</source>
         <target state="translated">輸出檔案或目錄。如果省略，則會覆寫輸入檔案。</target>
@@ -86,6 +106,11 @@
         <source>Sign CLI</source>
         <target state="translated">簽署 CLI</target>
         <note />
+      </trans-unit>
+      <trans-unit id="SomeFilesDoNotExist">
+        <source>Some files do not exist.  Try using a different {0} value or a fully qualified file path.</source>
+        <target state="translated">某些檔案不存在。請嘗試使用不同的 {0} 值或完整檔案路徑。</target>
+        <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
       <trans-unit id="TimestampDigestOptionDescription">
         <source>Digest algorithm for the RFC 3161 timestamp server. Allowed values are sha256, sha384, and sha512.</source>


### PR DESCRIPTION
This moves the resources that are in `AzureKeyVaultResources` and also used by `CertificateStoreCommand` to the shared `Resources`.