### PR TITLE
Added managed-identity credential type.

### DIFF
--- a/src/Sign.Cli/AzureCredentialOptions.cs
+++ b/src/Sign.Cli/AzureCredentialOptions.cs
@@ -15,8 +15,11 @@ namespace Sign.Cli
     {
         internal Option<string?> CredentialTypeOption { get; } = new Option<string?>(["--azure-credential-type", "-act"], Resources.CredentialTypeOptionDescription).FromAmong(
             AzureCredentialType.AzureCli,
-            AzureCredentialType.Environment);
+            AzureCredentialType.Environment,
+            AzureCredentialType.ManagedIdentity);
         internal Option<string?> TenantIdOption { get; } = new(["--azure-tenant-id", "-ati"], Resources.TenantIdOptionDescription);
+        internal Option<string?> ManagedIdentityClientIdOption = new(["--managed-identity-client-id", "-mici"], Resources.ManagedIdentityClientIdOptionDescription);
+        internal Option<string?> ManagedIdentityResourceIdOption = new(["--managed-identity-resource-id", "-miri"], Resources.ManagedIdentityResourceIdOptionDescription);
         internal Option<bool?> ObsoleteManagedIdentityOption { get; } = new(["--azure-key-vault-managed-identity", "-kvm"], Resources.ManagedIdentityOptionDescription) { IsHidden = true };
         internal Option<string?> ObsoleteTenantIdOption { get; } = new(["--azure-key-vault-tenant-id", "-kvt"], Resources.TenantIdOptionDescription) { IsHidden = true };
         internal Option<string?> ObsoleteClientIdOption { get; } = new(["--azure-key-vault-client-id", "-kvi"], Resources.ClientIdOptionDescription) { IsHidden = true };
@@ -26,6 +29,8 @@ namespace Sign.Cli
         {
             command.AddOption(CredentialTypeOption);
             command.AddOption(TenantIdOption);
+            command.AddOption(ManagedIdentityClientIdOption);
+            command.AddOption(ManagedIdentityResourceIdOption);
             command.AddOption(ObsoleteManagedIdentityOption);
             command.AddOption(ObsoleteTenantIdOption);
             command.AddOption(ObsoleteClientIdOption);
@@ -40,7 +45,19 @@ namespace Sign.Cli
             if (tenantId is not null)
             {
                 options.TenantId = tenantId;
-            };
+            }
+
+            string? managedIdentityClientId = parseResult.GetValueForOption(ManagedIdentityClientIdOption);
+            if (managedIdentityClientId is not null)
+            {
+                options.ManagedIdentityClientId = managedIdentityClientId;
+            }
+
+            string? managedIdentityResourceId = parseResult.GetValueForOption(ManagedIdentityResourceIdOption);
+            if (managedIdentityResourceId is not null)
+            {
+                options.ManagedIdentityResourceId = new ResourceIdentifier(managedIdentityResourceId);
+            }
 
             string? credentialType = parseResult.GetValueForOption(CredentialTypeOption);
             if (credentialType is not null)
@@ -49,7 +66,7 @@ namespace Sign.Cli
                 options.ExcludeAzureDeveloperCliCredential = true;
                 options.ExcludeAzurePowerShellCredential = true;
                 options.ExcludeEnvironmentCredential = credentialType != AzureCredentialType.Environment;
-                options.ExcludeManagedIdentityCredential = true;
+                options.ExcludeManagedIdentityCredential = credentialType != AzureCredentialType.ManagedIdentity;
                 options.ExcludeVisualStudioCredential = true;
                 options.ExcludeWorkloadIdentityCredential = true;
             }

--- a/src/Sign.Cli/AzureCredentialType.cs
+++ b/src/Sign.Cli/AzureCredentialType.cs
@@ -8,5 +8,6 @@ namespace Sign.Cli
     {
         public const string AzureCli = "azure-cli";
         public const string Environment = "environment";
+        public const string ManagedIdentity = "managed-identity";
     }
 }

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -232,6 +232,15 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The client id of a user assigned ManagedIdentity..
+        /// </summary>
+        internal static string ManagedIdentityClientIdOptionDescription {
+            get {
+                return ResourceManager.GetString("ManagedIdentityClientIdOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Managed identity to authenticate to Azure Key. (obsolete).
         /// </summary>
         internal static string ManagedIdentityOptionDescription {
@@ -246,6 +255,15 @@ namespace Sign.Cli {
         internal static string ManagedIdentityOptionObsolete {
             get {
                 return ResourceManager.GetString("ManagedIdentityOptionObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The resource id of a user assigned ManagedIdentity..
+        /// </summary>
+        internal static string ManagedIdentityResourceIdOptionDescription {
+            get {
+                return ResourceManager.GetString("ManagedIdentityResourceIdOptionDescription", resourceCulture);
             }
         }
         

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -180,11 +180,17 @@
     <value>Invalid value for {0}. The value must be an absolute HTTP or HTTPS URL.</value>
     <comment>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</comment>
   </data>
+  <data name="ManagedIdentityClientIdOptionDescription" xml:space="preserve">
+    <value>The client id of a user assigned ManagedIdentity.</value>
+  </data>
   <data name="ManagedIdentityOptionDescription" xml:space="preserve">
     <value>Managed identity to authenticate to Azure Key. (obsolete)</value>
   </data>
   <data name="ManagedIdentityOptionObsolete" xml:space="preserve">
     <value>The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</value>
+  </data>
+  <data name="ManagedIdentityResourceIdOptionDescription" xml:space="preserve">
+    <value>The resource id of a user assigned ManagedIdentity.</value>
   </data>
   <data name="MaxConcurrencyOptionDescription" xml:space="preserve">
     <value>Maximum concurrency.</value>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Neplatná hodnota pro {0}. Hodnota musí být absolutní adresa URL protokolu HTTP nebo HTTPS.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="ManagedIdentityClientIdOptionDescription">
+        <source>The client id of a user assigned ManagedIdentity.</source>
+        <target state="new">The client id of a user assigned ManagedIdentity.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key. (obsolete)</source>
         <target state="new">Managed identity to authenticate to Azure Key. (obsolete)</target>
@@ -105,6 +110,11 @@
       <trans-unit id="ManagedIdentityOptionObsolete">
         <source>The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</source>
         <target state="new">The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityResourceIdOptionDescription">
+        <source>The resource id of a user assigned ManagedIdentity.</source>
+        <target state="new">The resource id of a user assigned ManagedIdentity.</target>
         <note />
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Ungültiger Wert für {0}. Der Wert muss eine absolute HTTP- oder HTTPS-URL sein.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="ManagedIdentityClientIdOptionDescription">
+        <source>The client id of a user assigned ManagedIdentity.</source>
+        <target state="new">The client id of a user assigned ManagedIdentity.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key. (obsolete)</source>
         <target state="translated">Verwaltete Identität für die Authentifizierung bei Azure Key. (veraltet)</target>
@@ -105,6 +110,11 @@
       <trans-unit id="ManagedIdentityOptionObsolete">
         <source>The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</source>
         <target state="translated">Die Optionen „-kvm“ und „--azure-key-vault-managed-identity“ sind veraltet und sollten nicht mehr angegeben werden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityResourceIdOptionDescription">
+        <source>The resource id of a user assigned ManagedIdentity.</source>
+        <target state="new">The resource id of a user assigned ManagedIdentity.</target>
         <note />
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Valor no válido para {0}. El valor debe ser una dirección URL HTTP o HTTPS absoluta.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="ManagedIdentityClientIdOptionDescription">
+        <source>The client id of a user assigned ManagedIdentity.</source>
+        <target state="new">The client id of a user assigned ManagedIdentity.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key. (obsolete)</source>
         <target state="translated">Identidad administrada para autenticarse en Azure Key. (obsoleto)</target>
@@ -105,6 +110,11 @@
       <trans-unit id="ManagedIdentityOptionObsolete">
         <source>The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</source>
         <target state="translated">Las opciones -kvm y --azure-key-vault-managed-identity están obsoletas y ya no deben especificarse.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityResourceIdOptionDescription">
+        <source>The resource id of a user assigned ManagedIdentity.</source>
+        <target state="new">The resource id of a user assigned ManagedIdentity.</target>
         <note />
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Valeur non valide pour {0}. La valeur doit être une URL HTTP ou HTTPS absolue.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="ManagedIdentityClientIdOptionDescription">
+        <source>The client id of a user assigned ManagedIdentity.</source>
+        <target state="new">The client id of a user assigned ManagedIdentity.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key. (obsolete)</source>
         <target state="new">Managed identity to authenticate to Azure Key. (obsolete)</target>
@@ -105,6 +110,11 @@
       <trans-unit id="ManagedIdentityOptionObsolete">
         <source>The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</source>
         <target state="new">The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityResourceIdOptionDescription">
+        <source>The resource id of a user assigned ManagedIdentity.</source>
+        <target state="new">The resource id of a user assigned ManagedIdentity.</target>
         <note />
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Valore non valido per {0}. Il valore deve essere un URL HTTP o HTTPS assoluto.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="ManagedIdentityClientIdOptionDescription">
+        <source>The client id of a user assigned ManagedIdentity.</source>
+        <target state="new">The client id of a user assigned ManagedIdentity.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key. (obsolete)</source>
         <target state="new">Managed identity to authenticate to Azure Key. (obsolete)</target>
@@ -105,6 +110,11 @@
       <trans-unit id="ManagedIdentityOptionObsolete">
         <source>The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</source>
         <target state="new">The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityResourceIdOptionDescription">
+        <source>The resource id of a user assigned ManagedIdentity.</source>
+        <target state="new">The resource id of a user assigned ManagedIdentity.</target>
         <note />
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -97,6 +97,11 @@
         <target state="translated">{0}の値が無効です。値は HTTP または HTTPS の絶対 URL である必要があります。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="ManagedIdentityClientIdOptionDescription">
+        <source>The client id of a user assigned ManagedIdentity.</source>
+        <target state="new">The client id of a user assigned ManagedIdentity.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key. (obsolete)</source>
         <target state="new">Managed identity to authenticate to Azure Key. (obsolete)</target>
@@ -105,6 +110,11 @@
       <trans-unit id="ManagedIdentityOptionObsolete">
         <source>The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</source>
         <target state="new">The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityResourceIdOptionDescription">
+        <source>The resource id of a user assigned ManagedIdentity.</source>
+        <target state="new">The resource id of a user assigned ManagedIdentity.</target>
         <note />
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -97,6 +97,11 @@
         <target state="translated">{0}에 대한 값이 잘못되었습니다. 값은 절대 HTTP 또는 HTTPS URL이어야 합니다.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="ManagedIdentityClientIdOptionDescription">
+        <source>The client id of a user assigned ManagedIdentity.</source>
+        <target state="new">The client id of a user assigned ManagedIdentity.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key. (obsolete)</source>
         <target state="translated">Azure Key에 인증할 관리 ID입니다. (사용되지 않음)</target>
@@ -105,6 +110,11 @@
       <trans-unit id="ManagedIdentityOptionObsolete">
         <source>The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</source>
         <target state="translated">-kvm 및 --azure-key-vault-managed-identity 옵션은 사용되지 않으므로 더 이상 지정하지 않아야 합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityResourceIdOptionDescription">
+        <source>The resource id of a user assigned ManagedIdentity.</source>
+        <target state="new">The resource id of a user assigned ManagedIdentity.</target>
         <note />
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Nieprawidłowa wartość dla {0}. Wartość musi być bezwzględnym adresem URL protokołu HTTP lub HTTPS.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="ManagedIdentityClientIdOptionDescription">
+        <source>The client id of a user assigned ManagedIdentity.</source>
+        <target state="new">The client id of a user assigned ManagedIdentity.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key. (obsolete)</source>
         <target state="new">Managed identity to authenticate to Azure Key. (obsolete)</target>
@@ -105,6 +110,11 @@
       <trans-unit id="ManagedIdentityOptionObsolete">
         <source>The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</source>
         <target state="new">The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityResourceIdOptionDescription">
+        <source>The resource id of a user assigned ManagedIdentity.</source>
+        <target state="new">The resource id of a user assigned ManagedIdentity.</target>
         <note />
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Valor inválido para {0}. O valor deve ser uma URL HTTP ou HTTPS absoluta.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="ManagedIdentityClientIdOptionDescription">
+        <source>The client id of a user assigned ManagedIdentity.</source>
+        <target state="new">The client id of a user assigned ManagedIdentity.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key. (obsolete)</source>
         <target state="new">Managed identity to authenticate to Azure Key. (obsolete)</target>
@@ -105,6 +110,11 @@
       <trans-unit id="ManagedIdentityOptionObsolete">
         <source>The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</source>
         <target state="new">The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityResourceIdOptionDescription">
+        <source>The resource id of a user assigned ManagedIdentity.</source>
+        <target state="new">The resource id of a user assigned ManagedIdentity.</target>
         <note />
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -97,6 +97,11 @@
         <target state="translated">Недопустимое значение для {0}. Значение должно быть абсолютным URL-адресом HTTP или HTTPS.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="ManagedIdentityClientIdOptionDescription">
+        <source>The client id of a user assigned ManagedIdentity.</source>
+        <target state="new">The client id of a user assigned ManagedIdentity.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key. (obsolete)</source>
         <target state="translated">Управляемое удостоверение для проверки подлинности в Azure Key. (устарело)</target>
@@ -105,6 +110,11 @@
       <trans-unit id="ManagedIdentityOptionObsolete">
         <source>The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</source>
         <target state="translated">Параметры -kvm и --azure-key-vault-managed-identity устарели и больше не должны указываться.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityResourceIdOptionDescription">
+        <source>The resource id of a user assigned ManagedIdentity.</source>
+        <target state="new">The resource id of a user assigned ManagedIdentity.</target>
         <note />
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -97,6 +97,11 @@
         <target state="translated">{0} için geçersiz değer. Değer mutlak bir HTTP veya HTTPS URL’si olmalıdır.</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="ManagedIdentityClientIdOptionDescription">
+        <source>The client id of a user assigned ManagedIdentity.</source>
+        <target state="new">The client id of a user assigned ManagedIdentity.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key. (obsolete)</source>
         <target state="new">Managed identity to authenticate to Azure Key. (obsolete)</target>
@@ -105,6 +110,11 @@
       <trans-unit id="ManagedIdentityOptionObsolete">
         <source>The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</source>
         <target state="new">The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityResourceIdOptionDescription">
+        <source>The resource id of a user assigned ManagedIdentity.</source>
+        <target state="new">The resource id of a user assigned ManagedIdentity.</target>
         <note />
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -97,6 +97,11 @@
         <target state="translated">{0} 的值无效。值必须是绝对 HTTP 或 HTTPS URL。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="ManagedIdentityClientIdOptionDescription">
+        <source>The client id of a user assigned ManagedIdentity.</source>
+        <target state="new">The client id of a user assigned ManagedIdentity.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key. (obsolete)</source>
         <target state="new">Managed identity to authenticate to Azure Key. (obsolete)</target>
@@ -105,6 +110,11 @@
       <trans-unit id="ManagedIdentityOptionObsolete">
         <source>The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</source>
         <target state="new">The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityResourceIdOptionDescription">
+        <source>The resource id of a user assigned ManagedIdentity.</source>
+        <target state="new">The resource id of a user assigned ManagedIdentity.</target>
         <note />
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -97,6 +97,11 @@
         <target state="translated">{0} 的值無效。值必須是絕對 HTTP 或 HTTPS URL。</target>
         <note>{NumberedPlaceholder="{0}"} is an option name (e.g.:  --timestamp-url) and should not be localized.</note>
       </trans-unit>
+      <trans-unit id="ManagedIdentityClientIdOptionDescription">
+        <source>The client id of a user assigned ManagedIdentity.</source>
+        <target state="new">The client id of a user assigned ManagedIdentity.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ManagedIdentityOptionDescription">
         <source>Managed identity to authenticate to Azure Key. (obsolete)</source>
         <target state="translated">要向 Azure Key 進行驗證的受控識別。(已過時)</target>
@@ -105,6 +110,11 @@
       <trans-unit id="ManagedIdentityOptionObsolete">
         <source>The -kvm and --azure-key-vault-managed-identity options are obsolete and should no longer be specified.</source>
         <target state="translated">-kvm 和 --azure-key-vault-managed-identity 選項已過時，不應再指定。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManagedIdentityResourceIdOptionDescription">
+        <source>The resource id of a user assigned ManagedIdentity.</source>
+        <target state="new">The resource id of a user assigned ManagedIdentity.</target>
         <note />
       </trans-unit>
       <trans-unit id="MaxConcurrencyOptionDescription">

--- a/test/Sign.Cli.Test/AzureCredentialOptionsTests.cs
+++ b/test/Sign.Cli.Test/AzureCredentialOptionsTests.cs
@@ -49,6 +49,30 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
+        public void ManagedIdentityClientIdOption_Always_HasArityOfExactlyOne()
+        {
+            Assert.Equal(ArgumentArity.ExactlyOne, _options.ManagedIdentityClientIdOption.Arity);
+        }
+
+        [Fact]
+        public void ManagedIdentityClientIdOption_Always_IsNotRequired()
+        {
+            Assert.False(_options.ManagedIdentityClientIdOption.IsRequired);
+        }
+
+        [Fact]
+        public void ManagedIdentityResourceIdOption_Always_HasArityOfExactlyOne()
+        {
+            Assert.Equal(ArgumentArity.ExactlyOne, _options.ManagedIdentityResourceIdOption.Arity);
+        }
+
+        [Fact]
+        public void ManagedIdentityResourceIdOption_Always_IsNotRequired()
+        {
+            Assert.False(_options.ManagedIdentityResourceIdOption.IsRequired);
+        }
+
+        [Fact]
         public void ObsoleteManagedIdentityOption_Always_HasArityOfZeroOrOne()
         {
             Assert.Equal(ArgumentArity.ZeroOrOne, _options.ObsoleteManagedIdentityOption.Arity);
@@ -128,6 +152,9 @@ namespace Sign.Cli.Test
             _options.AddOptionsToCommand(command);
 
             Assert.Contains(_options.CredentialTypeOption, command.Options);
+            Assert.Contains(_options.TenantIdOption, command.Options);
+            Assert.Contains(_options.ManagedIdentityClientIdOption, command.Options);
+            Assert.Contains(_options.ManagedIdentityResourceIdOption, command.Options);
             Assert.Contains(_options.ObsoleteManagedIdentityOption, command.Options);
             Assert.Contains(_options.ObsoleteTenantIdOption, command.Options);
             Assert.Contains(_options.ObsoleteClientIdOption, command.Options);
@@ -135,13 +162,33 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
-        public void CreateDefaultAzureCredentialOptions_WhenTenantIsSpecified_TenantIdIsSet()
+        public void CreateDefaultAzureCredentialOptions_WhenTenantIdIsSpecified_TenantIdIsSet()
         {
             ParseResult result = _parser.Parse(@"azure-key-vault -kvu https://keyvault.test -kvc a -ati b c");
 
             DefaultAzureCredentialOptions credentialOptions = _options.CreateDefaultAzureCredentialOptions(result);
 
             Assert.Equal("b", credentialOptions.TenantId);
+        }
+
+        [Fact]
+        public void CreateDefaultAzureCredentialOptions_WhenManagedIdentityClientIdIsSpecified_ManagedIdentityClientIdIsSet()
+        {
+            ParseResult result = _parser.Parse(@"azure-key-vault -kvu https://keyvault.test -kvc a -mici b c");
+
+            DefaultAzureCredentialOptions credentialOptions = _options.CreateDefaultAzureCredentialOptions(result);
+
+            Assert.Equal("b", credentialOptions.ManagedIdentityClientId);
+        }
+
+        [Fact]
+        public void CreateDefaultAzureCredentialOptions_WhenManagedIdentityResourceIdIsSpecified_ManagedIdentityResourceIdIsSet()
+        {
+            ParseResult result = _parser.Parse(@"azure-key-vault -kvu https://keyvault.test -kvc a -miri b c");
+
+            DefaultAzureCredentialOptions credentialOptions = _options.CreateDefaultAzureCredentialOptions(result);
+
+            Assert.Equal("b", credentialOptions.ManagedIdentityResourceId);
         }
 
         [Fact]
@@ -164,6 +211,25 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
+        public void CreateDefaultAzureCredentialOptions_WhenAzureCliCredentialTypeIsSpecified_ExcludeOptionsHaveTheCorrectValues()
+        {
+            ParseResult result = _parser.Parse(@"azure-key-vault -kvu https://keyvault.test -kvc a -act azure-cli b");
+
+            DefaultAzureCredentialOptions credentialOptions = _options.CreateDefaultAzureCredentialOptions(result);
+
+            Assert.False(credentialOptions.ExcludeAzureCliCredential);
+            Assert.True(credentialOptions.ExcludeAzureDeveloperCliCredential);
+            Assert.True(credentialOptions.ExcludeAzurePowerShellCredential);
+            Assert.True(credentialOptions.ExcludeEnvironmentCredential);
+            Assert.True(credentialOptions.ExcludeInteractiveBrowserCredential);
+            Assert.True(credentialOptions.ExcludeManagedIdentityCredential);
+            Assert.True(credentialOptions.ExcludeSharedTokenCacheCredential);
+            Assert.True(credentialOptions.ExcludeVisualStudioCodeCredential);
+            Assert.True(credentialOptions.ExcludeVisualStudioCredential);
+            Assert.True(credentialOptions.ExcludeWorkloadIdentityCredential);
+        }
+
+        [Fact]
         public void CreateDefaultAzureCredentialOptions_WhenEnvironmentCredentialTypeIsSpecified_ExcludeOptionsHaveTheCorrectValues()
         {
             ParseResult result = _parser.Parse(@"azure-key-vault -kvu https://keyvault.test -kvc a -act environment b");
@@ -183,18 +249,18 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
-        public void CreateDefaultAzureCredentialOptions_WhenAzureCliCredentialTypeIsSpecified_ExcludeOptionsHaveTheCorrectValues()
+        public void CreateDefaultAzureCredentialOptions_WhenManagedIdentityCredentialTypeIsSpecified_ExcludeOptionsHaveTheCorrectValues()
         {
-            ParseResult result = _parser.Parse(@"azure-key-vault -kvu https://keyvault.test -kvc a -act azure-cli b");
+            ParseResult result = _parser.Parse(@"azure-key-vault -kvu https://keyvault.test -kvc a -act managed-identity b");
 
             DefaultAzureCredentialOptions credentialOptions = _options.CreateDefaultAzureCredentialOptions(result);
 
-            Assert.False(credentialOptions.ExcludeAzureCliCredential);
+            Assert.True(credentialOptions.ExcludeAzureCliCredential);
             Assert.True(credentialOptions.ExcludeAzureDeveloperCliCredential);
             Assert.True(credentialOptions.ExcludeAzurePowerShellCredential);
             Assert.True(credentialOptions.ExcludeEnvironmentCredential);
             Assert.True(credentialOptions.ExcludeInteractiveBrowserCredential);
-            Assert.True(credentialOptions.ExcludeManagedIdentityCredential);
+            Assert.False(credentialOptions.ExcludeManagedIdentityCredential);
             Assert.True(credentialOptions.ExcludeSharedTokenCacheCredential);
             Assert.True(credentialOptions.ExcludeVisualStudioCodeCredential);
             Assert.True(credentialOptions.ExcludeVisualStudioCredential);


### PR DESCRIPTION
This PR adds the managed-identity credential type. This also adds two new option that are specific for a managed identity in the `DefaultAzureCredentialOptions`. I can take those out if the team thinks that it is too early to add those.