### PR TITLE
Moved the shared logic of the AzureKeyVaultCommand and CertificateStoreCommand to a new Handle method inside the CodeCommand

### DIFF
--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -22,13 +22,14 @@ namespace Sign.Cli
     {
         private readonly CodeCommand _codeCommand;
 
-        internal Option<string> CertificateOption { get; } = new(new[] { "-kvc", "--azure-key-vault-certificate" }, AzureKeyVaultResources.CertificateOptionDescription);
-        internal Option<string?> ClientIdOption { get; } = new(new[] { "-kvi", "--azure-key-vault-client-id" }, AzureKeyVaultResources.ClientIdOptionDescription);
-        internal Option<string?> ClientSecretOption { get; } = new(new[] { "-kvs", "--azure-key-vault-client-secret" }, AzureKeyVaultResources.ClientSecretOptionDescription);
+        internal Option<string> CertificateOption { get; } = new(["-kvc", "--azure-key-vault-certificate"], AzureKeyVaultResources.CertificateOptionDescription);
+        internal Option<string?> ClientIdOption { get; } = new(["-kvi", "--azure-key-vault-client-id"], AzureKeyVaultResources.ClientIdOptionDescription);
+        internal Option<string?> ClientSecretOption { get; } = new(["-kvs", "--azure-key-vault-client-secret"], AzureKeyVaultResources.ClientSecretOptionDescription);
+        internal Option<bool> ManagedIdentityOption { get; } = new(["-kvm", "--azure-key-vault-managed-identity"], getDefaultValue: () => false, AzureKeyVaultResources.ManagedIdentityOptionDescription);
+        internal Option<string?> TenantIdOption { get; } = new(["-kvt", "--azure-key-vault-tenant-id"], AzureKeyVaultResources.TenantIdOptionDescription);
+        internal Option<Uri> UrlOption { get; } = new(["-kvu", "--azure-key-vault-url"], AzureKeyVaultResources.UrlOptionDescription);
+
         internal Argument<string?> FileArgument { get; } = new("file(s)", Resources.FilesArgumentDescription);
-        internal Option<bool> ManagedIdentityOption { get; } = new(new[] { "-kvm", "--azure-key-vault-managed-identity" }, getDefaultValue: () => false, AzureKeyVaultResources.ManagedIdentityOptionDescription);
-        internal Option<string?> TenantIdOption { get; } = new(new[] { "-kvt", "--azure-key-vault-tenant-id" }, AzureKeyVaultResources.TenantIdOptionDescription);
-        internal Option<Uri> UrlOption { get; } = new(new[] { "-kvu", "--azure-key-vault-url" }, AzureKeyVaultResources.UrlOptionDescription);
 
         internal AzureKeyVaultCommand(CodeCommand codeCommand, IServiceProviderFactory serviceProviderFactory)
             : base("azure-key-vault", AzureKeyVaultResources.CommandDescription)
@@ -54,25 +55,6 @@ namespace Sign.Cli
 
             this.SetHandler(async (InvocationContext context) =>
             {
-                DirectoryInfo baseDirectory = context.ParseResult.GetValueForOption(_codeCommand.BaseDirectoryOption)!;
-                string? applicationName = context.ParseResult.GetValueForOption(_codeCommand.ApplicationNameOption);
-                string? publisherName = context.ParseResult.GetValueForOption(_codeCommand.PublisherNameOption);
-                string? description = context.ParseResult.GetValueForOption(_codeCommand.DescriptionOption);
-                // This option is required.  If its value fails to parse we won't have reached here,
-                // and after successful parsing its value will never be null.
-                // Non-null is already guaranteed; the null-forgiving operator (!) just simplifies code.
-                Uri descriptionUrl = context.ParseResult.GetValueForOption(_codeCommand.DescriptionUrlOption)!;
-                string? fileListFilePath = context.ParseResult.GetValueForOption(_codeCommand.FileListOption);
-                HashAlgorithmName fileHashAlgorithmName = context.ParseResult.GetValueForOption(_codeCommand.FileDigestOption);
-                HashAlgorithmName timestampHashAlgorithmName = context.ParseResult.GetValueForOption(_codeCommand.TimestampDigestOption);
-                // This option is optional but has a default value.  If its value fails to parse we won't have
-                // reached here, and after successful parsing its value will never be null.
-                // Non-null is already guaranteed; the null-forgiving operator (!) just simplifies code.
-                Uri timestampUrl = context.ParseResult.GetValueForOption(_codeCommand.TimestampUrlOption)!;
-                LogLevel verbosity = context.ParseResult.GetValueForOption(_codeCommand.VerbosityOption);
-                string? output = context.ParseResult.GetValueForOption(_codeCommand.OutputOption);
-                int maxConcurrency = context.ParseResult.GetValueForOption(_codeCommand.MaxConcurrencyOption);
-
                 string? fileArgument = context.ParseResult.GetValueForArgument(FileArgument);
 
                 if (string.IsNullOrEmpty(fileArgument))
@@ -91,11 +73,13 @@ namespace Sign.Cli
                     return;
                 }
 
-                Uri? url = context.ParseResult.GetValueForOption(UrlOption);
+                // Some of the options are required and that is why we can safely use
+                // the null-forgiving operator (!) to simplify the code.
+                Uri url = context.ParseResult.GetValueForOption(UrlOption)!;
                 string? tenantId = context.ParseResult.GetValueForOption(TenantIdOption);
                 string? clientId = context.ParseResult.GetValueForOption(ClientIdOption);
                 string? secret = context.ParseResult.GetValueForOption(ClientSecretOption);
-                string? certificateId = context.ParseResult.GetValueForOption(CertificateOption);
+                string certificateId = context.ParseResult.GetValueForOption(CertificateOption)!;
                 bool useManagedIdentity = context.ParseResult.GetValueForOption(ManagedIdentityOption);
 
                 TokenCredential? credential = null;
@@ -119,136 +103,12 @@ namespace Sign.Cli
                         return;
                     }
 
-                    credential = new ClientSecretCredential(tenantId!, clientId!, secret!);
+                    credential = new ClientSecretCredential(tenantId, clientId, secret);
                 }
 
-                // Make sure this is rooted
-                if (!Path.IsPathRooted(baseDirectory.FullName))
-                {
-                    context.Console.Error.WriteFormattedLine(
-                        Resources.InvalidBaseDirectoryValue,
-                        _codeCommand.BaseDirectoryOption);
-                    context.ExitCode = ExitCode.InvalidOptions;
-                    return;
-                }
-
-                IServiceProvider serviceProvider = serviceProviderFactory.Create(
-                    verbosity,
-                    addServices: (IServiceCollection services) =>
-                    {
-                        KeyVaultServiceProvider keyVaultServiceProvider = new(credential, url!, certificateId!);
-
-                        services.AddSingleton<ISignatureAlgorithmProvider>(
-                            (IServiceProvider serviceProvider) => keyVaultServiceProvider.GetSignatureAlgorithmProvider(serviceProvider));
-                        services.AddSingleton<ICertificateProvider>(
-                            (IServiceProvider serviceProvider) => keyVaultServiceProvider.GetCertificateProvider(serviceProvider));
-                    });
-
-                List<FileInfo> inputFiles;
-
-                // If we're going to glob, we can't be fully rooted currently (fix me later)
-
-                bool isGlob = fileArgument.Contains('*');
-
-                if (isGlob)
-                {
-                    if (Path.IsPathRooted(fileArgument))
-                    {
-                        context.Console.Error.WriteLine(Resources.InvalidFileValue);
-                        context.ExitCode = ExitCode.InvalidOptions;
-                        return;
-                    }
-
-                    IFileListReader fileListReader = serviceProvider.GetRequiredService<IFileListReader>();
-                    IFileMatcher fileMatcher = serviceProvider.GetRequiredService<IFileMatcher>();
-
-                    using (MemoryStream stream = new(Encoding.UTF8.GetBytes(fileArgument)))
-                    using (StreamReader reader = new(stream))
-                    {
-                        fileListReader.Read(reader, out Matcher? matcher, out Matcher? antiMatcher);
-
-                        DirectoryInfoBase directory = new DirectoryInfoWrapper(baseDirectory);
-
-                        IEnumerable<FileInfo> matches = fileMatcher.EnumerateMatches(directory, matcher);
-
-                        if (antiMatcher is not null)
-                        {
-                            IEnumerable<FileInfo> antiMatches = fileMatcher.EnumerateMatches(directory, antiMatcher);
-                            matches = matches.Except(antiMatches, FileInfoComparer.Instance);
-                        }
-
-                        inputFiles = matches.ToList();
-                    }
-                }
-                else
-                {
-                    inputFiles = new List<FileInfo>()
-                    {
-                        new FileInfo(ExpandFilePath(baseDirectory, fileArgument))
-                    };
-                }
-
-                FileInfo? fileList = null;
-                if (!string.IsNullOrEmpty(fileListFilePath))
-                {
-                    if (Path.IsPathRooted(fileListFilePath))
-                    {
-                        fileList = new FileInfo(fileListFilePath);
-                    }
-                    else
-                    {
-                        fileList = new FileInfo(ExpandFilePath(baseDirectory, fileListFilePath));
-                    }
-                }
-
-                if (inputFiles.Count == 0)
-                {
-                    context.Console.Error.WriteLine(Resources.NoFilesToSign);
-                    context.ExitCode = ExitCode.NoInputsFound;
-                    return;
-                }
-
-                if (inputFiles.Any(file => !file.Exists))
-                {
-                    context.Console.Error.WriteFormattedLine(
-                        Resources.SomeFilesDoNotExist,
-                        _codeCommand.BaseDirectoryOption);
-
-                    foreach (FileInfo file in inputFiles.Where(file => !file.Exists))
-                    {
-                        context.Console.Error.WriteLine($"    {file.FullName}");
-                    }
-
-                    context.ExitCode = ExitCode.NoInputsFound;
-                    return;
-                }
-
-                ISigner signer = serviceProvider.GetRequiredService<ISigner>();
-
-                context.ExitCode = await signer.SignAsync(
-                    inputFiles,
-                    output,
-                    fileList,
-                    baseDirectory,
-                    applicationName,
-                    publisherName,
-                    description,
-                    descriptionUrl,
-                    timestampUrl,
-                    maxConcurrency,
-                    fileHashAlgorithmName,
-                    timestampHashAlgorithmName);
+                KeyVaultServiceProvider keyVaultServiceProvider = new(credential, url, certificateId);
+                await _codeCommand.HandleAsync(context, serviceProviderFactory, keyVaultServiceProvider, fileArgument);
             });
-        }
-
-        private static string ExpandFilePath(DirectoryInfo baseDirectory, string file)
-        {
-            if (Path.IsPathRooted(file))
-            {
-                return file;
-            }
-
-            return Path.Combine(baseDirectory.FullName, file);
         }
     }
 }

--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -6,11 +6,6 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.Security.Cryptography;
-using System.Text;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.FileSystemGlobbing;
-using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
-using Microsoft.Extensions.Logging;
 using Sign.Core;
 using Sign.SignatureProviders.CertificateStore;
 
@@ -53,33 +48,6 @@ namespace Sign.Cli
 
             this.SetHandler(async (InvocationContext context) =>
             {
-                DirectoryInfo baseDirectory = context.ParseResult.GetValueForOption(_codeCommand.BaseDirectoryOption)!;
-                string? applicationName = context.ParseResult.GetValueForOption(_codeCommand.ApplicationNameOption);
-                string? publisherName = context.ParseResult.GetValueForOption(_codeCommand.PublisherNameOption);
-                string? description = context.ParseResult.GetValueForOption(_codeCommand.DescriptionOption);
-                // This option is required.  If its value fails to parse we won't have reached here,
-                // and after successful parsing its value will never be null.
-                // Non-null is already guaranteed; the null-forgiving operator (!) just simplifies code.
-                Uri descriptionUrl = context.ParseResult.GetValueForOption(_codeCommand.DescriptionUrlOption)!;
-                string? fileListFilePath = context.ParseResult.GetValueForOption(_codeCommand.FileListOption);
-                HashAlgorithmName fileHashAlgorithmName = context.ParseResult.GetValueForOption(_codeCommand.FileDigestOption);
-                HashAlgorithmName timestampHashAlgorithmName = context.ParseResult.GetValueForOption(_codeCommand.TimestampDigestOption);
-                // This option is optional but has a default value.  If its value fails to parse we won't have
-                // reached here, and after successful parsing its value will never be null.
-                // Non-null is already guaranteed; the null-forgiving operator (!) just simplifies code.
-                Uri timestampUrl = context.ParseResult.GetValueForOption(_codeCommand.TimestampUrlOption)!;
-                LogLevel verbosity = context.ParseResult.GetValueForOption(_codeCommand.VerbosityOption);
-                string? output = context.ParseResult.GetValueForOption(_codeCommand.OutputOption);
-                int maxConcurrency = context.ParseResult.GetValueForOption(_codeCommand.MaxConcurrencyOption);
-
-                string? certificateFingerprint = context.ParseResult.GetValueForOption(CertificateFingerprintOption);
-                HashAlgorithmName certificateFingerprintAlgorithm = context.ParseResult.GetValueForOption(CertificateFingerprintAlgorithmOption);
-                string? certificatePath = context.ParseResult.GetValueForOption(CertificateFileOption);
-                string? certificatePassword = context.ParseResult.GetValueForOption(CertificatePasswordOption);
-                string? cryptoServiceProvider = context.ParseResult.GetValueForOption(CryptoServiceProviderOption);
-                string? privateKeyContainer = context.ParseResult.GetValueForOption(PrivateKeyContainerOption);
-                bool useMachineKeyContainer = context.ParseResult.GetValueForOption(UseMachineKeyContainerOption);
-
                 string? fileArgument = context.ParseResult.GetValueForArgument(FileArgument);
 
                 if (string.IsNullOrEmpty(fileArgument))
@@ -88,6 +56,16 @@ namespace Sign.Cli
                     context.ExitCode = ExitCode.InvalidOptions;
                     return;
                 }
+
+                // Some of the options are required and that is why we can safely use
+                // the null-forgiving operator (!) to simplify the code.
+                string certificateFingerprint = context.ParseResult.GetValueForOption(CertificateFingerprintOption)!;
+                HashAlgorithmName certificateFingerprintAlgorithm = context.ParseResult.GetValueForOption(CertificateFingerprintAlgorithmOption);
+                string? certificatePath = context.ParseResult.GetValueForOption(CertificateFileOption);
+                string? certificatePassword = context.ParseResult.GetValueForOption(CertificatePasswordOption);
+                string? cryptoServiceProvider = context.ParseResult.GetValueForOption(CryptoServiceProviderOption);
+                string? privateKeyContainer = context.ParseResult.GetValueForOption(PrivateKeyContainerOption);
+                bool useMachineKeyContainer = context.ParseResult.GetValueForOption(UseMachineKeyContainerOption);
 
                 // Certificate Fingerprint is required in case the provided certificate container contains multiple certificates.
                 if (string.IsNullOrEmpty(certificateFingerprint))
@@ -117,140 +95,17 @@ namespace Sign.Cli
                     }
                 }
 
-                // Make sure this is rooted
-                if (!Path.IsPathRooted(baseDirectory.FullName))
-                {
-                    context.Console.Error.WriteFormattedLine(
-                        Resources.InvalidBaseDirectoryValue,
-                        _codeCommand.BaseDirectoryOption);
-                    context.ExitCode = ExitCode.InvalidOptions;
-                    return;
-                }
+                CertificateStoreServiceProvider certificateStoreServiceProvider = new(
+                    certificateFingerprint,
+                    certificateFingerprintAlgorithm,
+                    cryptoServiceProvider,
+                    privateKeyContainer,
+                    certificatePath,
+                    certificatePassword,
+                    useMachineKeyContainer);
 
-                IServiceProvider serviceProvider = serviceProviderFactory.Create(
-                    verbosity,
-                    addServices: (IServiceCollection services) =>
-                    {
-                        CertificateStoreServiceProvider certificateStoreServiceProvider = new(
-                            certificateFingerprint,
-                            certificateFingerprintAlgorithm,
-                            cryptoServiceProvider,
-                            privateKeyContainer,
-                            certificatePath,
-                            certificatePassword,
-                            useMachineKeyContainer);
-
-                        services.AddSingleton<ISignatureAlgorithmProvider>(
-                            (IServiceProvider serviceProvider) => certificateStoreServiceProvider.GetSignatureAlgorithmProvider(serviceProvider));
-                        services.AddSingleton<ICertificateProvider>(
-                            (IServiceProvider serviceProvider) => certificateStoreServiceProvider.GetCertificateProvider(serviceProvider));
-                    });
-
-                List<FileInfo> inputFiles;
-
-                // If we're going to glob, we can't be fully rooted currently (fix me later)
-
-                bool isGlob = fileArgument.Contains('*');
-
-                if (isGlob)
-                {
-                    if (Path.IsPathRooted(fileArgument))
-                    {
-                        context.Console.Error.WriteLine(Resources.InvalidFileValue);
-                        context.ExitCode = ExitCode.InvalidOptions;
-                        return;
-                    }
-
-                    IFileListReader fileListReader = serviceProvider.GetRequiredService<IFileListReader>();
-                    IFileMatcher fileMatcher = serviceProvider.GetRequiredService<IFileMatcher>();
-
-                    using (MemoryStream stream = new(Encoding.UTF8.GetBytes(fileArgument)))
-                    using (StreamReader reader = new(stream))
-                    {
-                        fileListReader.Read(reader, out Matcher? matcher, out Matcher? antiMatcher);
-
-                        DirectoryInfoBase directory = new DirectoryInfoWrapper(baseDirectory);
-
-                        IEnumerable<FileInfo> matches = fileMatcher.EnumerateMatches(directory, matcher);
-
-                        if (antiMatcher is not null)
-                        {
-                            IEnumerable<FileInfo> antiMatches = fileMatcher.EnumerateMatches(directory, antiMatcher);
-                            matches = matches.Except(antiMatches, FileInfoComparer.Instance);
-                        }
-
-                        inputFiles = matches.ToList();
-                    }
-                }
-                else
-                {
-                    inputFiles = new List<FileInfo>()
-                    {
-                        new FileInfo(ExpandFilePath(baseDirectory, fileArgument))
-                    };
-                }
-
-                FileInfo? fileList = null;
-                if (!string.IsNullOrEmpty(fileListFilePath))
-                {
-                    if (Path.IsPathRooted(fileListFilePath))
-                    {
-                        fileList = new FileInfo(fileListFilePath);
-                    }
-                    else
-                    {
-                        fileList = new FileInfo(ExpandFilePath(baseDirectory, fileListFilePath));
-                    }
-                }
-
-                if (inputFiles.Count == 0)
-                {
-                    context.Console.Error.WriteLine(Resources.NoFilesToSign);
-                    context.ExitCode = ExitCode.NoInputsFound;
-                    return;
-                }
-
-                if (inputFiles.Any(file => !file.Exists))
-                {
-                    context.Console.Error.WriteFormattedLine(
-                        Resources.SomeFilesDoNotExist,
-                        _codeCommand.BaseDirectoryOption);
-
-                    foreach (FileInfo file in inputFiles.Where(file => !file.Exists))
-                    {
-                        context.Console.Error.WriteLine($"    {file.FullName}");
-                    }
-
-                    context.ExitCode = ExitCode.NoInputsFound;
-                    return;
-                }
-
-                ISigner signer = serviceProvider.GetRequiredService<ISigner>();
-
-                context.ExitCode = await signer.SignAsync(
-                    inputFiles,
-                    output,
-                    fileList,
-                    baseDirectory,
-                    applicationName,
-                    publisherName,
-                    description,
-                    descriptionUrl,
-                    timestampUrl,
-                    maxConcurrency,
-                    fileHashAlgorithmName,
-                    timestampHashAlgorithmName);
+                await _codeCommand.HandleAsync(context, serviceProviderFactory, certificateStoreServiceProvider, fileArgument);
             });
-        }
-
-        private static string ExpandFilePath(DirectoryInfo baseDirectory, string file)
-        {
-            if (Path.IsPathRooted(file))
-            {
-                return file;
-            }
-
-            return Path.Combine(baseDirectory.FullName, file);
         }
     }
 }

--- a/src/Sign.Core/ISignatureProvider.cs
+++ b/src/Sign.Core/ISignatureProvider.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.Core
+{
+    internal interface ISignatureProvider
+    {
+        ISignatureAlgorithmProvider GetSignatureAlgorithmProvider(IServiceProvider serviceProvider);
+        ICertificateProvider GetCertificateProvider(IServiceProvider serviceProvider);
+    }
+}

--- a/src/Sign.SignatureProviders.CertificateStore/CertificateStoreServiceProvider.cs
+++ b/src/Sign.SignatureProviders.CertificateStore/CertificateStoreServiceProvider.cs
@@ -10,7 +10,7 @@ namespace Sign.SignatureProviders.CertificateStore
     /// <summary>
     /// Provider that initializes a new <see cref="CertificateStoreService"/> if required.
     /// </summary>
-    internal class CertificateStoreServiceProvider
+    internal class CertificateStoreServiceProvider : ISignatureProvider
     {
         private readonly string _certificateFingerprint;
         private readonly HashAlgorithmName _certificateFingerprintAlgorithm;
@@ -62,14 +62,14 @@ namespace Sign.SignatureProviders.CertificateStore
             _certificateFilePassword = certificateFilePassword;
         }
 
-        internal ISignatureAlgorithmProvider GetSignatureAlgorithmProvider(IServiceProvider serviceProvider)
+        public ISignatureAlgorithmProvider GetSignatureAlgorithmProvider(IServiceProvider serviceProvider)
         {
             ArgumentNullException.ThrowIfNull(serviceProvider, nameof(serviceProvider));
 
             return GetService(serviceProvider);
         }
 
-        internal ICertificateProvider GetCertificateProvider(IServiceProvider serviceProvider)
+        public ICertificateProvider GetCertificateProvider(IServiceProvider serviceProvider)
         {
             ArgumentNullException.ThrowIfNull(serviceProvider, nameof(serviceProvider));
 

--- a/src/Sign.SignatureProviders.KeyVault/KeyVaultServiceProvider.cs
+++ b/src/Sign.SignatureProviders.KeyVault/KeyVaultServiceProvider.cs
@@ -7,7 +7,7 @@ using Sign.Core;
 
 namespace Sign.SignatureProviders.KeyVault
 {
-    internal sealed class KeyVaultServiceProvider
+    internal sealed class KeyVaultServiceProvider : ISignatureProvider
     {
         private readonly string _certificateName;
         private readonly Uri _keyVaultUrl;
@@ -29,14 +29,14 @@ namespace Sign.SignatureProviders.KeyVault
             _certificateName = certificateName;
         }
 
-        internal ISignatureAlgorithmProvider GetSignatureAlgorithmProvider(IServiceProvider serviceProvider)
+        public ISignatureAlgorithmProvider GetSignatureAlgorithmProvider(IServiceProvider serviceProvider)
         {
             ArgumentNullException.ThrowIfNull(serviceProvider, nameof(serviceProvider));
 
             return GetService(serviceProvider);
         }
 
-        internal ICertificateProvider GetCertificateProvider(IServiceProvider serviceProvider)
+        public ICertificateProvider GetCertificateProvider(IServiceProvider serviceProvider)
         {
             ArgumentNullException.ThrowIfNull(serviceProvider, nameof(serviceProvider));
 


### PR DESCRIPTION
This PR moves the shared logic of the AzureKeyVaultCommand and CertificateStoreCommand to a new Handle method inside the CodeCommand. And this also introduces a new interface called ISignatureProvider that can be used for a new TrustedSigningServiceProvider class.