### PR TITLE
Moved the CertificateStore services to their own library.

### DIFF
--- a/sign.sln
+++ b/sign.sln
@@ -32,6 +32,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sign.SignatureProviders.Key
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sign.TestInfrastructure", "test\Sign.TestInfrastructure\Sign.TestInfrastructure.csproj", "{47F03ADD-A646-44C8-92FA-9594CD4506E6}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sign.SignatureProviders.CertificateStore", "src\Sign.SignatureProviders.CertificateStore\Sign.SignatureProviders.CertificateStore.csproj", "{68104303-9832-4841-89AB-B98712C4E618}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -66,6 +68,10 @@ Global
 		{47F03ADD-A646-44C8-92FA-9594CD4506E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{47F03ADD-A646-44C8-92FA-9594CD4506E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{47F03ADD-A646-44C8-92FA-9594CD4506E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{68104303-9832-4841-89AB-B98712C4E618}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{68104303-9832-4841-89AB-B98712C4E618}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{68104303-9832-4841-89AB-B98712C4E618}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{68104303-9832-4841-89AB-B98712C4E618}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -78,6 +84,7 @@ Global
 		{5B69CC06-5CBA-4A0B-B262-76ABF01542AC} = {92C73EE1-4EF3-4721-B6A9-9F458A673CA3}
 		{2EF3535D-E359-4211-98AB-FC992815355E} = {780818DD-6B52-47C8-AC54-71448DF822BD}
 		{47F03ADD-A646-44C8-92FA-9594CD4506E6} = {780818DD-6B52-47C8-AC54-71448DF822BD}
+		{68104303-9832-4841-89AB-B98712C4E618} = {92C73EE1-4EF3-4721-B6A9-9F458A673CA3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7AA1043F-37A2-404F-8EC3-34C747C1CEB7}

--- a/sign.sln
+++ b/sign.sln
@@ -34,6 +34,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sign.TestInfrastructure", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sign.SignatureProviders.CertificateStore", "src\Sign.SignatureProviders.CertificateStore\Sign.SignatureProviders.CertificateStore.csproj", "{68104303-9832-4841-89AB-B98712C4E618}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sign.SignatureProviders.CertificateStore.Test", "test\Sign.SignatureProviders.CertificateStore.Test\Sign.SignatureProviders.CertificateStore.Test.csproj", "{3AE48DC2-8422-4E3A-AFBC-12551D50DBCA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -72,6 +74,10 @@ Global
 		{68104303-9832-4841-89AB-B98712C4E618}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{68104303-9832-4841-89AB-B98712C4E618}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{68104303-9832-4841-89AB-B98712C4E618}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3AE48DC2-8422-4E3A-AFBC-12551D50DBCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3AE48DC2-8422-4E3A-AFBC-12551D50DBCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3AE48DC2-8422-4E3A-AFBC-12551D50DBCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3AE48DC2-8422-4E3A-AFBC-12551D50DBCA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -85,6 +91,7 @@ Global
 		{2EF3535D-E359-4211-98AB-FC992815355E} = {780818DD-6B52-47C8-AC54-71448DF822BD}
 		{47F03ADD-A646-44C8-92FA-9594CD4506E6} = {780818DD-6B52-47C8-AC54-71448DF822BD}
 		{68104303-9832-4841-89AB-B98712C4E618} = {92C73EE1-4EF3-4721-B6A9-9F458A673CA3}
+		{3AE48DC2-8422-4E3A-AFBC-12551D50DBCA} = {780818DD-6B52-47C8-AC54-71448DF822BD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7AA1043F-37A2-404F-8EC3-34C747C1CEB7}

--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -21,7 +21,7 @@ namespace Sign.Cli
         private readonly CodeCommand _codeCommand;
 
         internal Option<string> CertificateFingerprintOption { get; } = new(["-cfp", "--certificate-fingerprint"], CertificateStoreResources.CertificateFingerprintOptionDescription);
-        internal Option<HashAlgorithmName> CertificateFingerprintAlgorithmOption { get; } = new([ "-cfpa", "--certificate-fingerprint-algorithm" ], HashAlgorithmParser.ParseHashAlgorithmName, description: CertificateStoreResources.CertificateFingerprintAlgorithmOptionDescription);
+        internal Option<HashAlgorithmName> CertificateFingerprintAlgorithmOption { get; } = new(["-cfpa", "--certificate-fingerprint-algorithm"], HashAlgorithmParser.ParseHashAlgorithmName, description: CertificateStoreResources.CertificateFingerprintAlgorithmOptionDescription);
         internal Option<string?> CertificateFileOption { get; } = new(["-cf", "--certificate-file"], CertificateStoreResources.CertificateFileOptionDescription);
         internal Option<string?> CertificatePasswordOption { get; } = new(["-p", "--password"], CertificateStoreResources.CertificatePasswordOptionDescription);
         internal Option<string?> CryptoServiceProviderOption { get; } = new(["-csp", "--crypto-service-provider"], CertificateStoreResources.CspOptionDescription);

--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 using Microsoft.Extensions.Logging;
 using Sign.Core;
+using Sign.SignatureProviders.CertificateStore;
 
 namespace Sign.Cli
 {

--- a/src/Sign.Cli/Sign.Cli.csproj
+++ b/src/Sign.Cli/Sign.Cli.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Sign.Core\Sign.Core.csproj" />
+    <ProjectReference Include="..\Sign.SignatureProviders.CertificateStore\Sign.SignatureProviders.CertificateStore.csproj" />
     <ProjectReference Include="..\Sign.SignatureProviders.KeyVault\Sign.SignatureProviders.KeyVault.csproj" />
   </ItemGroup>
 

--- a/src/Sign.Core/Sign.Core.csproj
+++ b/src/Sign.Core/Sign.Core.csproj
@@ -32,6 +32,12 @@
       <_Parameter1>Sign.Core.Test,PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Sign.SignatureProviders.CertificateStore,PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Sign.SignatureProviders.CertificateStore.Test,PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Sign.SignatureProviders.KeyVault,PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
@@ -55,6 +61,10 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="CertificateServices\" />
   </ItemGroup>
 
 </Project>

--- a/src/Sign.Core/Sign.Core.csproj
+++ b/src/Sign.Core/Sign.Core.csproj
@@ -63,8 +63,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="CertificateServices\" />
-  </ItemGroup>
-
 </Project>

--- a/src/Sign.SignatureProviders.CertificateStore/CertificateStoreService.cs
+++ b/src/Sign.SignatureProviders.CertificateStore/CertificateStoreService.cs
@@ -7,9 +7,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using Sign.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Sign.Core;
 
 namespace Sign.SignatureProviders.CertificateStore
 {
@@ -38,6 +38,7 @@ namespace Sign.SignatureProviders.CertificateStore
             string? certificatePassword,
             bool isPrivateMachineKeyContainer)
         {
+            ArgumentNullException.ThrowIfNull(serviceProvider, nameof(serviceProvider));
             ArgumentException.ThrowIfNullOrEmpty(certificateFingerprint, nameof(certificateFingerprint));
 
             _certificateFingerprint = certificateFingerprint;

--- a/src/Sign.SignatureProviders.CertificateStore/CertificateStoreService.cs
+++ b/src/Sign.SignatureProviders.CertificateStore/CertificateStoreService.cs
@@ -7,10 +7,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using Sign.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace Sign.Core
+namespace Sign.SignatureProviders.CertificateStore
 {
     /// <summary>
     /// Creates an object used to access Certificate Stores and acquire certificates and RSA keys (if applicable).

--- a/src/Sign.SignatureProviders.CertificateStore/CertificateStoreServiceProvider.cs
+++ b/src/Sign.SignatureProviders.CertificateStore/CertificateStoreServiceProvider.cs
@@ -3,8 +3,9 @@
 // See the LICENSE.txt file in the project root for more information.
 
 using System.Security.Cryptography;
+using Sign.Core;
 
-namespace Sign.Core
+namespace Sign.SignatureProviders.CertificateStore
 {
     /// <summary>
     /// Provider that initializes a new <see cref="CertificateStoreService"/> if required.

--- a/src/Sign.SignatureProviders.CertificateStore/CertificateStoreServiceProvider.cs
+++ b/src/Sign.SignatureProviders.CertificateStore/CertificateStoreServiceProvider.cs
@@ -43,12 +43,7 @@ namespace Sign.SignatureProviders.CertificateStore
             string? certificateFilePassword,
             bool isMachineKeyContainer)
         {
-            ArgumentNullException.ThrowIfNull(certificateFingerprint, nameof(certificateFingerprint));
-
-            if (string.IsNullOrEmpty(certificateFingerprint))
-            {
-                throw new ArgumentException(Resources.ValueCannotBeEmptyString, nameof(certificateFingerprint));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(certificateFingerprint, nameof(certificateFingerprint));
 
             // Both or neither can be provided when accessing a certificate.
             if (!string.IsNullOrEmpty(cryptoServiceProvider) == string.IsNullOrEmpty(privateKeyContainer))

--- a/src/Sign.SignatureProviders.CertificateStore/Sign.SignatureProviders.CertificateStore.csproj
+++ b/src/Sign.SignatureProviders.CertificateStore/Sign.SignatureProviders.CertificateStore.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsShipping>true</IsShipping>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Sign.Core\Sign.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>sign,PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Sign.SignatureProviders.CertificateStore.Test,PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>DynamicProxyGenAssembly2,PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+</Project>

--- a/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceProviderTests.cs
+++ b/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceProviderTests.cs
@@ -1,0 +1,147 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System.Security.Cryptography;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Sign.Core;
+using Sign.TestInfrastructure;
+
+namespace Sign.SignatureProviders.CertificateStore.Test
+{
+    public class CertificateStoreServiceProviderTests
+    {
+        private const string CertificateFingerprint = "a";
+        private static readonly HashAlgorithmName CertificateFingerprintAlgorithm = HashAlgorithmName.SHA256;
+        private const string? CryptoServiceProvider = "b";
+        private const string? PrivateKeyContainer = "c";
+        private const string? CertificateFilePath = null;
+        private const string? CertificateFilePassword = null;
+        private const bool IsMachineKeyContainer = true;
+        private readonly IServiceProvider serviceProvider;
+
+        public CertificateStoreServiceProviderTests()
+        {
+            ServiceCollection services = new();
+            services.AddSingleton<ILogger<CertificateStoreService>>(new TestLogger<CertificateStoreService>());
+            serviceProvider = services.BuildServiceProvider();
+        }
+
+        [Fact]
+        public void Constructor_WhenCertificateFingerprintIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new CertificateStoreServiceProvider(certificateFingerprint: null!, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+
+            Assert.Equal("certificateFingerprint", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenCertificateFingerprintIsEmpty_Throws()
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(
+                () => new CertificateStoreServiceProvider(certificateFingerprint: string.Empty, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+
+            Assert.Equal("certificateFingerprint", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenCryptoServiceProviderIsNullAndPrivateKeyContainerIsNot_Throws()
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider: null, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+
+            Assert.Equal("cryptoServiceProvider", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenCryptoServiceProviderIsEmptyAndPrivateKeyContainerIsNot_Throws()
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider: string.Empty, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+
+            Assert.Equal("cryptoServiceProvider", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenPrivateKeyContainerIsNullAndCryptoServiceProviderIsNot_Throws()
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, privateKeyContainer: null, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+
+            Assert.Equal("privateKeyContainer", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenPrivateKeyContainerIsEmptyAndCryptoServiceProviderIsNot_Throws()
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, privateKeyContainer: string.Empty, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+
+            Assert.Equal("privateKeyContainer", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(null, "")]
+        [InlineData("", null)]
+        [InlineData("", "")]
+        public void Constructor_WhenPrivateKeyContainerAndCryptoServiceProviderAreBothNullOrEmpty_DoesNotThrow(string? cryptoServiceProvider, string? privateKeyContainer)
+        {
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider, privateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer);
+        }
+
+        [Fact]
+        public void GetSignatureAlgorithmProvider_WhenServiceProviderIsNull_Throws()
+        {
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer);
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => provider.GetSignatureAlgorithmProvider(serviceProvider: null!));
+
+            Assert.Equal("serviceProvider", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetSignatureAlgorithmProvider_ReturnsSameInstance()
+        {
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer);
+
+            List<ISignatureAlgorithmProvider> signatureAlgorithmProviders = [];
+            Parallel.For(0, 2, (_, _) =>
+            {
+                signatureAlgorithmProviders.Add(provider.GetSignatureAlgorithmProvider(serviceProvider));
+            });
+
+            Assert.Equal(2, signatureAlgorithmProviders.Count);
+            Assert.Same(signatureAlgorithmProviders[0], signatureAlgorithmProviders[1]);
+        }
+
+        [Fact]
+        public void GetCertificateProvider_WhenServiceProviderIsNull_Throws()
+        {
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer);
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => provider.GetCertificateProvider(serviceProvider: null!));
+
+            Assert.Equal("serviceProvider", exception.ParamName);
+        }
+
+        [Fact]
+        public void GetCertificateProvider_ReturnsSameInstance()
+        {
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer);
+
+            List<ICertificateProvider> certificateProviders = [];
+            Parallel.For(0, 2, (_, _) =>
+            {
+                certificateProviders.Add(provider.GetCertificateProvider(serviceProvider));
+            });
+
+            Assert.Equal(2, certificateProviders.Count);
+            Assert.Same(certificateProviders[0], certificateProviders[1]);
+        }
+    }
+}

--- a/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceTests.cs
+++ b/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceTests.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System.Security.Cryptography;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Sign.TestInfrastructure;
+
+namespace Sign.SignatureProviders.CertificateStore.Test
+{
+    public class CertificateStoreServiceTests
+    {
+        private const string CertificateFingerprint = "a";
+        private static readonly HashAlgorithmName CertificateFingerprintAlgorithm = HashAlgorithmName.SHA256;
+        private const string? CryptoServiceProvider = "b";
+        private const string? PrivateKeyContainer = "c";
+        private const string? CertificateFilePath = null;
+        private const string? CertificateFilePassword = null;
+        private const bool IsMachineKeyContainer = true;
+        private readonly IServiceProvider serviceProvider;
+
+        public CertificateStoreServiceTests()
+        {
+            ServiceCollection services = new();
+            services.AddSingleton<ILogger<CertificateStoreService>>(new TestLogger<CertificateStoreService>());
+            serviceProvider = services.BuildServiceProvider();
+        }
+
+        [Fact]
+        public void Constructor_WhenServiceProviderIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new CertificateStoreService(serviceProvider: null!, CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+
+            Assert.Equal("serviceProvider", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenCertificateFingerprintIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new CertificateStoreService(serviceProvider, certificateFingerprint: null!, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+
+            Assert.Equal("certificateFingerprint", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenCertificateFingerprintIsEmpty_Throws()
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(
+                () => new CertificateStoreService(serviceProvider, certificateFingerprint: string.Empty, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+
+            Assert.Equal("certificateFingerprint", exception.ParamName);
+        }
+    }
+}

--- a/test/Sign.SignatureProviders.CertificateStore.Test/Sign.SignatureProviders.CertificateStore.Test.csproj
+++ b/test/Sign.SignatureProviders.CertificateStore.Test/Sign.SignatureProviders.CertificateStore.Test.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(RepositoryRootDirectory)\SdkTools.props" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <IsUnitTestProject>true</IsUnitTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sign.SignatureProviders.CertificateStore\Sign.SignatureProviders.CertificateStore.csproj" />
+    <ProjectReference Include="..\Sign.TestInfrastructure\Sign.TestInfrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/Sign.SignatureProviders.CertificateStore.Test/Usings.cs
+++ b/test/Sign.SignatureProviders.CertificateStore.Test/Usings.cs
@@ -1,0 +1,5 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+global using Xunit;


### PR DESCRIPTION
This is a followup of the PR that moved the KeyVaultService and KeyVaultServiceProvider to their own library. This moves CertificateStoreService and CertificateStoreServiceProvider to their own library.

This PR also adds some unit tests for both classes.
