### PR TITLE
Correct creation of the CryptographyClient in the KeyVaultService.

### DIFF
--- a/src/Sign.SignatureProviders.KeyVault/KeyVaultServiceProvider.cs
+++ b/src/Sign.SignatureProviders.KeyVault/KeyVaultServiceProvider.cs
@@ -3,6 +3,8 @@
 // See the LICENSE.txt file in the project root for more information.
 
 using Azure.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Sign.Core;
 
 namespace Sign.SignatureProviders.KeyVault
@@ -57,7 +59,8 @@ namespace Sign.SignatureProviders.KeyVault
                     return _keyVaultService;
                 }
 
-                _keyVaultService = new KeyVaultService(serviceProvider, _tokenCredential, _keyVaultUrl, _certificateName);
+                ILogger<KeyVaultService> logger = serviceProvider.GetRequiredService<ILogger<KeyVaultService>>();
+                _keyVaultService = new KeyVaultService(_tokenCredential, _keyVaultUrl, _certificateName, logger);
             }
 
             return _keyVaultService;

--- a/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceTests.cs
+++ b/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceTests.cs
@@ -3,10 +3,8 @@
 // See the LICENSE.txt file in the project root for more information.
 
 using Azure.Core;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Sign.TestInfrastructure;
 
 namespace Sign.SignatureProviders.KeyVault.Test
 {
@@ -15,29 +13,13 @@ namespace Sign.SignatureProviders.KeyVault.Test
         private readonly static TokenCredential TokenCredential = Mock.Of<TokenCredential>();
         private readonly static Uri KeyVaultUrl = new("https://keyvault.test");
         private const string CertificateName = "a";
-        private readonly IServiceProvider serviceProvider;
-
-        public KeyVaultServiceTests()
-        {
-            ServiceCollection services = new();
-            services.AddSingleton<ILogger<KeyVaultService>>(new TestLogger<KeyVaultService>());
-            serviceProvider = services.BuildServiceProvider();
-        }
-
-        [Fact]
-        public void Constructor_WhenServiceProviderIsNull_Throws()
-        {
-            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new KeyVaultService(serviceProvider: null!, TokenCredential, KeyVaultUrl, CertificateName));
-
-            Assert.Equal("serviceProvider", exception.ParamName);
-        }
+        private readonly static ILogger<KeyVaultService> logger = Mock.Of<ILogger<KeyVaultService>>();
 
         [Fact]
         public void Constructor_WhenTokenCredentialIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new KeyVaultService(serviceProvider, tokenCredential: null!, KeyVaultUrl, CertificateName));
+                () => new KeyVaultService(tokenCredential: null!, KeyVaultUrl, CertificateName, logger));
 
             Assert.Equal("tokenCredential", exception.ParamName);
         }
@@ -46,7 +28,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenKeyVaultUrlIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new KeyVaultService(serviceProvider, TokenCredential, keyVaultUrl: null!, CertificateName));
+                () => new KeyVaultService(TokenCredential, keyVaultUrl: null!, CertificateName, logger));
 
             Assert.Equal("keyVaultUrl", exception.ParamName);
         }
@@ -55,7 +37,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenCertificateNameIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new KeyVaultService(serviceProvider, TokenCredential, KeyVaultUrl, certificateName: null!));
+                () => new KeyVaultService(TokenCredential, KeyVaultUrl, certificateName: null!, logger));
 
             Assert.Equal("certificateName", exception.ParamName);
         }
@@ -64,9 +46,18 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenCertificateNameIsEmpty_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new KeyVaultService(serviceProvider, TokenCredential, KeyVaultUrl, certificateName: string.Empty));
+                () => new KeyVaultService(TokenCredential, KeyVaultUrl, certificateName: string.Empty, logger));
 
             Assert.Equal("certificateName", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenLoggerIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new KeyVaultService(TokenCredential, KeyVaultUrl, CertificateName, logger: null!));
+
+            Assert.Equal("logger", exception.ParamName);
         }
     }
 }


### PR DESCRIPTION
This corrects the implementation of the creation of the CryptographyClient. The `KeyClient` that was created used the `KeyId` instead of the url of the keyvault here: `KeyClient keyClient = new(certificateWithPolicy.KeyId, _tokenCredential);`. And that was then used to create a `CryptographyClient` with an incorrect url.

I have fixed this by creating the `CryptographyClient` without using the `KeyClient` because we already get this information when the public key is retrieved. I have also removed the `_task` field to make it possible to pass the `cancellationToken` to the `GetCertificateAsync` call.