### PR TITLE
Fix ClickOnce signing using Trusted Signing

### DIFF
--- a/src/Sign.Core/Native/mansign2.cs
+++ b/src/Sign.Core/Native/mansign2.cs
@@ -5,7 +5,6 @@
 #define RUNTIME_TYPE_NETCORE
 
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
@@ -13,7 +12,6 @@ using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.Xml;
 using System.Text;
 using System.Xml;
-using RSAKeyVaultProvider;
 using _FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 
 #nullable disable
@@ -885,11 +883,6 @@ namespace System.Deployment.Internal.CodeSigning
             if (signatureParent == null)
             {
                 throw new CryptographicException(Win32.TRUST_E_SUBJECT_FORM_UNKNOWN);
-            }
-
-            if (!(signer.StrongNameKey is RSA))
-            {
-                throw new NotSupportedException();
             }
 
             // Setup up XMLDSIG engine.

--- a/src/Sign.Core/Native/mansign2.cs
+++ b/src/Sign.Core/Native/mansign2.cs
@@ -660,16 +660,9 @@ namespace System.Deployment.Internal.CodeSigning
         private static void AuthenticodeSignLicenseDom(XmlDocument licenseDom, CmiManifestSigner2 signer, string timeStampUrl, bool disallowMansignTimestampFallback)
         {
             // Make sure it is RSA, as this is the only one Fusion will support.
-            // HACK: do this in a better way
-            RSA rsaPrivateKey = null;
-            if (signer.Certificate.HasPrivateKey)
-            {
-                rsaPrivateKey = signer.Certificate.GetRSAPrivateKey();
-            }
-            else if (signer.StrongNameKey is RSAKeyVault provider)
-            {
-                rsaPrivateKey = provider;
-            }
+            RSA rsaPrivateKey = signer.Certificate.HasPrivateKey
+                ? signer.Certificate.GetRSAPrivateKey()
+                : signer.StrongNameKey as RSA;
 
             if (rsaPrivateKey == null)
             {

--- a/test/Sign.Core.Test/Native/SignedCmiManifest2Tests.cs
+++ b/test/Sign.Core.Test/Native/SignedCmiManifest2Tests.cs
@@ -28,6 +28,7 @@ namespace Sign.Core.Test
         public void Sign_Never_GeneratesSha1MessageImprint()
         {
             using (X509Certificate2 certificate = CreateCertificate())
+            using (X509Certificate2 publicKeyCertificate = new(certificate.Export(X509ContentType.Cert)))
             using (RSA privateKey = certificate.GetRSAPrivateKey()!)
             {
                 XmlDocument manifest = new() { PreserveWhitespace = true };
@@ -35,14 +36,14 @@ namespace Sign.Core.Test
                 using (StringReader reader = new(@$"<?xml version=""1.0"" encoding=""utf-8""?>
     <asmv1:assembly xsi:schemaLocation=""urn:schemas-microsoft-com:asm.v1 assembly.adaptive.xsd"" manifestVersion=""1.0"" xmlns:asmv1=""urn:schemas-microsoft-com:asm.v1"" xmlns=""urn:schemas-microsoft-com:asm.v2"" xmlns:asmv2=""urn:schemas-microsoft-com:asm.v2"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:co.v1=""urn:schemas-microsoft-com:clickonce.v1"" xmlns:asmv3=""urn:schemas-microsoft-com:asm.v3"" xmlns:dsig=""http://www.w3.org/2000/09/xmldsig#"" xmlns:co.v2=""urn:schemas-microsoft-com:clickonce.v2"">
       <assemblyIdentity name=""WinFormsApp.application"" version=""1.0.0.0"" publicKeyToken=""46deb9a9283e4567"" language=""neutral"" processorArchitecture=""msil"" xmlns=""urn:schemas-microsoft-com:asm.v1"" />
-      <publisherIdentity name=""{certificate.Subject}"" />
+      <publisherIdentity name=""{publicKeyCertificate.Subject}"" />
     </asmv1:assembly>"))
                 {
                     manifest.Load(reader);
                 }
 
                 SignedCmiManifest2 signedCmiManifest = new(manifest);
-                CmiManifestSigner2 signer = new(privateKey, certificate)
+                CmiManifestSigner2 signer = new(privateKey, publicKeyCertificate)
                 {
                     Flag = CmiManifestSignerFlag.DontReplacePublicKeyToken
                 };


### PR DESCRIPTION
This PR fixes the issue that was reported in #735. There was an explicit cast to `RSAKeyVault` but this can be changed to `RSA` instead. I have updated a unit test to hit this "new" path and also removed an unnecessary duplicate check.