### PR TITLE
Use ConcurrentBag instead of a List because the .Add method of List is not thread safe.

### DIFF
--- a/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceProviderTests.cs
+++ b/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceProviderTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
+using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -108,14 +109,14 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         {
             CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer);
 
-            List<ISignatureAlgorithmProvider> signatureAlgorithmProviders = [];
+            ConcurrentBag<ISignatureAlgorithmProvider> signatureAlgorithmProviders = [];
             Parallel.For(0, 2, (_, _) =>
             {
                 signatureAlgorithmProviders.Add(provider.GetSignatureAlgorithmProvider(serviceProvider));
             });
 
             Assert.Equal(2, signatureAlgorithmProviders.Count);
-            Assert.Same(signatureAlgorithmProviders[0], signatureAlgorithmProviders[1]);
+            Assert.Same(signatureAlgorithmProviders.First(), signatureAlgorithmProviders.Last());
         }
 
         [Fact]
@@ -134,14 +135,14 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         {
             CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer);
 
-            List<ICertificateProvider> certificateProviders = [];
+            ConcurrentBag<ICertificateProvider> certificateProviders = [];
             Parallel.For(0, 2, (_, _) =>
             {
                 certificateProviders.Add(provider.GetCertificateProvider(serviceProvider));
             });
 
             Assert.Equal(2, certificateProviders.Count);
-            Assert.Same(certificateProviders[0], certificateProviders[1]);
+            Assert.Same(certificateProviders.First(), certificateProviders.Last());
         }
     }
 }

--- a/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceProviderTests.cs
+++ b/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceProviderTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
+using System.Collections.Concurrent;
 using Azure.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -77,14 +78,14 @@ namespace Sign.SignatureProviders.KeyVault.Test
         {
             KeyVaultServiceProvider provider = new(tokenCredential, KeyVaultUrl, CertificateName);
 
-            List<ISignatureAlgorithmProvider> signatureAlgorithmProviders = [];
+            ConcurrentBag<ISignatureAlgorithmProvider> signatureAlgorithmProviders = [];
             Parallel.For(0, 2, (_, _) =>
             {
                 signatureAlgorithmProviders.Add(provider.GetSignatureAlgorithmProvider(serviceProvider));
             });
 
             Assert.Equal(2, signatureAlgorithmProviders.Count);
-            Assert.Same(signatureAlgorithmProviders[0], signatureAlgorithmProviders[1]);
+            Assert.Same(signatureAlgorithmProviders.First(), signatureAlgorithmProviders.Last());
         }
 
         [Fact]
@@ -103,14 +104,14 @@ namespace Sign.SignatureProviders.KeyVault.Test
         {
             KeyVaultServiceProvider provider = new(tokenCredential, KeyVaultUrl, CertificateName);
 
-            List<ICertificateProvider> certificateProviders = [];
+            ConcurrentBag<ICertificateProvider> certificateProviders = [];
             Parallel.For(0, 2, (_, _) =>
             {
                 certificateProviders.Add(provider.GetCertificateProvider(serviceProvider));
             });
 
             Assert.Equal(2, certificateProviders.Count);
-            Assert.Same(certificateProviders[0], certificateProviders[1]);
+            Assert.Same(certificateProviders.First(), certificateProviders.Last());
         }
     }
 }


### PR DESCRIPTION
This PR fixes a mistake that I made in my earlier pull request. I did not take in account that List.Add is not thread safe. Using a ConcurrentBag instead fixes this issue.