### PR TITLE
Added azure-cli credential type.

### DIFF
--- a/src/Sign.Cli/AzureCredentialOptions.cs
+++ b/src/Sign.Cli/AzureCredentialOptions.cs
@@ -14,6 +14,7 @@ namespace Sign.Cli
     internal sealed class AzureCredentialOptions
     {
         internal Option<string?> CredentialTypeOption { get; } = new Option<string?>(["-act", "--azure-credential-type"], Resources.CredentialTypeOptionDescription).FromAmong(
+            AzureCredentialType.AzureCli,
             AzureCredentialType.Environment);
         internal Option<bool?> ManagedIdentityOption { get; } = new(["-kvm", "--azure-key-vault-managed-identity"], Resources.ManagedIdentityOptionDescription) { IsHidden = true };
         internal Option<string?> TenantIdOption { get; } = new(["-kvt", "--azure-key-vault-tenant-id"], Resources.TenantIdOptionDescription);
@@ -36,7 +37,7 @@ namespace Sign.Cli
             string? credentialType = parseResult.GetValueForOption(CredentialTypeOption);
             if (credentialType is not null)
             {
-                options.ExcludeAzureCliCredential = true;
+                options.ExcludeAzureCliCredential = credentialType != AzureCredentialType.AzureCli;
                 options.ExcludeAzureDeveloperCliCredential = true;
                 options.ExcludeAzurePowerShellCredential = true;
                 options.ExcludeEnvironmentCredential = credentialType != AzureCredentialType.Environment;

--- a/src/Sign.Cli/AzureCredentialType.cs
+++ b/src/Sign.Cli/AzureCredentialType.cs
@@ -6,6 +6,7 @@ namespace Sign.Cli
 {
     internal static class AzureCredentialType
     {
+        public const string AzureCli = "azure-cli";
         public const string Environment = "environment";
     }
 }

--- a/test/Sign.Cli.Test/AzureCredentialOptionsTests.cs
+++ b/test/Sign.Cli.Test/AzureCredentialOptionsTests.cs
@@ -124,7 +124,7 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
-        public void CreateDefaultAzureCredentialOptions_WhenEnvironmentIsSpecified_ExcludeOptionsHaveTheCorrectValues()
+        public void CreateDefaultAzureCredentialOptions_WhenEnvironmentCredentialTypeIsSpecified_ExcludeOptionsHaveTheCorrectValues()
         {
             ParseResult result = _parser.Parse(@"azure-key-vault -kvu https://keyvault.test -kvc a -act environment b");
 
@@ -134,6 +134,25 @@ namespace Sign.Cli.Test
             Assert.True(credentialOptions.ExcludeAzureDeveloperCliCredential);
             Assert.True(credentialOptions.ExcludeAzurePowerShellCredential);
             Assert.False(credentialOptions.ExcludeEnvironmentCredential);
+            Assert.True(credentialOptions.ExcludeInteractiveBrowserCredential);
+            Assert.True(credentialOptions.ExcludeManagedIdentityCredential);
+            Assert.True(credentialOptions.ExcludeSharedTokenCacheCredential);
+            Assert.True(credentialOptions.ExcludeVisualStudioCodeCredential);
+            Assert.True(credentialOptions.ExcludeVisualStudioCredential);
+            Assert.True(credentialOptions.ExcludeWorkloadIdentityCredential);
+        }
+
+        [Fact]
+        public void CreateDefaultAzureCredentialOptions_WhenAzureCliCredentialTypeIsSpecified_ExcludeOptionsHaveTheCorrectValues()
+        {
+            ParseResult result = _parser.Parse(@"azure-key-vault -kvu https://keyvault.test -kvc a -act azure-cli b");
+
+            DefaultAzureCredentialOptions credentialOptions = _options.CreateDefaultAzureCredentialOptions(result);
+
+            Assert.False(credentialOptions.ExcludeAzureCliCredential);
+            Assert.True(credentialOptions.ExcludeAzureDeveloperCliCredential);
+            Assert.True(credentialOptions.ExcludeAzurePowerShellCredential);
+            Assert.True(credentialOptions.ExcludeEnvironmentCredential);
             Assert.True(credentialOptions.ExcludeInteractiveBrowserCredential);
             Assert.True(credentialOptions.ExcludeManagedIdentityCredential);
             Assert.True(credentialOptions.ExcludeSharedTokenCacheCredential);


### PR DESCRIPTION
This PR adds `azure-cli` as a credential type. Having this options results in small speedup improvement because only the  `AzureCliCredential` type will be used by `DefaultAzureCredential`.  Being able to specify this credential type will be useful when `az login` is used in a pipeline.