### PR TITLE
Use Azure Key Vault's RSA implementation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,9 +7,7 @@
     <PackageVersion Include="Azure.CodeSigning.Sdk" Version="0.1.106" />
     <PackageVersion Include="Azure.Core" Version="1.42.0" />
     <PackageVersion Include="Azure.Identity" Version="1.12.0" />
-    <!-- Lift this dependency from NuGetKeyVaultSignTool.Core to get the latest version. -->
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
-    <!-- Lift this dependency from NuGetKeyVaultSignTool.Core to get the latest version. -->
     <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.6.0" />
     <PackageVersion Include="AzureSign.Core" Version="4.0.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
@@ -24,12 +22,8 @@
     <!-- Only use release versions.  Pre-release versions are signed with an untrusted certificate. -->
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1" />
     <PackageVersion Include="Moq" Version="4.18.4" />
-    <!-- Lift this dependency from NuGetKeyVaultSignTool.Core to get the latest version. -->
     <PackageVersion Include="NuGet.Packaging" Version="6.10.1" />
-    <!-- Lift this dependency from NuGetKeyVaultSignTool.Core to get the latest version. -->
     <PackageVersion Include="NuGet.Protocol" Version="6.10.1" />
-    <PackageVersion Include="NuGetKeyVaultSignTool.Core" Version="3.2.3" />
-    <PackageVersion Include="RSAKeyVaultProvider" Version="2.1.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.1" />

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -149,3 +149,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 Available at https://github.com/vcsjones/OpenOpcSignTool/blob/main/LICENSE
+
+
+License notice for NuGetKeyVaultSignTool
+-------------------------------
+
+The MIT License (MIT)
+
+Copyright (c) Claire Novotny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+Available at https://github.com/novotnyllc/NuGetKeyVaultSignTool/blob/main/LICENSE

--- a/src/Sign.Core/Sign.Core.csproj
+++ b/src/Sign.Core/Sign.Core.csproj
@@ -6,9 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Security.KeyVault.Keys" PrivateAssets="analyzers;build;compile;contentfiles" />
-    <PackageReference Include="Azure.Security.KeyVault.Certificates" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="AzureSign.Core" PrivateAssets="analyzers;build;compile;contentfiles" />
+    <PackageReference Include="Microsoft.Dynamics.BusinessCentral.Sip.Main" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
@@ -16,11 +15,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="NuGet.Protocol" />
-    <PackageReference Include="NuGetKeyVaultSignTool.Core" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="System.Security.Cryptography.Xml" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="System.Text.Json" PrivateAssets="analyzers;build;compile;contentfiles" />
-    <PackageReference Include="Microsoft.Dynamics.BusinessCentral.Sip.Main" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sign.Core/Tools/NuGet/NuGetLogger.cs
+++ b/src/Sign.Core/Tools/NuGet/NuGetLogger.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using NuGet.Common;
+using LogLevel = NuGet.Common.LogLevel;
+
+namespace Sign.Core
+{
+    internal sealed class NuGetLogger : NuGet.Common.ILogger
+    {
+        private readonly Microsoft.Extensions.Logging.ILogger _logger;
+        private readonly string _fileName;
+
+        internal NuGetLogger(Microsoft.Extensions.Logging.ILogger logger, string fileName)
+        {
+            ArgumentNullException.ThrowIfNull(logger, nameof(logger));
+            ArgumentException.ThrowIfNullOrEmpty(fileName, nameof(fileName));
+
+            _logger = logger;
+            _fileName = fileName;
+        }
+
+        public void Log(LogLevel level, string data)
+        {
+            _logger.Log(ConvertLevel(level), $"NuGet [{_fileName}]: {data}");
+        }
+
+        public void Log(ILogMessage message)
+        {
+            Log(message.Level, message.FormatWithCode());
+        }
+
+        public Task LogAsync(LogLevel level, string data)
+        {
+            Log(level, data);
+
+            return Task.CompletedTask;
+        }
+
+        public Task LogAsync(ILogMessage message)
+        {
+            Log(message.Level, message.FormatWithCode());
+
+            return Task.CompletedTask;
+        }
+
+        public void LogDebug(string data)
+        {
+            Log(LogLevel.Debug, data);
+        }
+
+        public void LogError(string data)
+        {
+            Log(LogLevel.Error, data);
+        }
+
+        public void LogInformation(string data)
+        {
+            Log(LogLevel.Information, data);
+        }
+
+        public void LogInformationSummary(string data)
+        {
+            Log(LogLevel.Information, data);
+        }
+
+        public void LogMinimal(string data)
+        {
+            Log(LogLevel.Minimal, data);
+        }
+
+        public void LogVerbose(string data)
+        {
+            Log(LogLevel.Verbose, data);
+        }
+
+        public void LogWarning(string data)
+        {
+            Log(LogLevel.Warning, data);
+        }
+
+        private static Microsoft.Extensions.Logging.LogLevel ConvertLevel(LogLevel level)
+        {
+            return level switch
+            {
+                LogLevel.Debug => Microsoft.Extensions.Logging.LogLevel.Debug,
+                LogLevel.Verbose => Microsoft.Extensions.Logging.LogLevel.Trace,
+                LogLevel.Information => Microsoft.Extensions.Logging.LogLevel.Information,
+                LogLevel.Minimal => Microsoft.Extensions.Logging.LogLevel.Information,
+                LogLevel.Warning => Microsoft.Extensions.Logging.LogLevel.Warning,
+                LogLevel.Error => Microsoft.Extensions.Logging.LogLevel.Error,
+                _ => Microsoft.Extensions.Logging.LogLevel.Information
+            };
+        }
+    }
+}

--- a/src/Sign.Core/Tools/NuGet/NuGetPackageSigner.cs
+++ b/src/Sign.Core/Tools/NuGet/NuGetPackageSigner.cs
@@ -1,0 +1,138 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Extensions.Logging;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+using NuGet.Protocol;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace Sign.Core
+{
+    internal sealed class NuGetPackageSigner
+    {
+        private readonly ILogger _logger;
+
+        public NuGetPackageSigner(ILogger logger)
+        {
+            ArgumentNullException.ThrowIfNull(logger, nameof(logger));
+
+            _logger = logger;
+        }
+
+        public async Task<bool> SignAsync(
+            string packagePath,
+            string outputPath,
+            Uri timestampUrl,
+            SignatureType signatureType,
+            HashAlgorithmName signatureHashAlgorithm,
+            HashAlgorithmName timestampHashAlgorithm,
+            X509Certificate2 signingCertificate,
+            System.Security.Cryptography.RSA rsa,
+            bool overwrite,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(packagePath, nameof(packagePath));
+            ArgumentException.ThrowIfNullOrEmpty(outputPath, nameof(outputPath));
+            ArgumentNullException.ThrowIfNull(timestampUrl, nameof(timestampUrl));
+            ArgumentNullException.ThrowIfNull(signingCertificate, nameof(signingCertificate));
+            ArgumentNullException.ThrowIfNull(rsa, nameof(rsa));
+
+            bool inPlaceSigning = String.Equals(packagePath, outputPath);
+            bool usingWildCards = packagePath.Contains('*') || packagePath.Contains('?');
+            IEnumerable<string> packageFilePaths = LocalFolderUtility.ResolvePackageFromPath(packagePath);
+            NuGetSignatureProvider signatureProvider = new(rsa, new Rfc3161TimestampProvider(timestampUrl));
+            SignPackageRequest? request = null;
+
+            if (signatureType == SignatureType.Author)
+            {
+                request = new AuthorSignPackageRequest(signingCertificate, signatureHashAlgorithm, timestampHashAlgorithm);
+            }
+            else
+            {
+                throw new NotSupportedException(nameof(signatureType));
+            }
+
+            foreach (string packageFilePath in packageFilePaths)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                string packageFileName = Path.GetFileName(packageFilePath);
+
+                _logger.LogInformation($"{nameof(SignAsync)} [{packageFilePath}]: Begin signing {packageFileName}");
+
+                string? originalPackageCopyPath = null;
+
+                try
+                {
+                    originalPackageCopyPath = CopyPackage(packageFilePath);
+                    string signedPackagePath = outputPath;
+
+                    if (inPlaceSigning)
+                    {
+                        signedPackagePath = packageFilePath;
+                    }
+                    else if (usingWildCards)
+                    {
+                        string? pathName = Path.GetDirectoryName(outputPath + Path.DirectorySeparatorChar);
+
+                        if (!string.IsNullOrEmpty(pathName) && !Directory.Exists(pathName))
+                        {
+                            Directory.CreateDirectory(pathName);
+                        }
+
+                        signedPackagePath = pathName + Path.DirectorySeparatorChar + packageFileName;
+                    }
+
+                    using (SigningOptions options = SigningOptions.CreateFromFilePaths(
+                        originalPackageCopyPath,
+                        signedPackagePath,
+                        overwrite,
+                        signatureProvider,
+                        new NuGetLogger(_logger, packageFilePath)))
+                    {
+                        await SigningUtility.SignAsync(options, request, cancellationToken);
+                    }
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, e.Message);
+                    return false;
+                }
+                finally
+                {
+                    if (!string.IsNullOrEmpty(originalPackageCopyPath))
+                    {
+                        try
+                        {
+                            FileUtility.Delete(originalPackageCopyPath);
+                        }
+                        catch
+                        {
+                        }
+                    }
+
+                    _logger.LogInformation($"{nameof(SignAsync)} [{packageFilePath}]: End signing {packageFileName}");
+                }
+            }
+
+            return true;
+        }
+
+        private static string CopyPackage(string sourceFilePath)
+        {
+            string destFilePath = Path.GetTempFileName();
+
+            File.Copy(sourceFilePath, destFilePath, overwrite: true);
+
+            return destFilePath;
+        }
+
+        private static void OverwritePackage(string sourceFilePath, string destFilePath)
+        {
+            File.Copy(sourceFilePath, destFilePath, overwrite: true);
+        }
+    }
+}

--- a/src/Sign.Core/Tools/NuGet/NuGetSignatureProvider.cs
+++ b/src/Sign.Core/Tools/NuGet/NuGetSignatureProvider.cs
@@ -1,0 +1,181 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using NuGet.Common;
+using NuGet.Packaging.Signing;
+
+namespace Sign.Core
+{
+    internal sealed class NuGetSignatureProvider : NuGet.Packaging.Signing.ISignatureProvider
+    {
+        // Occurs when SignedCms.ComputeSignature cannot read the certificate private key
+        // "Invalid provider type specified." (INVALID_PROVIDER_TYPE)
+        private const int INVALID_PROVIDER_TYPE_HRESULT = unchecked((int)0x80090014);
+
+        private readonly RSA _rsa;
+        private readonly ITimestampProvider _timestampProvider;
+
+        public NuGetSignatureProvider(RSA rsa, ITimestampProvider timestampProvider)
+        {
+            ArgumentNullException.ThrowIfNull(rsa, nameof(rsa));
+            ArgumentNullException.ThrowIfNull(timestampProvider, nameof(timestampProvider));
+
+            _rsa = rsa;
+            _timestampProvider = timestampProvider;
+        }
+
+        public Task<PrimarySignature> CreatePrimarySignatureAsync(
+            SignPackageRequest request,
+            SignatureContent signatureContent,
+            ILogger logger,
+            CancellationToken token)
+        {
+            if (request is AuthorSignPackageRequest authorSignPackageRequest)
+            {
+                return CreateAuthorSignatureAsync(authorSignPackageRequest, signatureContent, logger, token);
+            }
+
+            throw new NotSupportedException($"Unsupported {nameof(SignPackageRequest)} type: {request.GetType().Name}");
+        }
+
+        public Task<PrimarySignature> CreateRepositoryCountersignatureAsync(
+            RepositorySignPackageRequest request,
+            PrimarySignature primarySignature,
+            ILogger logger,
+            CancellationToken token)
+        {
+            throw new NotSupportedException($"Unsupported {nameof(SignPackageRequest)} type: {request.GetType().Name}");
+        }
+
+        private async Task<PrimarySignature> CreateAuthorSignatureAsync(
+            AuthorSignPackageRequest request,
+            SignatureContent signatureContent,
+            ILogger logger,
+            CancellationToken token)
+        {
+            ArgumentNullException.ThrowIfNull(request, nameof(request));
+            ArgumentNullException.ThrowIfNull(signatureContent, nameof(signatureContent));
+            ArgumentNullException.ThrowIfNull(logger, nameof(logger));
+
+            logger.LogInformation($"{nameof(CreateAuthorSignatureAsync)}: Creating primary signature");
+            PrimarySignature authorSignature = CreatePrimarySignature(request, signatureContent, logger);
+            logger.LogInformation($"{nameof(CreateAuthorSignatureAsync)}: Primary signature completed");
+
+            logger.LogInformation($"{nameof(CreateAuthorSignatureAsync)}: Timestamping primary signature");
+            PrimarySignature timestampedAuthorSignature = await TimestampPrimarySignatureAsync(request, logger, authorSignature, token);
+            logger.LogInformation($"{nameof(CreateAuthorSignatureAsync)}: Timestamping completed");
+
+            return timestampedAuthorSignature;
+        }
+
+        private PrimarySignature CreatePrimarySignature(AuthorSignPackageRequest request, SignatureContent signatureContent, ILogger logger)
+        {
+            const string PropertyName = "Chain";
+
+            PropertyInfo? property = typeof(SignPackageRequest)
+                .GetProperty(PropertyName, BindingFlags.Instance | BindingFlags.NonPublic);
+
+            if (property is null)
+            {
+                throw new MissingMemberException(nameof(SignPackageRequest), PropertyName);
+            }
+
+            MethodInfo? getter = property.GetGetMethod(nonPublic: true);
+
+            if (getter is null)
+            {
+                throw new MissingMemberException(nameof(SignPackageRequest), PropertyName);
+            }
+
+            var certificates = (IReadOnlyList<X509Certificate2>?)getter.Invoke(request, parameters: null);
+            CmsSigner cmsSigner = CreateCmsSigner(request, certificates!);
+            ContentInfo contentInfo = new(signatureContent.GetBytes());
+            SignedCms signedCms = new(contentInfo);
+
+            try
+            {
+                signedCms.ComputeSignature(cmsSigner, silent: false); // silent is false to ensure PIN prompts appear if CNG/CAPI requires it
+            }
+            catch (CryptographicException ex) when (ex.HResult == INVALID_PROVIDER_TYPE_HRESULT)
+            {
+                StringBuilder stringBuilder = new();
+                stringBuilder.AppendLine("Invalid _rsa type");
+                stringBuilder.AppendLine(CertificateUtility.X509Certificate2ToString(request.Certificate, NuGet.Common.HashAlgorithmName.SHA256));
+
+                throw new SignatureException(NuGetLogCode.NU3001, stringBuilder.ToString());
+            }
+
+            return PrimarySignature.Load(signedCms);
+        }
+
+        private CmsSigner CreateCmsSigner(SignPackageRequest request, IReadOnlyList<X509Certificate2> chain)
+        {
+            // Subject Key Identifier (SKI) is smaller and less prone to accidental matching than issuer and serial
+            // number.  However, to ensure cross-platform verification, SKI should only be used if the certificate
+            // has the SKI extension attribute.
+            CmsSigner signer;
+
+            if (request.Certificate.Extensions[Oids.SubjectKeyIdentifier] == null)
+            {
+                signer = new CmsSigner(SubjectIdentifierType.IssuerAndSerialNumber, request.Certificate, _rsa);
+            }
+            else
+            {
+                signer = new CmsSigner(SubjectIdentifierType.SubjectKeyIdentifier, request.Certificate, _rsa);
+            }
+
+            foreach (X509Certificate2 certificate in chain)
+            {
+                signer.Certificates.Add(certificate);
+            }
+
+            CryptographicAttributeObjectCollection attributes;
+
+            if (request.SignatureType == SignatureType.Repository)
+            {
+                attributes = SigningUtility.CreateSignedAttributes((RepositorySignPackageRequest)request, chain);
+            }
+            else
+            {
+                attributes = SigningUtility.CreateSignedAttributes(request, chain);
+            }
+
+            foreach (CryptographicAttributeObject attribute in attributes)
+            {
+                signer.SignedAttributes.Add(attribute);
+            }
+
+            // We built the chain ourselves and added certificates.
+            // Passing any other value here would trigger another chain build
+            // and possibly add duplicate certs to the collection.
+            signer.IncludeOption = X509IncludeOption.None;
+            signer.DigestAlgorithm = request.SignatureHashAlgorithm.ConvertToOid();
+
+            return signer;
+        }
+
+        private Task<PrimarySignature> TimestampPrimarySignatureAsync(
+            SignPackageRequest request,
+            ILogger logger,
+            PrimarySignature signature,
+            CancellationToken token)
+        {
+            byte[] signatureValue = signature.GetSignatureValue();
+            byte[] messageHash = request.TimestampHashAlgorithm.ComputeHash(signatureValue);
+
+            TimestampRequest timestampRequest = new(
+                signingSpecifications: SigningSpecifications.V1,
+                hashedMessage: messageHash,
+                hashAlgorithm: request.TimestampHashAlgorithm,
+                target: SignaturePlacement.PrimarySignature);
+
+            return _timestampProvider.TimestampSignatureAsync(signature, timestampRequest, logger, token);
+        }
+    }
+}

--- a/src/Sign.SignatureProviders.KeyVault/KeyVaultService.cs
+++ b/src/Sign.SignatureProviders.KeyVault/KeyVaultService.cs
@@ -8,9 +8,10 @@ using System.Security.Cryptography.X509Certificates;
 using Azure;
 using Azure.Core;
 using Azure.Security.KeyVault.Certificates;
+using Azure.Security.KeyVault.Keys;
+using Azure.Security.KeyVault.Keys.Cryptography;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using RSAKeyVaultProvider;
 using Sign.Core;
 
 namespace Sign.SignatureProviders.KeyVault
@@ -48,10 +49,10 @@ namespace Sign.SignatureProviders.KeyVault
         public async Task<RSA> GetRsaAsync(CancellationToken cancellationToken)
         {
             KeyVaultCertificateWithPolicy certificateWithPolicy = await _task!;
-            X509Certificate2 certificate = new(certificateWithPolicy.Cer);
-            Uri keyIdentifier = certificateWithPolicy.KeyId;
+            KeyClient keyClient = new(certificateWithPolicy.KeyId, _tokenCredential);
+            CryptographyClient cryptoClient = keyClient.GetCryptographyClient(certificateWithPolicy.Name);
 
-            return RSAFactory.Create(_tokenCredential, keyIdentifier, certificate);
+            return await cryptoClient.CreateRSAAsync(cancellationToken);
         }
 
         private async Task<KeyVaultCertificateWithPolicy> GetKeyVaultCertificateAsync(

--- a/src/Sign.SignatureProviders.KeyVault/Sign.SignatureProviders.KeyVault.csproj
+++ b/src/Sign.SignatureProviders.KeyVault/Sign.SignatureProviders.KeyVault.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Security.KeyVault.Certificates" PrivateAssets="analyzers;build;compile;contentfiles" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" PrivateAssets="analyzers;build;compile;contentfiles" />
-    <PackageReference Include="RSAKeyVaultProvider" PrivateAssets="analyzers;build;compile;contentfiles" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/649

This change:

* uses Azure Key Vault SDK's [`RSA`](https://learn.microsoft.com/dotnet/api/system.security.cryptography.rsa?view=net-8.0) implementation instead of RSAKeyVaultProvider's
* copies and modifies code from https://github.com/novotnyllc/NuGetKeyVaultSignTool/tree/946e5c863a12a65feceecce50840dc611d9d1da8/NuGetKeyVaultSignTool.Core to use the Azure Key Vault RSA implementation
* removes NuGetKeyVaultSignTool.Core and RSAKeyVaultProvider package dependencies

CC @clairernovotny, @javierdlg