### PR TITLE
Make the --description and --description-url optional and pass an empty string when not specified.

### DIFF
--- a/src/Sign.Cli/CodeCommand.cs
+++ b/src/Sign.Cli/CodeCommand.cs
@@ -35,9 +35,6 @@ namespace Sign.Cli
         internal CodeCommand()
             : base("code", Resources.CodeCommandDescription)
         {
-            DescriptionOption.IsRequired = true;
-            DescriptionUrlOption.IsRequired = true;
-
             MaxConcurrencyOption.SetDefaultValue(4);
             FileDigestOption.SetDefaultValue(HashAlgorithmName.SHA256);
             TimestampDigestOption.SetDefaultValue(HashAlgorithmName.SHA256);
@@ -63,13 +60,13 @@ namespace Sign.Cli
 
         internal async Task HandleAsync(InvocationContext context, IServiceProviderFactory serviceProviderFactory, ISignatureProvider signatureProvider, string fileArgument)
         {
-            // Some of the options have either a default value or are required and that is why
-            // we can safely use the null-forgiving operator (!) to simplify the code.
+            // Some of the options have a default value and that is why we can safely use
+            // the null-forgiving operator (!) to simplify the code.
             DirectoryInfo baseDirectory = context.ParseResult.GetValueForOption(BaseDirectoryOption)!;
             string? applicationName = context.ParseResult.GetValueForOption(ApplicationNameOption);
             string? publisherName = context.ParseResult.GetValueForOption(PublisherNameOption);
             string? description = context.ParseResult.GetValueForOption(DescriptionOption);
-            Uri descriptionUrl = context.ParseResult.GetValueForOption(DescriptionUrlOption)!;
+            Uri? descriptionUrl = context.ParseResult.GetValueForOption(DescriptionUrlOption);
             string? fileListFilePath = context.ParseResult.GetValueForOption(FileListOption);
             HashAlgorithmName fileHashAlgorithmName = context.ParseResult.GetValueForOption(FileDigestOption);
             HashAlgorithmName timestampHashAlgorithmName = context.ParseResult.GetValueForOption(TimestampDigestOption);

--- a/src/Sign.Core/DataFormatSigners/AzureSignToolSigner.cs
+++ b/src/Sign.Core/DataFormatSigners/AzureSignToolSigner.cs
@@ -162,8 +162,8 @@ namespace Sign.Core
                 {
                     code = signer.SignFile(
                         file.FullName,
-                        options.Description,
-                        options.DescriptionUrl?.AbsoluteUri,
+                        options.Description ?? string.Empty,
+                        options.DescriptionUrl?.AbsoluteUri ?? string.Empty,
                         pageHashing: null,
                         _logger);
                     success = code == S_OK;

--- a/test/Sign.Cli.Test/CodeCommandTests.cs
+++ b/test/Sign.Cli.Test/CodeCommandTests.cs
@@ -29,9 +29,9 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
-        public void DescriptionOption_Always_IsRequired()
+        public void DescriptionOption_Always_IsNotRequired()
         {
-            Assert.True(_command.DescriptionOption.IsRequired);
+            Assert.False(_command.DescriptionOption.IsRequired);
         }
 
         [Fact]
@@ -41,9 +41,9 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
-        public void DescriptionUrlOption_Always_IsRequired()
+        public void DescriptionUrlOption_Always_IsNotRequired()
         {
-            Assert.True(_command.DescriptionUrlOption.IsRequired);
+            Assert.False(_command.DescriptionUrlOption.IsRequired);
         }
 
         [Fact]


### PR DESCRIPTION
This makes the `--description` and `--description-url` optional. This is only used by authenticode and should not be required for all operations. I tried local testing with passing `null` values and that completed without any issues. But looking at the code of `AzureSign.Core` I noticed that this would not work if the value was null so I changed this to pass an empty string when these values are not specified.