### PR TITLE
Added --azure-tenant-id option and made all the --azure-key-vault options obsolete.

### DIFF
--- a/src/Sign.Cli/AzureCredentialOptions.cs
+++ b/src/Sign.Cli/AzureCredentialOptions.cs
@@ -16,23 +16,31 @@ namespace Sign.Cli
         internal Option<string?> CredentialTypeOption { get; } = new Option<string?>(["--azure-credential-type", "-act"], Resources.CredentialTypeOptionDescription).FromAmong(
             AzureCredentialType.AzureCli,
             AzureCredentialType.Environment);
-        internal Option<bool?> ManagedIdentityOption { get; } = new(["--azure-key-vault-managed-identity", "-kvm"], Resources.ManagedIdentityOptionDescription) { IsHidden = true };
-        internal Option<string?> TenantIdOption { get; } = new(["--azure-key-vault-tenant-id", "-kvt"], Resources.TenantIdOptionDescription);
-        internal Option<string?> ClientIdOption { get; } = new(["--azure-key-vault-client-id", "-kvi"], Resources.ClientIdOptionDescription);
-        internal Option<string?> ClientSecretOption { get; } = new(["--azure-key-vault-client-secret", "-kvs"], Resources.ClientSecretOptionDescription);
+        internal Option<string?> TenantIdOption { get; } = new(["--azure-tenant-id", "-ati"], Resources.TenantIdOptionDescription);
+        internal Option<bool?> ObsoleteManagedIdentityOption { get; } = new(["--azure-key-vault-managed-identity", "-kvm"], Resources.ManagedIdentityOptionDescription) { IsHidden = true };
+        internal Option<string?> ObsoleteTenantIdOption { get; } = new(["--azure-key-vault-tenant-id", "-kvt"], Resources.TenantIdOptionDescription) { IsHidden = true };
+        internal Option<string?> ObsoleteClientIdOption { get; } = new(["--azure-key-vault-client-id", "-kvi"], Resources.ClientIdOptionDescription) { IsHidden = true };
+        internal Option<string?> ObsoleteClientSecretOption { get; } = new(["--azure-key-vault-client-secret", "-kvs"], Resources.ClientSecretOptionDescription) { IsHidden = true };
 
         internal void AddOptionsToCommand(Command command)
         {
             command.AddOption(CredentialTypeOption);
-            command.AddOption(ManagedIdentityOption);
             command.AddOption(TenantIdOption);
-            command.AddOption(ClientIdOption);
-            command.AddOption(ClientSecretOption);
+            command.AddOption(ObsoleteManagedIdentityOption);
+            command.AddOption(ObsoleteTenantIdOption);
+            command.AddOption(ObsoleteClientIdOption);
+            command.AddOption(ObsoleteClientSecretOption);
         }
 
         internal DefaultAzureCredentialOptions CreateDefaultAzureCredentialOptions(ParseResult parseResult)
         {
             DefaultAzureCredentialOptions options = new();
+
+            string? tenantId = parseResult.GetValueForOption(TenantIdOption);
+            if (tenantId is not null)
+            {
+                options.TenantId = tenantId;
+            };
 
             string? credentialType = parseResult.GetValueForOption(CredentialTypeOption);
             if (credentialType is not null)
@@ -51,21 +59,22 @@ namespace Sign.Cli
 
         internal TokenCredential? CreateTokenCredential(InvocationContext context)
         {
-            bool? useManagedIdentity = context.ParseResult.GetValueForOption(ManagedIdentityOption);
+            bool? useManagedIdentity = context.ParseResult.GetValueForOption(ObsoleteManagedIdentityOption);
 
             if (useManagedIdentity is not null)
             {
                 context.Console.Out.WriteLine(Resources.ManagedIdentityOptionObsolete);
             }
 
-            string? tenantId = context.ParseResult.GetValueForOption(TenantIdOption);
-            string? clientId = context.ParseResult.GetValueForOption(ClientIdOption);
-            string? secret = context.ParseResult.GetValueForOption(ClientSecretOption);
+            string? tenantId = context.ParseResult.GetValueForOption(ObsoleteTenantIdOption);
+            string? clientId = context.ParseResult.GetValueForOption(ObsoleteClientIdOption);
+            string? secret = context.ParseResult.GetValueForOption(ObsoleteClientSecretOption);
 
             if (!string.IsNullOrEmpty(tenantId) &&
                 !string.IsNullOrEmpty(clientId) &&
                 !string.IsNullOrEmpty(secret))
             {
+                context.Console.Out.WriteLine(Resources.ClientSecretOptionsObsolete);
                 return new ClientSecretCredential(tenantId, clientId, secret);
             }
 

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -106,6 +106,15 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The client secret options are obsolete and should no longer be specified..
+        /// </summary>
+        internal static string ClientSecretOptionsObsolete {
+            get {
+                return ResourceManager.GetString("ClientSecretOptionsObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Sign binaries and containers..
         /// </summary>
         internal static string CodeCommandDescription {

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -132,6 +132,9 @@
   <data name="ClientSecretOptionDescription" xml:space="preserve">
     <value>Client secret to authenticate to Azure.</value>
   </data>
+  <data name="ClientSecretOptionsObsolete" xml:space="preserve">
+    <value>The client secret options are obsolete and should no longer be specified.</value>
+  </data>
   <data name="CodeCommandDescription" xml:space="preserve">
     <value>Sign binaries and containers.</value>
   </data>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -27,6 +27,11 @@
         <target state="new">Client secret to authenticate to Azure.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClientSecretOptionsObsolete">
+        <source>The client secret options are obsolete and should no longer be specified.</source>
+        <target state="new">The client secret options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeCommandDescription">
         <source>Sign binaries and containers.</source>
         <target state="translated">Podepisovat binární soubory a kontejnery.</target>

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -27,6 +27,11 @@
         <target state="new">Client secret to authenticate to Azure.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClientSecretOptionsObsolete">
+        <source>The client secret options are obsolete and should no longer be specified.</source>
+        <target state="new">The client secret options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeCommandDescription">
         <source>Sign binaries and containers.</source>
         <target state="translated">Signieren Sie Binärdateien und Container.</target>

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -27,6 +27,11 @@
         <target state="new">Client secret to authenticate to Azure.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClientSecretOptionsObsolete">
+        <source>The client secret options are obsolete and should no longer be specified.</source>
+        <target state="new">The client secret options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeCommandDescription">
         <source>Sign binaries and containers.</source>
         <target state="translated">Firmar archivos binarios y contenedores.</target>

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -27,6 +27,11 @@
         <target state="new">Client secret to authenticate to Azure.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClientSecretOptionsObsolete">
+        <source>The client secret options are obsolete and should no longer be specified.</source>
+        <target state="new">The client secret options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeCommandDescription">
         <source>Sign binaries and containers.</source>
         <target state="translated">Signer les fichiers binaires et les conteneurs.</target>

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -27,6 +27,11 @@
         <target state="new">Client secret to authenticate to Azure.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClientSecretOptionsObsolete">
+        <source>The client secret options are obsolete and should no longer be specified.</source>
+        <target state="new">The client secret options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeCommandDescription">
         <source>Sign binaries and containers.</source>
         <target state="translated">Consente di firmare file binari e contenitori.</target>

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -27,6 +27,11 @@
         <target state="new">Client secret to authenticate to Azure.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClientSecretOptionsObsolete">
+        <source>The client secret options are obsolete and should no longer be specified.</source>
+        <target state="new">The client secret options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeCommandDescription">
         <source>Sign binaries and containers.</source>
         <target state="translated">バイナリとコンテナーに署名します。</target>

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -27,6 +27,11 @@
         <target state="new">Client secret to authenticate to Azure.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClientSecretOptionsObsolete">
+        <source>The client secret options are obsolete and should no longer be specified.</source>
+        <target state="new">The client secret options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeCommandDescription">
         <source>Sign binaries and containers.</source>
         <target state="translated">이진 파일 및 컨테이너에 서명합니다.</target>

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -27,6 +27,11 @@
         <target state="new">Client secret to authenticate to Azure.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClientSecretOptionsObsolete">
+        <source>The client secret options are obsolete and should no longer be specified.</source>
+        <target state="new">The client secret options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeCommandDescription">
         <source>Sign binaries and containers.</source>
         <target state="translated">Podpisz pliki binarne i kontenery.</target>

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="new">Client secret to authenticate to Azure.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClientSecretOptionsObsolete">
+        <source>The client secret options are obsolete and should no longer be specified.</source>
+        <target state="new">The client secret options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeCommandDescription">
         <source>Sign binaries and containers.</source>
         <target state="translated">Autenticar contêineres e binários.</target>

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -27,6 +27,11 @@
         <target state="new">Client secret to authenticate to Azure.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClientSecretOptionsObsolete">
+        <source>The client secret options are obsolete and should no longer be specified.</source>
+        <target state="new">The client secret options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeCommandDescription">
         <source>Sign binaries and containers.</source>
         <target state="translated">Подписывание двоичных файлов и контейнеров.</target>

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -27,6 +27,11 @@
         <target state="new">Client secret to authenticate to Azure.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClientSecretOptionsObsolete">
+        <source>The client secret options are obsolete and should no longer be specified.</source>
+        <target state="new">The client secret options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeCommandDescription">
         <source>Sign binaries and containers.</source>
         <target state="translated">İkili dosyaları ve kapsayıcıları imzalayın.</target>

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="new">Client secret to authenticate to Azure.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClientSecretOptionsObsolete">
+        <source>The client secret options are obsolete and should no longer be specified.</source>
+        <target state="new">The client secret options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeCommandDescription">
         <source>Sign binaries and containers.</source>
         <target state="translated">对二进制文件和容器进行签名。</target>

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="new">Client secret to authenticate to Azure.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ClientSecretOptionsObsolete">
+        <source>The client secret options are obsolete and should no longer be specified.</source>
+        <target state="new">The client secret options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CodeCommandDescription">
         <source>Sign binaries and containers.</source>
         <target state="translated">簽署二進位檔和容器。</target>

--- a/test/Sign.Cli.Test/AzureCredentialOptionsTests.cs
+++ b/test/Sign.Cli.Test/AzureCredentialOptionsTests.cs
@@ -37,24 +37,6 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
-        public void ManagedIdentityOption_Always_HasArityOfZeroOrOne()
-        {
-            Assert.Equal(ArgumentArity.ZeroOrOne, _options.ManagedIdentityOption.Arity);
-        }
-
-        [Fact]
-        public void ManagedIdentityOption_Always_IsNotRequired()
-        {
-            Assert.False(_options.ManagedIdentityOption.IsRequired);
-        }
-
-        [Fact]
-        public void ManagedIdentityOption_Always_IsHidden()
-        {
-            Assert.True(_options.ManagedIdentityOption.IsHidden);
-        }
-
-        [Fact]
         public void TenantIdOption_Always_HasArityOfExactlyOne()
         {
             Assert.Equal(ArgumentArity.ExactlyOne, _options.TenantIdOption.Arity);
@@ -67,27 +49,75 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
-        public void ClientIdOption_Always_HasArityOfExactlyOne()
+        public void ObsoleteManagedIdentityOption_Always_HasArityOfZeroOrOne()
         {
-            Assert.Equal(ArgumentArity.ExactlyOne, _options.ClientIdOption.Arity);
+            Assert.Equal(ArgumentArity.ZeroOrOne, _options.ObsoleteManagedIdentityOption.Arity);
         }
 
         [Fact]
-        public void ClientIdOption_Always_IsNotRequired()
+        public void ObsoleteManagedIdentityOption_Always_IsNotRequired()
         {
-            Assert.False(_options.ClientIdOption.IsRequired);
+            Assert.False(_options.ObsoleteManagedIdentityOption.IsRequired);
         }
 
         [Fact]
-        public void ClientSecretOption_Always_HasArityOfExactlyOne()
+        public void ObsoleteManagedIdentityOption_Always_IsHidden()
         {
-            Assert.Equal(ArgumentArity.ExactlyOne, _options.ClientSecretOption.Arity);
+            Assert.True(_options.ObsoleteManagedIdentityOption.IsHidden);
         }
 
         [Fact]
-        public void ClientSecretOption_Always_IsNotRequired()
+        public void ObsoleteTenantIdOption_Always_HasArityOfExactlyOne()
         {
-            Assert.False(_options.ClientSecretOption.IsRequired);
+            Assert.Equal(ArgumentArity.ExactlyOne, _options.ObsoleteTenantIdOption.Arity);
+        }
+
+        [Fact]
+        public void ObsoleteTenantIdOption_Always_IsNotRequired()
+        {
+            Assert.False(_options.ObsoleteTenantIdOption.IsRequired);
+        }
+
+        [Fact]
+        public void ObsoleteTenantIdOption_Always_IsHidden()
+        {
+            Assert.True(_options.ObsoleteTenantIdOption.IsHidden);
+        }
+
+        [Fact]
+        public void ObsoleteClientIdOption_Always_HasArityOfExactlyOne()
+        {
+            Assert.Equal(ArgumentArity.ExactlyOne, _options.ObsoleteClientIdOption.Arity);
+        }
+
+        [Fact]
+        public void ObsoleteClientIdOption_Always_IsNotRequired()
+        {
+            Assert.False(_options.ObsoleteClientIdOption.IsRequired);
+        }
+
+        [Fact]
+        public void ObsoleteClientIdOption_Always_IsHidden()
+        {
+            Assert.True(_options.ObsoleteClientIdOption.IsHidden);
+        }
+
+        [Fact]
+        public void ObsoleteClientSecretOption_Always_HasArityOfExactlyOne()
+        {
+            Assert.Equal(ArgumentArity.ExactlyOne, _options.ObsoleteClientSecretOption.Arity);
+        }
+
+        [Fact]
+        public void ObsoleteClientSecretOption_Always_IsNotRequired()
+        {
+            Assert.False(_options.ObsoleteClientSecretOption.IsRequired);
+        }
+
+        [Fact]
+        public void ObsoleteClientSecretOption_Always_IsHidden()
+        {
+            Assert.True(_options.ObsoleteClientSecretOption.IsHidden);
         }
 
         [Fact]
@@ -98,10 +128,20 @@ namespace Sign.Cli.Test
             _options.AddOptionsToCommand(command);
 
             Assert.Contains(_options.CredentialTypeOption, command.Options);
-            Assert.Contains(_options.ManagedIdentityOption, command.Options);
-            Assert.Contains(_options.TenantIdOption, command.Options);
-            Assert.Contains(_options.ClientIdOption, command.Options);
-            Assert.Contains(_options.ClientSecretOption, command.Options);
+            Assert.Contains(_options.ObsoleteManagedIdentityOption, command.Options);
+            Assert.Contains(_options.ObsoleteTenantIdOption, command.Options);
+            Assert.Contains(_options.ObsoleteClientIdOption, command.Options);
+            Assert.Contains(_options.ObsoleteClientSecretOption, command.Options);
+        }
+
+        [Fact]
+        public void CreateDefaultAzureCredentialOptions_WhenTenantIsSpecified_TenantIdIsSet()
+        {
+            ParseResult result = _parser.Parse(@"azure-key-vault -kvu https://keyvault.test -kvc a -ati b c");
+
+            DefaultAzureCredentialOptions credentialOptions = _options.CreateDefaultAzureCredentialOptions(result);
+
+            Assert.Equal("b", credentialOptions.TenantId);
         }
 
         [Fact]


### PR DESCRIPTION
This PR makes all the `--azure-key-vault` obsolete and hidden. When the options are hidden they can still be used but they will no longer show up in the help. And this PR also introduces an option to set the `TenantId` property of the `DefaultAzureCredential`.