### PR TITLE
refactor get certificate async function to use get cert chain operation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Core" Version="1.38.0" />
-    <PackageVersion Include="Azure.CodeSigning.Sdk" Version="0.1.96" />
+    <PackageVersion Include="Azure.CodeSigning.Sdk" Version="0.1.106" />
     <PackageVersion Include="Azure.Identity" Version="1.11.4" />
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
     <PackageVersion Include="AzureSign.Core" Version="4.0.1" />


### PR DESCRIPTION
Hey,

Given that I added the get certificate chain operation to the nuget.org [azure.codesigning.sdk](https://www.nuget.org/packages/Azure.CodeSigning.Sdk/0.1.106). I thought it would be appropriate, given that trusted signing charges per signature, to create this PR.  This also improves the performance of the signing step.

<img width="858" alt="image" src="https://github.com/dotnet/sign/assets/5913008/36e6248d-1230-435e-926b-0cf637274999">


![image](https://github.com/dotnet/sign/assets/5913008/a5772a14-3663-48c0-bdb8-963f288ac2db)


Aside from the usual live test, I don't see any integration tests so I didn't dared adding those, but if you would like me to, please let me know.

cc: @dlemstra 