### PR TITLE
Remove `--certificate-fingerprint-algorithm` option

### DIFF
--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -5,6 +5,8 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
+using System.CommandLine.Parsing;
+using System.Globalization;
 using System.Security.Cryptography;
 using Sign.Core;
 using Sign.SignatureProviders.CertificateStore;
@@ -15,8 +17,7 @@ namespace Sign.Cli
     {
         private readonly CodeCommand _codeCommand;
 
-        internal Option<string> CertificateFingerprintOption { get; } = new(["-cfp", "--certificate-fingerprint"], CertificateStoreResources.CertificateFingerprintOptionDescription);
-        internal Option<HashAlgorithmName> CertificateFingerprintAlgorithmOption { get; } = new(["-cfpa", "--certificate-fingerprint-algorithm"], HashAlgorithmParser.ParseHashAlgorithmName, description: CertificateStoreResources.CertificateFingerprintAlgorithmOptionDescription);
+        internal Option<string?> CertificateFingerprintOption { get; } = new(["-cfp", "--certificate-fingerprint"], ParseCertificateFingerprint, description: CertificateStoreResources.CertificateFingerprintOptionDescription);
         internal Option<string?> CertificateFileOption { get; } = new(["-cf", "--certificate-file"], CertificateStoreResources.CertificateFileOptionDescription);
         internal Option<string?> CertificatePasswordOption { get; } = new(["-p", "--password"], CertificateStoreResources.CertificatePasswordOptionDescription);
         internal Option<string?> CryptoServiceProviderOption { get; } = new(["-csp", "--crypto-service-provider"], CertificateStoreResources.CspOptionDescription);
@@ -35,10 +36,7 @@ namespace Sign.Cli
 
             CertificateFingerprintOption.IsRequired = true;
 
-            CertificateFingerprintAlgorithmOption.SetDefaultValue(HashAlgorithmName.SHA256);
-
             AddOption(CertificateFingerprintOption);
-            AddOption(CertificateFingerprintAlgorithmOption);
             AddOption(CertificateFileOption);
             AddOption(CertificatePasswordOption);
             AddOption(CryptoServiceProviderOption);
@@ -60,20 +58,29 @@ namespace Sign.Cli
                 // Some of the options are required and that is why we can safely use
                 // the null-forgiving operator (!) to simplify the code.
                 string certificateFingerprint = context.ParseResult.GetValueForOption(CertificateFingerprintOption)!;
-                HashAlgorithmName certificateFingerprintAlgorithm = context.ParseResult.GetValueForOption(CertificateFingerprintAlgorithmOption);
                 string? certificatePath = context.ParseResult.GetValueForOption(CertificateFileOption);
                 string? certificatePassword = context.ParseResult.GetValueForOption(CertificatePasswordOption);
                 string? cryptoServiceProvider = context.ParseResult.GetValueForOption(CryptoServiceProviderOption);
                 string? privateKeyContainer = context.ParseResult.GetValueForOption(PrivateKeyContainerOption);
                 bool useMachineKeyContainer = context.ParseResult.GetValueForOption(UseMachineKeyContainerOption);
 
-                // Certificate Fingerprint is required in case the provided certificate container contains multiple certificates.
+                // Certificate fingerprint is required in case the provided certificate container contains multiple certificates.
                 if (string.IsNullOrEmpty(certificateFingerprint))
                 {
                     context.Console.Error.WriteFormattedLine(
                         Resources.InvalidCertificateFingerprintValue,
                         CertificateFingerprintOption);
-                    context.ExitCode = ExitCode.NoInputsFound;
+                    context.ExitCode = ExitCode.InvalidOptions;
+
+                    return;
+                }
+
+                if (!TryDeduceHashAlgorithm(certificateFingerprint, out HashAlgorithmName certificateFingerprintAlgorithm))
+                {
+                    context.Console.Error.WriteFormattedLine(
+                        Resources.InvalidCertificateFingerprintValue,
+                        CertificateFingerprintOption);
+                    context.ExitCode = ExitCode.InvalidOptions;
 
                     return;
                 }
@@ -106,6 +113,73 @@ namespace Sign.Cli
 
                 await _codeCommand.HandleAsync(context, serviceProviderFactory, certificateStoreServiceProvider, fileArgument);
             });
+        }
+
+        private static string? ParseCertificateFingerprint(ArgumentResult result)
+        {
+            string? token = null;
+
+            if (result.Tokens.Count == 1)
+            {
+                token = result.Tokens[0].Value;
+
+                if (!HexHelpers.IsHex(token))
+                {
+                    result.ErrorMessage = FormatMessage(
+                        Resources.InvalidCertificateFingerprintValue,
+                        result.Argument);
+                }
+                else if (!TryDeduceHashAlgorithm(token, out HashAlgorithmName hashAlgorithmName))
+                {
+                    result.ErrorMessage = FormatMessage(
+                        Resources.InvalidCertificateFingerprintValue,
+                        result.Argument);
+                }
+            }
+            else
+            {
+                result.ErrorMessage = FormatMessage(
+                    Resources.InvalidCertificateFingerprintValue,
+                    result.Argument);
+            }
+
+            return token;
+        }
+
+        private static string FormatMessage(string format, Argument argument)
+        {
+            return string.Format(CultureInfo.CurrentCulture, format, $"--{argument.Name}");
+        }
+
+        private static bool TryDeduceHashAlgorithm(
+            string certificateFingerprint,
+            out HashAlgorithmName hashAlgorithmName)
+        {
+            hashAlgorithmName = HashAlgorithmName.SHA256;
+
+            if (string.IsNullOrEmpty(certificateFingerprint))
+            {
+                return false;
+            }
+
+            // One hexadecimal character is 4 bits.
+            switch (certificateFingerprint.Length)
+            {
+                case 64: // 64 characters * 4 bits/character = 256 bits
+                    hashAlgorithmName = HashAlgorithmName.SHA256;
+                    return true;
+
+                case 96: // 96 characters * 4 bits/character = 384 bits
+                    hashAlgorithmName = HashAlgorithmName.SHA384;
+                    return true;
+
+                case 128: // 128 characters * 4 bits/character = 512 bits
+                    hashAlgorithmName = HashAlgorithmName.SHA512;
+                    return true;
+
+                default:
+                    return false;
+            }
         }
     }
 }

--- a/src/Sign.Cli/CertificateStoreResources.Designer.cs
+++ b/src/Sign.Cli/CertificateStoreResources.Designer.cs
@@ -70,15 +70,6 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Certificate fingerprint algorithm. Allowed values are &apos;sha256&apos;, &apos;sha384&apos;, and &apos;sha512&apos;..
-        /// </summary>
-        internal static string CertificateFingerprintAlgorithmOptionDescription {
-            get {
-                return ResourceManager.GetString("CertificateFingerprintAlgorithmOptionDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to SHA fingerprint used to identify a certificate..
         /// </summary>
         internal static string CertificateFingerprintOptionDescription {

--- a/src/Sign.Cli/CertificateStoreResources.resx
+++ b/src/Sign.Cli/CertificateStoreResources.resx
@@ -121,10 +121,6 @@
     <value>PFX, P7B, or CER file containing a certificate and potentially a private key.</value>
     <comment>{Locked="PFX", "P7B", "CER"} are file extensions.</comment>
   </data>
-  <data name="CertificateFingerprintAlgorithmOptionDescription" xml:space="preserve">
-    <value>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</value>
-    <comment>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</comment>
-  </data>
   <data name="CertificateFingerprintOptionDescription" xml:space="preserve">
     <value>SHA fingerprint used to identify a certificate.</value>
     <comment>{Locked="SHA"} is a cryptographic algorithm.</comment>

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -151,16 +151,7 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid value for {0}. The value must be &apos;sha256&apos;, &apos;sha384&apos;, or &apos;sha512&apos;..
-        /// </summary>
-        internal static string InvalidCertificateFingerprintAlgorithmValue {
-            get {
-                return ResourceManager.GetString("InvalidCertificateFingerprintAlgorithmValue", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid value for {0}. The value must be the certificate&apos;s fingerprint (in hexadecimal)..
+        ///   Looks up a localized string similar to Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal)..
         /// </summary>
         internal static string InvalidCertificateFingerprintValue {
             get {

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -149,13 +149,9 @@
     <value>Invalid value for {0}. The value must be a fully rooted directory path.</value>
     <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</comment>
   </data>
-  <data name="InvalidCertificateFingerprintAlgorithmValue" xml:space="preserve">
-    <value>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</value>
-    <comment>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</comment>
-  </data>
   <data name="InvalidCertificateFingerprintValue" xml:space="preserve">
-    <value>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</value>
-    <comment>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</comment>
+    <value>Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</value>
+    <comment>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint).  {Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic hash algorithms.</comment>
   </data>
   <data name="InvalidDigestValue" xml:space="preserve">
     <value>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</value>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Soubor PFX, P7B nebo CER obsahující certifikát a potenciálně privátní klíč.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
-      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Algoritmus otisku certifikátu. Povolené hodnoty jsou sha256, sha384 a sha512.</target>
-        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>
         <target state="translated">Otisk SHA sloužící k identifikaci certifikátu</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
@@ -7,11 +7,6 @@
         <target state="translated">PFX-, P7B- oder CER-Datei, die ein Zertifikat und möglicherweise einen privaten Schlüssel enthält.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
-      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Algorithmus für Zertifikatfingerabdruck. Zulässige Werte sind "sha256", "sha384" und "sha512".</target>
-        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>
         <target state="translated">SHA-Fingerabdruck zum Identifizieren eines Zertifikats.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Archivo PFX, P7B o CER que contiene un certificado y una clave privada potencialmente.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
-      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Algoritmo de huella digital del certificado. Los valores permitidos son "sha256", "sha384" y "sha512".</target>
-        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>
         <target state="translated">Huella digital SHA usada para identificar un certificado.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Fichier PFX, P7B ou CER contenant un certificat et éventuellement une clé privée.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
-      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Algorithme d’empreinte digitale de certificat. Les valeurs autorisées sont 'sha256', 'sha384' et 'sha512'.</target>
-        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>
         <target state="translated">Empreinte digitale SHA utilisée pour identifier un certificat.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
@@ -7,11 +7,6 @@
         <target state="translated">PFX, P7B o CER file contenente un certificato e potenzialmente una chiave privata.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
-      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Algoritmo di impronta digitale del certificato. I valori consentiti sono 'sha256', 'sha384'e ' sha512'.</target>
-        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>
         <target state="translated">Impronta digitale SHA usata per identificare un certificato.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
@@ -7,11 +7,6 @@
         <target state="translated">証明書と潜在的に秘密キーを含む PFX、P7B、または CER ファイル。</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
-      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">証明書のフィンガープリント アルゴリズム。使用できる値は、'sha256'、'sha384'、および 'sha512' です。</target>
-        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>
         <target state="translated">証明書の識別に使用される SHA フィンガープリント。</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
@@ -7,11 +7,6 @@
         <target state="translated">인증서와 잠재적으로 프라이빗 키가 포함된 PFX, P7B 또는 CER 파일입니다.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
-      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">인증서 지문 알고리즘입니다. 허용되는 값은 'sha256', 'sha384', 'sha512'입니다.</target>
-        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>
         <target state="translated">인증서를 식별하는 데 사용되는 SHA 지문입니다.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Plik PFX, P7B lub CER zawierający certyfikat i potencjalnie klucz prywatny.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
-      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Algorytm odcisku palca certyfikatu. Dozwolone wartości to „sha256”, „sha384” i „sha512”.</target>
-        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>
         <target state="translated">Odcisk palca SHA używany do identyfikowania certyfikatu.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Arquivos PFX, P7B ou CER que contêm um certificado e, possivelmente, uma chave privada.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
-      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Algoritmo de impressão digital do certificado. Os valores permitidos são "sha256", "sha384" e "sha512".</target>
-        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>
         <target state="translated">Impressão digital SHA usada para identificar um certificado.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Файл PFX, P7B или CER, содержащий сертификат и, возможно, закрытый ключ.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
-      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Алгоритм отпечатков сертификата. Допустимые значения: "sha256", "sha384" и "sha512".</target>
-        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>
         <target state="translated">Отпечаток SHA, используемый для идентификации сертификата.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
@@ -7,11 +7,6 @@
         <target state="translated">Bir sertifika ve potansiyel olarak özel anahtar içeren PFX, P7B veya CER dosyası.</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
-      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">Sertifika parmak izi algoritması. İzin verilen değerler: 'sha256', 'sha384' ve 'sha512'.</target>
-        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>
         <target state="translated">Sertifikayı tanımlamak için kullanılan SHA parmak izi.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
@@ -7,11 +7,6 @@
         <target state="translated">包含证书和可能包含私钥的 PFX、P7B 或 CER 文件。</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
-      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">证书指纹算法。允许的值为“sha256”、“sha384”和“sha512”。</target>
-        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>
         <target state="translated">用于标识证书的 SHA 指纹。</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
@@ -7,11 +7,6 @@
         <target state="translated">包含憑證和潛在的私用金鑰的 PFX、P7B 或 CER 檔案。</target>
         <note>{Locked="PFX", "P7B", "CER"} are file extensions.</note>
       </trans-unit>
-      <trans-unit id="CertificateFingerprintAlgorithmOptionDescription">
-        <source>Certificate fingerprint algorithm. Allowed values are 'sha256', 'sha384', and 'sha512'.</source>
-        <target state="translated">憑證指紋演算法。允許的值為 'sha256'、'sha384' 和 'sha512'。</target>
-        <note>{Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="CertificateFingerprintOptionDescription">
         <source>SHA fingerprint used to identify a certificate.</source>
         <target state="translated">用以識別憑證的 SHA 指紋。</target>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -52,15 +52,10 @@
         <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být plně kořenová cesta k adresáři.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
-        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být sha256, sha384 nebo sha512.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
-        <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být digitální otisk certifikátu (v šestnáctkovém tvaru).</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</source>
+        <target state="needs-review-translation">Neplatná hodnota pro {0}. Hodnota musí být digitální otisk certifikátu (v šestnáctkovém tvaru).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint).  {Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -52,15 +52,10 @@
         <target state="translated">Ungültiger Wert für {0}. Der Wert muss ein vollständiger Stammverzeichnispfad sein.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
-        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Ungültiger Wert für {0}. Der Wert muss "sha256", "sha384" oder "sha512" sein.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
-        <target state="translated">Ungültiger Wert für {0}. Der Wert muss der Fingerabdruck des Zertifikats sein (hexadezimal).</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</source>
+        <target state="needs-review-translation">Ungültiger Wert für {0}. Der Wert muss der Fingerabdruck des Zertifikats sein (hexadezimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint).  {Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -52,15 +52,10 @@
         <target state="translated">Valor no válido para {0}. El valor debe ser una ruta de acceso de directorio totalmente raíz.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
-        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Valor no válido para {0}. El valor debe ser 'sha256', 'sha384' o 'sha512'.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
-        <target state="translated">Valor no válido para {0}. El valor debe ser la huella digital del certificado (en hexadecimal).</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</source>
+        <target state="needs-review-translation">Valor no válido para {0}. El valor debe ser la huella digital del certificado (en hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint).  {Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -52,15 +52,10 @@
         <target state="translated">Valeur non valide pour {0}. La valeur doit être un chemin d’accès de répertoire entièrement rooté.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
-        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Valeur invalide pour {0}. La valeur doit être 'sha256', 'sha384' ou 'sha512'.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
-        <target state="translated">Valeur non valide pour {0}. La valeur doit être l’empreinte digitale du certificat (hexadécimal).</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</source>
+        <target state="needs-review-translation">Valeur non valide pour {0}. La valeur doit être l’empreinte digitale du certificat (hexadécimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint).  {Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -52,15 +52,10 @@
         <target state="translated">Valore non valido per {0}. Il valore deve essere un percorso di directory completo.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
-        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Valore non valido per {0}. Il valore deve essere 'sha256', 'sha384' o 'sha512'.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
-        <target state="translated">Valore non valido per {0}. Il valore deve essere l'impronta digitale del certificato (in formato esadecimale).</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</source>
+        <target state="needs-review-translation">Valore non valido per {0}. Il valore deve essere l'impronta digitale del certificato (in formato esadecimale).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint).  {Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -52,15 +52,10 @@
         <target state="translated">{0} の値が無効です。値は、完全にルート化されたディレクトリ パスである必要があります。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
-        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">{0} の値が無効です。値は 'sha256'、'sha384'、または 'sha512' である必要があります。</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
-        <target state="translated">{0} の値が無効です。値は証明書のフィンガープリント (16 進数) である必要があります。</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</source>
+        <target state="needs-review-translation">{0} の値が無効です。値は証明書のフィンガープリント (16 進数) である必要があります。</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint).  {Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -52,15 +52,10 @@
         <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 완전한 루트 디렉터리 경로여야 합니다.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
-        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 'sha256', 'sha384' 또는 'sha512'.여야 합니다.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
-        <target state="translated">{0}의 값이 잘못되었습니다. 값은 인증서의 지문(16진수)이어야 합니다.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</source>
+        <target state="needs-review-translation">{0}의 값이 잘못되었습니다. 값은 인증서의 지문(16진수)이어야 합니다.</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint).  {Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -52,15 +52,10 @@
         <target state="translated">Nieprawidłowa wartość dla {0}. Wartość musi być w pełni główną ścieżką katalogu.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
-        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Nieprawidłowa wartość dla {0}. Wartością musi być „sha256”, „sha384”, lub „sha512”.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
-        <target state="translated">Nieprawidłowa wartość dla opcji {0}. Wartość musi być odciskiem palca certyfikatu (w systemie szesnastkowym).</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</source>
+        <target state="needs-review-translation">Nieprawidłowa wartość dla opcji {0}. Wartość musi być odciskiem palca certyfikatu (w systemie szesnastkowym).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint).  {Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -52,15 +52,10 @@
         <target state="translated">Valor inválido para {0}. O valor deve ser um caminho de diretório totalmente desbloqueado por rooting.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
-        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Valor inválido para {0}. O valor deve ser 'sha256', 'sha384' ou 'sha512'.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
-        <target state="translated">Valor inválido para {0}. O valor deve ser a impressão digital do certificado (em hexadecimal).</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</source>
+        <target state="needs-review-translation">Valor inválido para {0}. O valor deve ser a impressão digital do certificado (em hexadecimal).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint).  {Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -52,15 +52,10 @@
         <target state="translated">Недопустимое значение для {0}. Значение должно быть полным корневым путем к каталогу.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
-        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">Недопустимое значение для {0}. Необходимо использовать "sha256", "sha384" или "sha512".</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
-        <target state="translated">Недопустимое значение для {0}. Значение должно быть отпечатком сертификата (в шестнадцатеричном формате).</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</source>
+        <target state="needs-review-translation">Недопустимое значение для {0}. Значение должно быть отпечатком сертификата (в шестнадцатеричном формате).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint).  {Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -52,15 +52,10 @@
         <target state="translated">{0} için geçersiz değer. Değer, tam olarak kök erişim izni verilmiş bir dizin yolu olmalıdır.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
-        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">{0} için geçersiz değer. Değer 'sha256', 'sha384' veya 'sha512' olmalıdır.</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
-        <target state="translated">{0} için geçersiz değer. Değer, sertifikanın parmak izi olmalıdır (onaltılık).</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</source>
+        <target state="needs-review-translation">{0} için geçersiz değer. Değer, sertifikanın parmak izi olmalıdır (onaltılık).</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint).  {Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -52,15 +52,10 @@
         <target state="translated">{0} 的值无效。该值必须是完整的根目录路径。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
-        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">{0} 的值无效。值必须为 "sha256"、"sha384" 或 "sha512"。</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
-        <target state="translated">{0} 的值无效。该值必须是证书的指纹(十六进制)。</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</source>
+        <target state="needs-review-translation">{0} 的值无效。该值必须是证书的指纹(十六进制)。</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint).  {Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -52,15 +52,10 @@
         <target state="translated">{0} 的值無效。值必須是完整的根目錄路徑。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --base-directory) and should not be localized.</note>
       </trans-unit>
-      <trans-unit id="InvalidCertificateFingerprintAlgorithmValue">
-        <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>
-        <target state="translated">{0} 的值無效。值必須是 'sha256'、'sha384' 或 'sha512'。</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint-algorithm).  {Locked="sha256", "sha384", "sha512"} are cryptographic hash algorithms.</note>
-      </trans-unit>
       <trans-unit id="InvalidCertificateFingerprintValue">
-        <source>Invalid value for {0}. The value must be the certificate's fingerprint (in hexadecimal).</source>
-        <target state="translated">{0} 的無效值。該值必須是憑證的指紋 (十六進位)。</target>
-        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint) and should not be localized.</note>
+        <source>Invalid value for {0}. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).</source>
+        <target state="needs-review-translation">{0} 的無效值。該值必須是憑證的指紋 (十六進位)。</target>
+        <note>{NumberedPlaceholder="{0}"} is the option name (e.g.:  --certificate-fingerprint).  {Locked="SHA-256", "SHA-384", "SHA-512"} are cryptographic hash algorithms.</note>
       </trans-unit>
       <trans-unit id="InvalidDigestValue">
         <source>Invalid value for {0}. The value must be 'sha256', 'sha384', or 'sha512'.</source>

--- a/src/Sign.Core/Tools/VsixSignTool/HexHelpers.cs
+++ b/src/Sign.Core/Tools/VsixSignTool/HexHelpers.cs
@@ -14,6 +14,26 @@ namespace Sign.Core
             (byte)'F',
         };
 
+        internal static bool IsHex(ReadOnlySpan<char> text)
+        {
+            if (text.IsEmpty)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < text.Length; ++i)
+            {
+                char c = text[i];
+
+                if (!char.IsDigit(c) && !(c >= 'a' && c <= 'f') && !(c >= 'A' && c <= 'F'))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         public static bool TryHexEncode(ReadOnlySpan<byte> data, Span<char> buffer)
         {
             var charsRequired = data.Length * 2;

--- a/test/Sign.Cli.Test/CertificateStoreCommandTests.cs
+++ b/test/Sign.Cli.Test/CertificateStoreCommandTests.cs
@@ -14,6 +14,11 @@ namespace Sign.Cli.Test
     {
         private readonly CertificateStoreCommand _command = new(new CodeCommand(), Mock.Of<IServiceProviderFactory>());
 
+        private const string Sha1Fingerprint = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+        private const string Sha256Fingerprint = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        private const string Sha384Fingerprint = "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b";
+        private const string Sha512Fingerprint = "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e";
+
         [Fact]
         public void Constructor_WhenCodeCommandIsNull_Throws()
         {
@@ -42,12 +47,6 @@ namespace Sign.Cli.Test
         public void CertificateFingerprintOption_Always_HasArityOfExactlyOne()
         {
             Assert.Equal(ArgumentArity.ExactlyOne, _command.CertificateFingerprintOption.Arity);
-        }
-
-        [Fact]
-        public void CertificateFingerprintAlgorithmOption_Always_HasArityOfExactlyOne()
-        {
-            Assert.Equal(ArgumentArity.ExactlyOne, _command.CertificateFingerprintAlgorithmOption.Arity);
         }
 
         [Fact]
@@ -88,14 +87,13 @@ namespace Sign.Cli.Test
             [Theory]
             [InlineData("certificate-store a")]
             [InlineData("certificate-store a -cfp")]
-            [InlineData("certificate-store a -cfp -cfpa -cf")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -cf")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha-333 -cf")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa -cf filePath -p")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -cf filePath -csp")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -cf filePath -csp sampleCSP -k")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -csp")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -csp sampleCSP -k")]
+            [InlineData("certificate-store a -cfp -cf")]
+            [InlineData($"certificate-store a -cfp {Sha256Fingerprint} -cf")]
+            [InlineData($"certificate-store a -cfp {Sha256Fingerprint} -cf filePath -p")]
+            [InlineData($"certificate-store a -cfp {Sha256Fingerprint} -cf filePath -csp")]
+            [InlineData($"certificate-store a -cfp {Sha256Fingerprint} -cf filePath -csp sampleCSP -k")]
+            [InlineData($"certificate-store a -cfp {Sha256Fingerprint} -csp")]
+            [InlineData($"certificate-store a -cfp {Sha256Fingerprint} -csp sampleCSP -k")]
             public void Command_WhenRequiredArgumentOrOptionsAreMissing_HasError(string command)
             {
                 ParseResult result = _parser.Parse(command);
@@ -104,14 +102,27 @@ namespace Sign.Cli.Test
             }
 
             [Theory]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha384 -cf filePath")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha512 -cf filePath -p password")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -csp sampleCSP -k keyContainer ")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -csp sampleCSP -k machineKeyContainer -km")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -cf filePath -csp sampleCSP -k keyContainer ")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -cf filePath -p password -csp sampleCSP -k keyContainer")]
-            [InlineData("certificate-store a -cfp fingerprint -cfpa sha256 -cf filePath -csp sampleCSP -k keyContainer -km")]
+            [InlineData("certificate-store a -cfp \"\"")]
+            [InlineData("certificate-store a -cfp b")]
+            [InlineData("certificate-store a -cfp b c")]
+            [InlineData($"certificate-store a -cfp {Sha1Fingerprint}")]
+            [InlineData("certificate-store a -cfp Z3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")] // SHA-256 length, but contains a non-hex character
+            public void Command_WhenCertificateFingerprintAlgorithmCannotBeDeduced_HasError(string command)
+            {
+                ParseResult result = _parser.Parse(command);
+
+                Assert.NotEmpty(result.Errors);
+            }
+
+            [Theory]
+            [InlineData($"certificate-store a -cfp {Sha256Fingerprint}")]
+            [InlineData($"certificate-store a -cfp {Sha384Fingerprint} -cf filePath")]
+            [InlineData($"certificate-store a -cfp {Sha512Fingerprint} -cf filePath -p password")]
+            [InlineData($"certificate-store a -cfp {Sha256Fingerprint} -csp sampleCSP -k keyContainer ")]
+            [InlineData($"certificate-store a -cfp {Sha256Fingerprint} -csp sampleCSP -k machineKeyContainer -km")]
+            [InlineData($"certificate-store a -cfp {Sha256Fingerprint} -cf filePath -csp sampleCSP -k keyContainer ")]
+            [InlineData($"certificate-store a -cfp {Sha256Fingerprint} -cf filePath -p password -csp sampleCSP -k keyContainer")]
+            [InlineData($"certificate-store a -cfp {Sha256Fingerprint} -cf filePath -csp sampleCSP -k keyContainer -km")]
             public void Command_WhenRequiredArgumentsArePresent_HasNoError(string command)
             {
                 ParseResult result = _parser.Parse(command);

--- a/test/Sign.Core.Test/Tools/VSIXSignTool/HexHelperTests.cs
+++ b/test/Sign.Core.Test/Tools/VSIXSignTool/HexHelperTests.cs
@@ -11,7 +11,7 @@ namespace Sign.Core.Test
         [InlineData(new byte[] { 0 }, "00")]
         [InlineData(new byte[] { 0, 0, 0, 1 }, "00000001")]
         [InlineData(new byte[] { 0, 255, 1, 254 }, "00FF01FE")]
-        public void ShouldEncodeToHex(byte[] input, string expected)
+        public void TryHexEncode_WhenInputsAreValid_ReturnsTrue(byte[] input, string expected)
         {
             Span<char> buffer = stackalloc char[expected.Length];
             Assert.True(HexHelpers.TryHexEncode(input, buffer));
@@ -19,14 +19,14 @@ namespace Sign.Core.Test
         }
 
         [Fact]
-        public void ShouldReturnFalseIfBufferIsTooSmall()
+        public void TryHexEncode_WhenBufferIsTooSmall_ReturnsFalse()
         {
             Span<char> buffer = stackalloc char[1];
             Assert.False(HexHelpers.TryHexEncode(new byte[2], buffer));
         }
 
         [Fact]
-        public void ShouldNotClobberSurroundingData()
+        public void TryHexEncode_Never_ClobbersSurroundingData()
         {
             Span<char> buffer = stackalloc char[] { 'Q', 'Q', 'Q', 'Q' };
             Assert.True(HexHelpers.TryHexEncode(new byte[] { 0x66 }, buffer.Slice(1, 2)));
@@ -34,7 +34,7 @@ namespace Sign.Core.Test
         }
 
         [Fact]
-        public void ShouldTranslateAllValues()
+        public void TryHexEncode_WithAnyByteValue_ReturnsTrue()
         {
             Span<char> buffer = stackalloc char[2];
             Span<byte> value = stackalloc byte[1];
@@ -44,6 +44,22 @@ namespace Sign.Core.Test
                 Assert.True(HexHelpers.TryHexEncode(value, buffer));
                 Assert.Equal(i.ToString("X2"), buffer.ToString());
             }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("g")]
+        public void IsHex_WhenTextIsNotHex_ReturnsFalse(string? text)
+        {
+            Assert.False(HexHelpers.IsHex(text));
+        }
+
+        [Fact]
+        public void IsHex_WhenTextIsHex_ReturnsTrue()
+        {
+            Assert.True(HexHelpers.IsHex("0123456789abcdefABCDEF"));
         }
     }
 }


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/721.

This change removes the `--certificate-fingerprint-algorithm` option and instead infers the fingerprint algorithm from the length of the fingerprint.

If an invalid value is provided (e.g.:  not hexadecimal or an unsupported algorithm like SHA-1), the error is:

`Invalid value for --certificate-fingerprint. The value must be a SHA-256, SHA-384, or SHA-512 certificate fingerprint (in hexadecimal).`

CC @clairernovotny, @javierdlg, @kartheekp-ms