### PR TITLE
Resolve CG alert

### DIFF
--- a/src/Sign.SignatureProviders.KeyVault/Sign.SignatureProviders.KeyVault.csproj
+++ b/src/Sign.SignatureProviders.KeyVault/Sign.SignatureProviders.KeyVault.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Core" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" PrivateAssets="analyzers;build;compile;contentfiles" />


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/748.

This change uses the version ([1.42.0](https://github.com/dotnet/sign/blob/1786400add5fabcb7135c4213637b47080bb1bc5/Directory.Packages.props#L8)) of Azure.Core that is defined in Directory.Packages.props to override the version RSAKeyVaultProvider brings in.  This should resolve a CG alert.

CC @clairernovotny, @javierdlg