### PR TITLE
Added --azure-credential-type that can be used to specify which Azure credential type should be enabled.

### DIFF
--- a/src/Sign.Cli/AzureCredentialOptions.cs
+++ b/src/Sign.Cli/AzureCredentialOptions.cs
@@ -15,7 +15,7 @@ namespace Sign.Cli
     {
         internal Option<string?> CredentialTypeOption { get; } = new Option<string?>(["-act", "--azure-credential-type"], Resources.CredentialTypeOptionDescription).FromAmong(
             AzureCredentialType.Environment);
-        internal Option<bool?> ManagedIdentityOption { get; } = new(["-kvm", "--azure-key-vault-managed-identity"], Resources.ManagedIdentityOptionDescription);
+        internal Option<bool?> ManagedIdentityOption { get; } = new(["-kvm", "--azure-key-vault-managed-identity"], Resources.ManagedIdentityOptionDescription) { IsHidden = true };
         internal Option<string?> TenantIdOption { get; } = new(["-kvt", "--azure-key-vault-tenant-id"], Resources.TenantIdOptionDescription);
         internal Option<string?> ClientIdOption { get; } = new(["-kvi", "--azure-key-vault-client-id"], Resources.ClientIdOptionDescription);
         internal Option<string?> ClientSecretOption { get; } = new(["-kvs", "--azure-key-vault-client-secret"], Resources.ClientSecretOptionDescription);

--- a/src/Sign.Cli/AzureCredentialType.cs
+++ b/src/Sign.Cli/AzureCredentialType.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.Cli
+{
+    internal static class AzureCredentialType
+    {
+        public const string Environment = "environment";
+    }
+}

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -115,7 +115,7 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code..
+        ///   Looks up a localized string similar to Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code..
         /// </summary>
         internal static string CredentialTypeOptionDescription {
             get {

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -115,6 +115,15 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code..
+        /// </summary>
+        internal static string CredentialTypeOptionDescription {
+            get {
+                return ResourceManager.GetString("CredentialTypeOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Description of the signing certificate..
         /// </summary>
         internal static string DescriptionOptionDescription {

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -136,7 +136,7 @@
     <value>Sign binaries and containers.</value>
   </data>
   <data name="CredentialTypeOptionDescription" xml:space="preserve">
-    <value>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</value>
+    <value>Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</value>
   </data>
   <data name="DescriptionOptionDescription" xml:space="preserve">
     <value>Description of the signing certificate.</value>

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -135,6 +135,9 @@
   <data name="CodeCommandDescription" xml:space="preserve">
     <value>Sign binaries and containers.</value>
   </data>
+  <data name="CredentialTypeOptionDescription" xml:space="preserve">
+    <value>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</value>
+  </data>
   <data name="DescriptionOptionDescription" xml:space="preserve">
     <value>Description of the signing certificate.</value>
   </data>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Podepisovat binární soubory a kontejnery.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialTypeOptionDescription">
+        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionOptionDescription">
         <source>Description of the signing certificate.</source>
         <target state="translated">Popis podpisového certifikátu.</target>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CredentialTypeOptionDescription">
-        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
-        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <source>Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</target>
         <note />
       </trans-unit>
       <trans-unit id="DescriptionOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Signieren Sie Binärdateien und Container.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialTypeOptionDescription">
+        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionOptionDescription">
         <source>Description of the signing certificate.</source>
         <target state="translated">Beschreibung des Signaturzertifikats.</target>

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CredentialTypeOptionDescription">
-        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
-        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <source>Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</target>
         <note />
       </trans-unit>
       <trans-unit id="DescriptionOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Firmar archivos binarios y contenedores.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialTypeOptionDescription">
+        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionOptionDescription">
         <source>Description of the signing certificate.</source>
         <target state="translated">Descripción del certificado de firma.</target>

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CredentialTypeOptionDescription">
-        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
-        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <source>Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</target>
         <note />
       </trans-unit>
       <trans-unit id="DescriptionOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Signer les fichiers binaires et les conteneurs.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialTypeOptionDescription">
+        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionOptionDescription">
         <source>Description of the signing certificate.</source>
         <target state="translated">Description du certificat de signature.</target>

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CredentialTypeOptionDescription">
-        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
-        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <source>Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</target>
         <note />
       </trans-unit>
       <trans-unit id="DescriptionOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Consente di firmare file binari e contenitori.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialTypeOptionDescription">
+        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionOptionDescription">
         <source>Description of the signing certificate.</source>
         <target state="translated">Descrizione del certificato di firma.</target>

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CredentialTypeOptionDescription">
-        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
-        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <source>Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</target>
         <note />
       </trans-unit>
       <trans-unit id="DescriptionOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">バイナリとコンテナーに署名します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialTypeOptionDescription">
+        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionOptionDescription">
         <source>Description of the signing certificate.</source>
         <target state="translated">署名証明書の説明。</target>

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CredentialTypeOptionDescription">
-        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
-        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <source>Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</target>
         <note />
       </trans-unit>
       <trans-unit id="DescriptionOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">이진 파일 및 컨테이너에 서명합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialTypeOptionDescription">
+        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionOptionDescription">
         <source>Description of the signing certificate.</source>
         <target state="translated">서명 인증서에 대한 설명입니다.</target>

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CredentialTypeOptionDescription">
-        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
-        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <source>Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</target>
         <note />
       </trans-unit>
       <trans-unit id="DescriptionOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Podpisz pliki binarne i kontenery.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialTypeOptionDescription">
+        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionOptionDescription">
         <source>Description of the signing certificate.</source>
         <target state="translated">Opis certyfikatu podpisywania.</target>

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CredentialTypeOptionDescription">
-        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
-        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <source>Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</target>
         <note />
       </trans-unit>
       <trans-unit id="DescriptionOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Autenticar contêineres e binários.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialTypeOptionDescription">
+        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionOptionDescription">
         <source>Description of the signing certificate.</source>
         <target state="translated">Descrição do certificado de autenticação.</target>

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CredentialTypeOptionDescription">
-        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
-        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <source>Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</target>
         <note />
       </trans-unit>
       <trans-unit id="DescriptionOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CredentialTypeOptionDescription">
-        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
-        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <source>Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</target>
         <note />
       </trans-unit>
       <trans-unit id="DescriptionOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Подписывание двоичных файлов и контейнеров.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialTypeOptionDescription">
+        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionOptionDescription">
         <source>Description of the signing certificate.</source>
         <target state="translated">Описание сертификата для подписи</target>

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">İkili dosyaları ve kapsayıcıları imzalayın.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialTypeOptionDescription">
+        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionOptionDescription">
         <source>Description of the signing certificate.</source>
         <target state="translated">İmzalama sertifikasının açıklaması.</target>

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CredentialTypeOptionDescription">
-        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
-        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <source>Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</target>
         <note />
       </trans-unit>
       <trans-unit id="DescriptionOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="translated">对二进制文件和容器进行签名。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialTypeOptionDescription">
+        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionOptionDescription">
         <source>Description of the signing certificate.</source>
         <target state="translated">签名证书的说明。</target>

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CredentialTypeOptionDescription">
-        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
-        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <source>Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</target>
         <note />
       </trans-unit>
       <trans-unit id="DescriptionOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">簽署二進位檔和容器。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CredentialTypeOptionDescription">
+        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DescriptionOptionDescription">
         <source>Description of the signing certificate.</source>
         <target state="translated">簽署憑證的描述。</target>

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CredentialTypeOptionDescription">
-        <source>Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</source>
-        <target state="new">Azure credential type that will be used. This defaults to all types except interactive-browser, shared-token and visual-studio-code.</target>
+        <source>Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</source>
+        <target state="new">Azure credential type that will be used. This defaults to all types except interactive browser, shared token and Visual Studio Code.</target>
         <note />
       </trans-unit>
       <trans-unit id="DescriptionOptionDescription">

--- a/test/Sign.Cli.Test/AzureCredentialOptionsTests.cs
+++ b/test/Sign.Cli.Test/AzureCredentialOptionsTests.cs
@@ -3,12 +3,38 @@
 // See the LICENSE.txt file in the project root for more information.
 
 using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Parsing;
+using Azure.Identity;
+using Moq;
+using Sign.Core;
 
 namespace Sign.Cli.Test
 {
     public class AzureCredentialOptionsTests
     {
-        private readonly AzureCredentialOptions _options = new();
+        private readonly AzureCredentialOptions _options;
+        private readonly AzureKeyVaultCommand _command;
+        private readonly Parser _parser;
+
+        public AzureCredentialOptionsTests()
+        {
+            _command = new(new CodeCommand(), Mock.Of<IServiceProviderFactory>());
+            _parser = new CommandLineBuilder(_command).Build();
+            _options = _command.AzureCredentialOptions;
+        }
+
+        [Fact]
+        public void CredentialTypeOption_Always_HasArityOfExactlyOne()
+        {
+            Assert.Equal(ArgumentArity.ExactlyOne, _options.CredentialTypeOption.Arity);
+        }
+
+        [Fact]
+        public void CredentialTypeOption_Always_IsNotRequired()
+        {
+            Assert.False(_options.CredentialTypeOption.IsRequired);
+        }
 
         [Fact]
         public void ManagedIdentityOption_Always_HasArityOfZeroOrOne()
@@ -56,6 +82,58 @@ namespace Sign.Cli.Test
         public void ClientSecretOption_Always_IsNotRequired()
         {
             Assert.False(_options.ClientSecretOption.IsRequired);
+        }
+
+        [Fact]
+        public void AddOptionsToCommand_Always_AddsAllOptionsToCommand()
+        {
+            var command = new Command("test");
+
+            _options.AddOptionsToCommand(command);
+
+            Assert.Contains(_options.CredentialTypeOption, command.Options);
+            Assert.Contains(_options.ManagedIdentityOption, command.Options);
+            Assert.Contains(_options.TenantIdOption, command.Options);
+            Assert.Contains(_options.ClientIdOption, command.Options);
+            Assert.Contains(_options.ClientSecretOption, command.Options);
+        }
+
+        [Fact]
+        public void CreateDefaultAzureCredentialOptions_WhenNoOptionsAreSpecified_ExcludeOptionsHaveTheCorrectDefaultValues()
+        {
+            ParseResult result = _parser.Parse("azure-key-vault -kvu https://keyvault.test -kvc a b");
+
+            DefaultAzureCredentialOptions credentialOptions = _options.CreateDefaultAzureCredentialOptions(result);
+
+            Assert.True(credentialOptions.ExcludeInteractiveBrowserCredential);
+            Assert.True(credentialOptions.ExcludeSharedTokenCacheCredential);
+            Assert.True(credentialOptions.ExcludeVisualStudioCodeCredential);
+            Assert.False(credentialOptions.ExcludeAzureCliCredential);
+            Assert.False(credentialOptions.ExcludeAzureDeveloperCliCredential);
+            Assert.False(credentialOptions.ExcludeAzurePowerShellCredential);
+            Assert.False(credentialOptions.ExcludeEnvironmentCredential);
+            Assert.False(credentialOptions.ExcludeManagedIdentityCredential);
+            Assert.False(credentialOptions.ExcludeVisualStudioCredential);
+            Assert.False(credentialOptions.ExcludeWorkloadIdentityCredential);
+        }
+
+        [Fact]
+        public void CreateDefaultAzureCredentialOptions_WhenEnvironmentIsSpecified_ExcludeOptionsHaveTheCorrectValues()
+        {
+            ParseResult result = _parser.Parse(@"azure-key-vault -kvu https://keyvault.test -kvc a -act environment b");
+
+            DefaultAzureCredentialOptions credentialOptions = _options.CreateDefaultAzureCredentialOptions(result);
+
+            Assert.True(credentialOptions.ExcludeAzureCliCredential);
+            Assert.True(credentialOptions.ExcludeAzureDeveloperCliCredential);
+            Assert.True(credentialOptions.ExcludeAzurePowerShellCredential);
+            Assert.False(credentialOptions.ExcludeEnvironmentCredential);
+            Assert.True(credentialOptions.ExcludeInteractiveBrowserCredential);
+            Assert.True(credentialOptions.ExcludeManagedIdentityCredential);
+            Assert.True(credentialOptions.ExcludeSharedTokenCacheCredential);
+            Assert.True(credentialOptions.ExcludeVisualStudioCodeCredential);
+            Assert.True(credentialOptions.ExcludeVisualStudioCredential);
+            Assert.True(credentialOptions.ExcludeWorkloadIdentityCredential);
         }
     }
 }

--- a/test/Sign.Cli.Test/AzureCredentialOptionsTests.cs
+++ b/test/Sign.Cli.Test/AzureCredentialOptionsTests.cs
@@ -49,6 +49,12 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
+        public void ManagedIdentityOption_Always_IsHidden()
+        {
+            Assert.True(_options.ManagedIdentityOption.IsHidden);
+        }
+
+        [Fact]
         public void TenantIdOption_Always_HasArityOfExactlyOne()
         {
             Assert.Equal(ArgumentArity.ExactlyOne, _options.TenantIdOption.Arity);


### PR DESCRIPTION
This pull requests adds the `--azure-credential-type` option that was discussed in #724. The easiest to start with was `environment` but it is build so we can add 