### PR TITLE
Enable user protected keys in certificate store

### DIFF
--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -21,7 +21,7 @@ namespace Sign.Cli
         internal Option<string?> CryptoServiceProviderOption { get; } = new(["--crypto-service-provider", "-csp"], CertificateStoreResources.CspOptionDescription);
         internal Option<string?> PrivateKeyContainerOption { get; } = new(["--key-container", "-k"], CertificateStoreResources.KeyContainerOptionDescription);
         internal Option<bool> UseMachineKeyContainerOption { get; } = new(["--use-machine-key-container", "-km"], getDefaultValue: () => false, description: CertificateStoreResources.UseMachineKeyContainerOptionDescription);
-        internal Option<bool> UserProtectedKeyOption { get; } = new(["--user-protected-key", "-upk"], getDefaultValue: () => false, description: CertificateStoreResources.UserProtectedKeyDescription);
+        internal Option<bool> AllowUiPromptsOption { get; } = new(["--allow-ui-prompts", "-ui"], getDefaultValue: () => false, description: CertificateStoreResources.AllowUiPromptsDescription);
 
         internal Argument<string?> FileArgument { get; } = new("file(s)", Resources.FilesArgumentDescription);
 
@@ -39,7 +39,7 @@ namespace Sign.Cli
             AddOption(CryptoServiceProviderOption);
             AddOption(PrivateKeyContainerOption);
             AddOption(UseMachineKeyContainerOption);
-            AddOption(UserProtectedKeyOption);
+            AddOption(AllowUiPromptsOption);
             AddArgument(FileArgument);
 
             this.SetHandler(async (InvocationContext context) =>
@@ -61,7 +61,7 @@ namespace Sign.Cli
                 string? cryptoServiceProvider = context.ParseResult.GetValueForOption(CryptoServiceProviderOption);
                 string? privateKeyContainer = context.ParseResult.GetValueForOption(PrivateKeyContainerOption);
                 bool useMachineKeyContainer = context.ParseResult.GetValueForOption(UseMachineKeyContainerOption);
-                bool userProtectedKey = context.ParseResult.GetValueForOption(UserProtectedKeyOption);
+                bool allowUiPrompts = context.ParseResult.GetValueForOption(AllowUiPromptsOption);
 
                 // Certificate fingerprint is required in case the provided certificate container contains multiple certificates.
                 if (string.IsNullOrEmpty(certificateFingerprint))
@@ -109,7 +109,7 @@ namespace Sign.Cli
                     certificatePath,
                     certificatePassword,
                     useMachineKeyContainer,
-                    userProtectedKey);
+                    allowUiPrompts);
 
                 await codeCommand.HandleAsync(context, serviceProviderFactory, certificateStoreServiceProvider, fileArgument);
             });

--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -21,6 +21,7 @@ namespace Sign.Cli
         internal Option<string?> CryptoServiceProviderOption { get; } = new(["--crypto-service-provider", "-csp"], CertificateStoreResources.CspOptionDescription);
         internal Option<string?> PrivateKeyContainerOption { get; } = new(["--key-container", "-k"], CertificateStoreResources.KeyContainerOptionDescription);
         internal Option<bool> UseMachineKeyContainerOption { get; } = new(["--use-machine-key-container", "-km"], getDefaultValue: () => false, description: CertificateStoreResources.UseMachineKeyContainerOptionDescription);
+        internal Option<bool> UserProtectedKeyOption { get; } = new(["--user-protected-key", "-upk"], getDefaultValue: () => false, description: CertificateStoreResources.UserProtectedKeyDescription);
 
         internal Argument<string?> FileArgument { get; } = new("file(s)", Resources.FilesArgumentDescription);
 
@@ -38,6 +39,7 @@ namespace Sign.Cli
             AddOption(CryptoServiceProviderOption);
             AddOption(PrivateKeyContainerOption);
             AddOption(UseMachineKeyContainerOption);
+            AddOption(UserProtectedKeyOption);
             AddArgument(FileArgument);
 
             this.SetHandler(async (InvocationContext context) =>
@@ -59,6 +61,7 @@ namespace Sign.Cli
                 string? cryptoServiceProvider = context.ParseResult.GetValueForOption(CryptoServiceProviderOption);
                 string? privateKeyContainer = context.ParseResult.GetValueForOption(PrivateKeyContainerOption);
                 bool useMachineKeyContainer = context.ParseResult.GetValueForOption(UseMachineKeyContainerOption);
+                bool userProtectedKey = context.ParseResult.GetValueForOption(UserProtectedKeyOption);
 
                 // Certificate fingerprint is required in case the provided certificate container contains multiple certificates.
                 if (string.IsNullOrEmpty(certificateFingerprint))
@@ -105,7 +108,8 @@ namespace Sign.Cli
                     privateKeyContainer,
                     certificatePath,
                     certificatePassword,
-                    useMachineKeyContainer);
+                    useMachineKeyContainer,
+                    userProtectedKey);
 
                 await codeCommand.HandleAsync(context, serviceProviderFactory, certificateStoreServiceProvider, fileArgument);
             });

--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -21,7 +21,7 @@ namespace Sign.Cli
         internal Option<string?> CryptoServiceProviderOption { get; } = new(["--crypto-service-provider", "-csp"], CertificateStoreResources.CspOptionDescription);
         internal Option<string?> PrivateKeyContainerOption { get; } = new(["--key-container", "-k"], CertificateStoreResources.KeyContainerOptionDescription);
         internal Option<bool> UseMachineKeyContainerOption { get; } = new(["--use-machine-key-container", "-km"], getDefaultValue: () => false, description: CertificateStoreResources.UseMachineKeyContainerOptionDescription);
-        internal Option<bool> AllowUiPromptsOption { get; } = new(["--allow-ui-prompts", "-ui"], getDefaultValue: () => false, description: CertificateStoreResources.AllowUiPromptsDescription);
+        internal Option<bool> InteractiveOption { get; } = new(["--interactive", "-i"], getDefaultValue: () => false, description: CertificateStoreResources.InteractiveDescription);
 
         internal Argument<string?> FileArgument { get; } = new("file(s)", Resources.FilesArgumentDescription);
 
@@ -39,7 +39,7 @@ namespace Sign.Cli
             AddOption(CryptoServiceProviderOption);
             AddOption(PrivateKeyContainerOption);
             AddOption(UseMachineKeyContainerOption);
-            AddOption(AllowUiPromptsOption);
+            AddOption(InteractiveOption);
             AddArgument(FileArgument);
 
             this.SetHandler(async (InvocationContext context) =>
@@ -61,7 +61,7 @@ namespace Sign.Cli
                 string? cryptoServiceProvider = context.ParseResult.GetValueForOption(CryptoServiceProviderOption);
                 string? privateKeyContainer = context.ParseResult.GetValueForOption(PrivateKeyContainerOption);
                 bool useMachineKeyContainer = context.ParseResult.GetValueForOption(UseMachineKeyContainerOption);
-                bool allowUiPrompts = context.ParseResult.GetValueForOption(AllowUiPromptsOption);
+                bool isInteractive = context.ParseResult.GetValueForOption(InteractiveOption);
 
                 // Certificate fingerprint is required in case the provided certificate container contains multiple certificates.
                 if (string.IsNullOrEmpty(certificateFingerprint))
@@ -109,7 +109,7 @@ namespace Sign.Cli
                     certificatePath,
                     certificatePassword,
                     useMachineKeyContainer,
-                    allowUiPrompts);
+                    isInteractive);
 
                 await codeCommand.HandleAsync(context, serviceProviderFactory, certificateStoreServiceProvider, fileArgument);
             });

--- a/src/Sign.Cli/CertificateStoreResources.Designer.cs
+++ b/src/Sign.Cli/CertificateStoreResources.Designer.cs
@@ -61,6 +61,15 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allow user interactions (such as a dialog box) when a key is accessed..
+        /// </summary>
+        internal static string AllowUiPromptsDescription {
+            get {
+                return ResourceManager.GetString("AllowUiPromptsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to PFX, P7B, or CER file containing a certificate and potentially a private key..
         /// </summary>
         internal static string CertificateFileOptionDescription {
@@ -129,15 +138,6 @@ namespace Sign.Cli {
         internal static string UseMachineKeyContainerOptionDescription {
             get {
                 return ResourceManager.GetString("UseMachineKeyContainerOptionDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Allow user interactions (such as a dialog box) when a key is accessed..
-        /// </summary>
-        internal static string UserProtectedKeyDescription {
-            get {
-                return ResourceManager.GetString("UserProtectedKeyDescription", resourceCulture);
             }
         }
     }

--- a/src/Sign.Cli/CertificateStoreResources.Designer.cs
+++ b/src/Sign.Cli/CertificateStoreResources.Designer.cs
@@ -61,15 +61,6 @@ namespace Sign.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Allow user interactions (such as a dialog box) when a key is accessed..
-        /// </summary>
-        internal static string AllowUiPromptsDescription {
-            get {
-                return ResourceManager.GetString("AllowUiPromptsDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to PFX, P7B, or CER file containing a certificate and potentially a private key..
         /// </summary>
         internal static string CertificateFileOptionDescription {
@@ -102,6 +93,15 @@ namespace Sign.Cli {
         internal static string CspOptionDescription {
             get {
                 return ResourceManager.GetString("CspOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allow user interactions (such as a dialog box) when a private key is accessed..
+        /// </summary>
+        internal static string InteractiveDescription {
+            get {
+                return ResourceManager.GetString("InteractiveDescription", resourceCulture);
             }
         }
         

--- a/src/Sign.Cli/CertificateStoreResources.Designer.cs
+++ b/src/Sign.Cli/CertificateStoreResources.Designer.cs
@@ -131,5 +131,14 @@ namespace Sign.Cli {
                 return ResourceManager.GetString("UseMachineKeyContainerOptionDescription", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Allow user interactions (such as a dialog box) when a key is accessed..
+        /// </summary>
+        internal static string UserProtectedKeyDescription {
+            get {
+                return ResourceManager.GetString("UserProtectedKeyDescription", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Sign.Cli/CertificateStoreResources.resx
+++ b/src/Sign.Cli/CertificateStoreResources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AllowUiPromptsDescription" xml:space="preserve">
+    <value>Allow user interactions (such as a dialog box) when a key is accessed.</value>
+  </data>
   <data name="CertificateFileOptionDescription" xml:space="preserve">
     <value>PFX, P7B, or CER file containing a certificate and potentially a private key.</value>
     <comment>{Locked="PFX", "P7B", "CER"} are file extensions.</comment>
@@ -145,8 +148,5 @@
   </data>
   <data name="UseMachineKeyContainerOptionDescription" xml:space="preserve">
     <value>Use a machine-level private key container.  (The default is user-level.)</value>
-  </data>
-  <data name="UserProtectedKeyDescription" xml:space="preserve">
-    <value>Allow user interactions (such as a dialog box) when a key is accessed.</value>
   </data>
 </root>

--- a/src/Sign.Cli/CertificateStoreResources.resx
+++ b/src/Sign.Cli/CertificateStoreResources.resx
@@ -146,4 +146,7 @@
   <data name="UseMachineKeyContainerOptionDescription" xml:space="preserve">
     <value>Use a machine-level private key container.  (The default is user-level.)</value>
   </data>
+  <data name="UserProtectedKeyDescription" xml:space="preserve">
+    <value>Allow user interactions (such as a dialog box) when a key is accessed.</value>
+  </data>
 </root>

--- a/src/Sign.Cli/CertificateStoreResources.resx
+++ b/src/Sign.Cli/CertificateStoreResources.resx
@@ -117,8 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AllowUiPromptsDescription" xml:space="preserve">
-    <value>Allow user interactions (such as a dialog box) when a key is accessed.</value>
+  <data name="InteractiveDescription" xml:space="preserve">
+    <value>Allow user interactions (such as a dialog box) when a private key is accessed.</value>
   </data>
   <data name="CertificateFileOptionDescription" xml:space="preserve">
     <value>PFX, P7B, or CER file containing a certificate and potentially a private key.</value>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../CertificateStoreResources.resx">
     <body>
+      <trans-unit id="AllowUiPromptsDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">Soubor PFX, P7B nebo CER obsahující certifikát a potenciálně privátní klíč.</target>
@@ -40,11 +45,6 @@
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
         <target state="translated">Použijte kontejner privátního klíče na úrovni počítače.  (Výchozí hodnota je na úrovni uživatele.)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UserProtectedKeyDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Použijte kontejner privátního klíče na úrovni počítače.  (Výchozí hodnota je na úrovni uživatele.)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserProtectedKeyDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../CertificateStoreResources.resx">
     <body>
-      <trans-unit id="AllowUiPromptsDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">Soubor PFX, P7B nebo CER obsahující certifikát a potenciálně privátní klíč.</target>
@@ -26,6 +21,11 @@
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Zprostředkovatel kryptografických služeb obsahující kontejner privátního klíče. Vyžaduje /k a volitelně /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
+      </trans-unit>
+      <trans-unit id="InteractiveDescription">
+        <source>Allow user interactions (such as a dialog box) when a private key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a private key is accessed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../CertificateStoreResources.resx">
     <body>
-      <trans-unit id="AllowUiPromptsDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">PFX-, P7B- oder CER-Datei, die ein Zertifikat und möglicherweise einen privaten Schlüssel enthält.</target>
@@ -26,6 +21,11 @@
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Kryptografiedienstanbieter, der den privaten Schlüsselcontainer enthält. Erfordert /k und optional /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
+      </trans-unit>
+      <trans-unit id="InteractiveDescription">
+        <source>Allow user interactions (such as a dialog box) when a private key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a private key is accessed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Verwenden Sie einen Container mit privatem Schlüssel auf Computerebene.  (Der Standardwert ist Benutzerebene.)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserProtectedKeyDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../CertificateStoreResources.resx">
     <body>
+      <trans-unit id="AllowUiPromptsDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">PFX-, P7B- oder CER-Datei, die ein Zertifikat und möglicherweise einen privaten Schlüssel enthält.</target>
@@ -40,11 +45,6 @@
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
         <target state="translated">Verwenden Sie einen Container mit privatem Schlüssel auf Computerebene.  (Der Standardwert ist Benutzerebene.)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UserProtectedKeyDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../CertificateStoreResources.resx">
     <body>
-      <trans-unit id="AllowUiPromptsDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">Archivo PFX, P7B o CER que contiene un certificado y una clave privada potencialmente.</target>
@@ -26,6 +21,11 @@
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Proveedor de servicios criptográficos que contiene el contenedor de claves privadas. Requiere /k y, opcionalmente, /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
+      </trans-unit>
+      <trans-unit id="InteractiveDescription">
+        <source>Allow user interactions (such as a dialog box) when a private key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a private key is accessed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../CertificateStoreResources.resx">
     <body>
+      <trans-unit id="AllowUiPromptsDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">Archivo PFX, P7B o CER que contiene un certificado y una clave privada potencialmente.</target>
@@ -40,11 +45,6 @@
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
         <target state="translated">Use un contenedor de claves privadas de nivel de máquina.  (El valor predeterminado es de nivel de usuario).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UserProtectedKeyDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Use un contenedor de claves privadas de nivel de máquina.  (El valor predeterminado es de nivel de usuario).</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserProtectedKeyDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Utilisez un conteneur de clé privée au niveau de l’ordinateur.  (La valeur par défaut est au niveau de l’utilisateur.)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserProtectedKeyDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../CertificateStoreResources.resx">
     <body>
-      <trans-unit id="AllowUiPromptsDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">Fichier PFX, P7B ou CER contenant un certificat et éventuellement une clé privée.</target>
@@ -26,6 +21,11 @@
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Fournisseur de services de chiffrement contenant le conteneur de clé privée. Nécessite /k et éventuellement /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
+      </trans-unit>
+      <trans-unit id="InteractiveDescription">
+        <source>Allow user interactions (such as a dialog box) when a private key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a private key is accessed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../CertificateStoreResources.resx">
     <body>
+      <trans-unit id="AllowUiPromptsDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">Fichier PFX, P7B ou CER contenant un certificat et éventuellement une clé privée.</target>
@@ -40,11 +45,6 @@
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
         <target state="translated">Utilisez un conteneur de clé privée au niveau de l’ordinateur.  (La valeur par défaut est au niveau de l’utilisateur.)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UserProtectedKeyDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Usare un contenitore di chiavi private a livello di computer.  (Il valore predefinito è a livello di utente).</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserProtectedKeyDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../CertificateStoreResources.resx">
     <body>
-      <trans-unit id="AllowUiPromptsDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">PFX, P7B o CER file contenente un certificato e potenzialmente una chiave privata.</target>
@@ -26,6 +21,11 @@
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Provider del servizio di crittografia contenente il contenitore di chiavi private. Richiede /k e facoltativamente /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
+      </trans-unit>
+      <trans-unit id="InteractiveDescription">
+        <source>Allow user interactions (such as a dialog box) when a private key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a private key is accessed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../CertificateStoreResources.resx">
     <body>
+      <trans-unit id="AllowUiPromptsDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">PFX, P7B o CER file contenente un certificato e potenzialmente una chiave privata.</target>
@@ -40,11 +45,6 @@
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
         <target state="translated">Usare un contenitore di chiavi private a livello di computer.  (Il valore predefinito è a livello di utente).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UserProtectedKeyDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
@@ -42,6 +42,11 @@
         <target state="translated">コンピューター レベルの秘密キー コンテナーを使用します。(既定値はユーザー レベルです)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserProtectedKeyDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../CertificateStoreResources.resx">
     <body>
+      <trans-unit id="AllowUiPromptsDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">証明書と潜在的に秘密キーを含む PFX、P7B、または CER ファイル。</target>
@@ -40,11 +45,6 @@
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
         <target state="translated">コンピューター レベルの秘密キー コンテナーを使用します。(既定値はユーザー レベルです)。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UserProtectedKeyDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../CertificateStoreResources.resx">
     <body>
-      <trans-unit id="AllowUiPromptsDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">証明書と潜在的に秘密キーを含む PFX、P7B、または CER ファイル。</target>
@@ -26,6 +21,11 @@
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">秘密キー コンテナーを含む暗号化サービス プロバイダー。/k および必要に応じて /km が必要です。</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
+      </trans-unit>
+      <trans-unit id="InteractiveDescription">
+        <source>Allow user interactions (such as a dialog box) when a private key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a private key is accessed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../CertificateStoreResources.resx">
     <body>
+      <trans-unit id="AllowUiPromptsDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">인증서와 잠재적으로 프라이빗 키가 포함된 PFX, P7B 또는 CER 파일입니다.</target>
@@ -40,11 +45,6 @@
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
         <target state="translated">컴퓨터 수준 프라이빗 키 컨테이너를 사용합니다.  (기본값은 사용자 수준입니다.)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UserProtectedKeyDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
@@ -42,6 +42,11 @@
         <target state="translated">컴퓨터 수준 프라이빗 키 컨테이너를 사용합니다.  (기본값은 사용자 수준입니다.)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserProtectedKeyDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../CertificateStoreResources.resx">
     <body>
-      <trans-unit id="AllowUiPromptsDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">인증서와 잠재적으로 프라이빗 키가 포함된 PFX, P7B 또는 CER 파일입니다.</target>
@@ -26,6 +21,11 @@
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">프라이빗 키 컨테이너를 포함하는 암호화 서비스 공급자입니다. /k 및 선택적으로 /km이 필요합니다.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
+      </trans-unit>
+      <trans-unit id="InteractiveDescription">
+        <source>Allow user interactions (such as a dialog box) when a private key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a private key is accessed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../CertificateStoreResources.resx">
     <body>
-      <trans-unit id="AllowUiPromptsDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">Plik PFX, P7B lub CER zawierający certyfikat i potencjalnie klucz prywatny.</target>
@@ -26,6 +21,11 @@
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Dostawca usług kryptograficznych zawierający kontener kluczy prywatnych. Wymaga opcji /k i opcjonalnie /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
+      </trans-unit>
+      <trans-unit id="InteractiveDescription">
+        <source>Allow user interactions (such as a dialog box) when a private key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a private key is accessed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../CertificateStoreResources.resx">
     <body>
+      <trans-unit id="AllowUiPromptsDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">Plik PFX, P7B lub CER zawierający certyfikat i potencjalnie klucz prywatny.</target>
@@ -40,11 +45,6 @@
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
         <target state="translated">Użyj kontenera kluczy prywatnych na poziomie komputera.  (Wartość domyślna to poziom użytkownika).</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UserProtectedKeyDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Użyj kontenera kluczy prywatnych na poziomie komputera.  (Wartość domyślna to poziom użytkownika).</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserProtectedKeyDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Use um contêiner de chave privada no nível do computador.  (O padrão é o nível do usuário.)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserProtectedKeyDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../CertificateStoreResources.resx">
     <body>
+      <trans-unit id="AllowUiPromptsDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">Arquivos PFX, P7B ou CER que contêm um certificado e, possivelmente, uma chave privada.</target>
@@ -40,11 +45,6 @@
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
         <target state="translated">Use um contêiner de chave privada no nível do computador.  (O padrão é o nível do usuário.)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UserProtectedKeyDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../CertificateStoreResources.resx">
     <body>
-      <trans-unit id="AllowUiPromptsDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">Arquivos PFX, P7B ou CER que contêm um certificado e, possivelmente, uma chave privada.</target>
@@ -26,6 +21,11 @@
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Provedor de Serviços Criptográficos que contém o contêiner de chave privada. Requer /k e, opcionalmente, /km.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
+      </trans-unit>
+      <trans-unit id="InteractiveDescription">
+        <source>Allow user interactions (such as a dialog box) when a private key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a private key is accessed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../CertificateStoreResources.resx">
     <body>
-      <trans-unit id="AllowUiPromptsDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">Файл PFX, P7B или CER, содержащий сертификат и, возможно, закрытый ключ.</target>
@@ -26,6 +21,11 @@
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Поставщик служб шифрования, содержащий контейнер закрытого ключа. Требуется /k и /km (необязательно).</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
+      </trans-unit>
+      <trans-unit id="InteractiveDescription">
+        <source>Allow user interactions (such as a dialog box) when a private key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a private key is accessed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Используйте контейнер закрытого ключа на уровне компьютера.  (По умолчанию используется уровень пользователя.)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserProtectedKeyDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../CertificateStoreResources.resx">
     <body>
+      <trans-unit id="AllowUiPromptsDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">Файл PFX, P7B или CER, содержащий сертификат и, возможно, закрытый ключ.</target>
@@ -40,11 +45,6 @@
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
         <target state="translated">Используйте контейнер закрытого ключа на уровне компьютера.  (По умолчанию используется уровень пользователя.)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UserProtectedKeyDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../CertificateStoreResources.resx">
     <body>
+      <trans-unit id="AllowUiPromptsDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">Bir sertifika ve potansiyel olarak özel anahtar içeren PFX, P7B veya CER dosyası.</target>
@@ -40,11 +45,6 @@
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
         <target state="translated">Makine düzeyinde özel anahtar kapsayıcısı kullanın.  (Varsayılan, kullanıcı düzeyidir.)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UserProtectedKeyDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../CertificateStoreResources.resx">
     <body>
-      <trans-unit id="AllowUiPromptsDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">Bir sertifika ve potansiyel olarak özel anahtar içeren PFX, P7B veya CER dosyası.</target>
@@ -26,6 +21,11 @@
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Özel anahtar kapsayıcısını içeren Şifreleme Hizmeti Sağlayıcısı. /k ve alternatif olarak /km gerektirir.</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
+      </trans-unit>
+      <trans-unit id="InteractiveDescription">
+        <source>Allow user interactions (such as a dialog box) when a private key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a private key is accessed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
@@ -42,6 +42,11 @@
         <target state="translated">Makine düzeyinde özel anahtar kapsayıcısı kullanın.  (Varsayılan, kullanıcı düzeyidir.)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserProtectedKeyDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../CertificateStoreResources.resx">
     <body>
+      <trans-unit id="AllowUiPromptsDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">包含证书和可能包含私钥的 PFX、P7B 或 CER 文件。</target>
@@ -40,11 +45,6 @@
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
         <target state="translated">使用计算机级私钥容器。(默认值为用户级别。)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UserProtectedKeyDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
@@ -42,6 +42,11 @@
         <target state="translated">使用计算机级私钥容器。(默认值为用户级别。)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserProtectedKeyDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../CertificateStoreResources.resx">
     <body>
-      <trans-unit id="AllowUiPromptsDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">包含证书和可能包含私钥的 PFX、P7B 或 CER 文件。</target>
@@ -26,6 +21,11 @@
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">包含私钥容器的加密服务提供程序。需要 /k 和 /km (可选)。</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
+      </trans-unit>
+      <trans-unit id="InteractiveDescription">
+        <source>Allow user interactions (such as a dialog box) when a private key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a private key is accessed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
@@ -42,6 +42,11 @@
         <target state="translated">使用機器層級私密金鑰容器。(預設為使用者等級。)</target>
         <note />
       </trans-unit>
+      <trans-unit id="UserProtectedKeyDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../CertificateStoreResources.resx">
     <body>
-      <trans-unit id="AllowUiPromptsDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">包含憑證和潛在的私用金鑰的 PFX、P7B 或 CER 檔案。</target>
@@ -26,6 +21,11 @@
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">包含私密金鑰容器的加密服務提供者。需要 /k 並選擇性地 /km。</target>
         <note>{Locked="/k", "/km"} are command line options.</note>
+      </trans-unit>
+      <trans-unit id="InteractiveDescription">
+        <source>Allow user interactions (such as a dialog box) when a private key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a private key is accessed.</target>
+        <note />
       </trans-unit>
       <trans-unit id="KeyContainerOptionDescription">
         <source>Private key container name.</source>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../CertificateStoreResources.resx">
     <body>
+      <trans-unit id="AllowUiPromptsDescription">
+        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
+        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CertificateFileOptionDescription">
         <source>PFX, P7B, or CER file containing a certificate and potentially a private key.</source>
         <target state="translated">包含憑證和潛在的私用金鑰的 PFX、P7B 或 CER 檔案。</target>
@@ -40,11 +45,6 @@
       <trans-unit id="UseMachineKeyContainerOptionDescription">
         <source>Use a machine-level private key container.  (The default is user-level.)</source>
         <target state="translated">使用機器層級私密金鑰容器。(預設為使用者等級。)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UserProtectedKeyDescription">
-        <source>Allow user interactions (such as a dialog box) when a key is accessed.</source>
-        <target state="new">Allow user interactions (such as a dialog box) when a key is accessed.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Sign.SignatureProviders.CertificateStore/CertificateStoreService.cs
+++ b/src/Sign.SignatureProviders.CertificateStore/CertificateStoreService.cs
@@ -25,7 +25,7 @@ namespace Sign.SignatureProviders.CertificateStore
         private readonly string? _certificatePath;
         private readonly string? _certificatePassword;
         private readonly bool _isPrivateMachineKeyContainer;
-        private readonly bool _isUiAllowed;
+        private readonly bool _isInteractive;
 
         private readonly ILogger<CertificateStoreService> _logger;
 
@@ -38,7 +38,7 @@ namespace Sign.SignatureProviders.CertificateStore
             string? certificatePath,
             string? certificatePassword,
             bool isPrivateMachineKeyContainer,
-            bool isUiAllowed)
+            bool isInteractive)
         {
             ArgumentNullException.ThrowIfNull(serviceProvider, nameof(serviceProvider));
             ArgumentException.ThrowIfNullOrEmpty(certificateFingerprint, nameof(certificateFingerprint));
@@ -48,7 +48,7 @@ namespace Sign.SignatureProviders.CertificateStore
             _cryptoServiceProvider = cryptoServiceProvider;
             _privateKeyContainer = privateKeyContainer;
             _isPrivateMachineKeyContainer = isPrivateMachineKeyContainer;
-            _isUiAllowed = isUiAllowed;
+            _isInteractive = isInteractive;
             _certificatePath = certificatePath;
             _certificatePassword = certificatePassword;
 
@@ -68,7 +68,7 @@ namespace Sign.SignatureProviders.CertificateStore
             // Get RSA from a cryptographic service provider
             if (!string.IsNullOrEmpty(_privateKeyContainer) && !string.IsNullOrEmpty(_cryptoServiceProvider))
             {
-                var cngKeyFlags = _isUiAllowed ? CngKeyOpenOptions.None : CngKeyOpenOptions.Silent;
+                var cngKeyFlags = _isInteractive ? CngKeyOpenOptions.None : CngKeyOpenOptions.Silent;
 
                 if (_isPrivateMachineKeyContainer)
                 {

--- a/src/Sign.SignatureProviders.CertificateStore/CertificateStoreService.cs
+++ b/src/Sign.SignatureProviders.CertificateStore/CertificateStoreService.cs
@@ -25,7 +25,7 @@ namespace Sign.SignatureProviders.CertificateStore
         private readonly string? _certificatePath;
         private readonly string? _certificatePassword;
         private readonly bool _isPrivateMachineKeyContainer;
-        private readonly bool _isUserProtectedKey;
+        private readonly bool _isUiAllowed;
 
         private readonly ILogger<CertificateStoreService> _logger;
 
@@ -38,7 +38,7 @@ namespace Sign.SignatureProviders.CertificateStore
             string? certificatePath,
             string? certificatePassword,
             bool isPrivateMachineKeyContainer,
-            bool isUserProtectedKey)
+            bool isUiAllowed)
         {
             ArgumentNullException.ThrowIfNull(serviceProvider, nameof(serviceProvider));
             ArgumentException.ThrowIfNullOrEmpty(certificateFingerprint, nameof(certificateFingerprint));
@@ -48,7 +48,7 @@ namespace Sign.SignatureProviders.CertificateStore
             _cryptoServiceProvider = cryptoServiceProvider;
             _privateKeyContainer = privateKeyContainer;
             _isPrivateMachineKeyContainer = isPrivateMachineKeyContainer;
-            _isUserProtectedKey = isUserProtectedKey;
+            _isUiAllowed = isUiAllowed;
             _certificatePath = certificatePath;
             _certificatePassword = certificatePassword;
 
@@ -68,7 +68,7 @@ namespace Sign.SignatureProviders.CertificateStore
             // Get RSA from a cryptographic service provider
             if (!string.IsNullOrEmpty(_privateKeyContainer) && !string.IsNullOrEmpty(_cryptoServiceProvider))
             {
-                var cngKeyFlags = _isUserProtectedKey ? CngKeyOpenOptions.None : CngKeyOpenOptions.Silent;
+                var cngKeyFlags = _isUiAllowed ? CngKeyOpenOptions.None : CngKeyOpenOptions.Silent;
 
                 if (_isPrivateMachineKeyContainer)
                 {

--- a/src/Sign.SignatureProviders.CertificateStore/CertificateStoreService.cs
+++ b/src/Sign.SignatureProviders.CertificateStore/CertificateStoreService.cs
@@ -25,6 +25,7 @@ namespace Sign.SignatureProviders.CertificateStore
         private readonly string? _certificatePath;
         private readonly string? _certificatePassword;
         private readonly bool _isPrivateMachineKeyContainer;
+        private readonly bool _isUserProtectedKey;
 
         private readonly ILogger<CertificateStoreService> _logger;
 
@@ -36,7 +37,8 @@ namespace Sign.SignatureProviders.CertificateStore
             string? privateKeyContainer,
             string? certificatePath,
             string? certificatePassword,
-            bool isPrivateMachineKeyContainer)
+            bool isPrivateMachineKeyContainer,
+            bool isUserProtectedKey)
         {
             ArgumentNullException.ThrowIfNull(serviceProvider, nameof(serviceProvider));
             ArgumentException.ThrowIfNullOrEmpty(certificateFingerprint, nameof(certificateFingerprint));
@@ -46,6 +48,7 @@ namespace Sign.SignatureProviders.CertificateStore
             _cryptoServiceProvider = cryptoServiceProvider;
             _privateKeyContainer = privateKeyContainer;
             _isPrivateMachineKeyContainer = isPrivateMachineKeyContainer;
+            _isUserProtectedKey = isUserProtectedKey;
             _certificatePath = certificatePath;
             _certificatePassword = certificatePassword;
 
@@ -65,7 +68,7 @@ namespace Sign.SignatureProviders.CertificateStore
             // Get RSA from a cryptographic service provider
             if (!string.IsNullOrEmpty(_privateKeyContainer) && !string.IsNullOrEmpty(_cryptoServiceProvider))
             {
-                var cngKeyFlags = CngKeyOpenOptions.Silent;
+                var cngKeyFlags = _isUserProtectedKey ? CngKeyOpenOptions.None : CngKeyOpenOptions.Silent;
 
                 if (_isPrivateMachineKeyContainer)
                 {

--- a/src/Sign.SignatureProviders.CertificateStore/CertificateStoreServiceProvider.cs
+++ b/src/Sign.SignatureProviders.CertificateStore/CertificateStoreServiceProvider.cs
@@ -19,7 +19,7 @@ namespace Sign.SignatureProviders.CertificateStore
         private readonly string? _certificateFilePath;
         private readonly string? _certificateFilePassword;
         private readonly bool _isMachineKeyContainer;
-        private readonly bool _isUserProtectedKey;
+        private readonly bool _isUiAllowed;
 
         private readonly object _lockObject = new();
         private CertificateStoreService? _certificateStoreService;
@@ -34,7 +34,7 @@ namespace Sign.SignatureProviders.CertificateStore
         /// <param name="certificateFilePath">Optional path to the PFX, P7B, or CER file with the certificate.</param>
         /// <param name="certificateFilePassword">Optional password used to open the provided certificate.</param>
         /// <param name="isMachineKeyContainer">Optional Flag used to denote per-machine key container should be used.</param>
-        /// <param name="isUserProtectedKey">Optional Flag used to denote when user interactions are expected during key retrieval.</param>
+        /// <param name="isUiAllowed">Optional Flag used to denote when user interactions are expected during key retrieval.</param>
         /// <exception cref="ArgumentException">Thrown when a required argument is empty not valid.</exception>
         internal CertificateStoreServiceProvider(
             string certificateFingerprint,
@@ -44,7 +44,7 @@ namespace Sign.SignatureProviders.CertificateStore
             string? certificateFilePath,
             string? certificateFilePassword,
             bool isMachineKeyContainer,
-            bool isUserProtectedKey)
+            bool isUiAllowed)
         {
             ArgumentException.ThrowIfNullOrEmpty(certificateFingerprint, nameof(certificateFingerprint));
 
@@ -61,7 +61,7 @@ namespace Sign.SignatureProviders.CertificateStore
             _cryptoServiceProvider = cryptoServiceProvider;
             _privateKeyContainer = privateKeyContainer;
             _isMachineKeyContainer = isMachineKeyContainer;
-            _isUserProtectedKey = isUserProtectedKey;
+            _isUiAllowed = isUiAllowed;
             _certificateFilePath = certificateFilePath;
             _certificateFilePassword = certificateFilePassword;
         }
@@ -103,7 +103,7 @@ namespace Sign.SignatureProviders.CertificateStore
                     _certificateFilePath,
                     _certificateFilePassword,
                     _isMachineKeyContainer,
-                    _isUserProtectedKey);
+                    _isUiAllowed);
             }
 
             return _certificateStoreService;

--- a/src/Sign.SignatureProviders.CertificateStore/CertificateStoreServiceProvider.cs
+++ b/src/Sign.SignatureProviders.CertificateStore/CertificateStoreServiceProvider.cs
@@ -19,7 +19,7 @@ namespace Sign.SignatureProviders.CertificateStore
         private readonly string? _certificateFilePath;
         private readonly string? _certificateFilePassword;
         private readonly bool _isMachineKeyContainer;
-        private readonly bool _isUiAllowed;
+        private readonly bool _isInteractive;
 
         private readonly object _lockObject = new();
         private CertificateStoreService? _certificateStoreService;
@@ -34,7 +34,7 @@ namespace Sign.SignatureProviders.CertificateStore
         /// <param name="certificateFilePath">Optional path to the PFX, P7B, or CER file with the certificate.</param>
         /// <param name="certificateFilePassword">Optional password used to open the provided certificate.</param>
         /// <param name="isMachineKeyContainer">Optional Flag used to denote per-machine key container should be used.</param>
-        /// <param name="isUiAllowed">Optional Flag used to denote when user interactions are expected during key retrieval.</param>
+        /// <param name="isInteractive">Optional Flag used to denote when user interactions are expected during key retrieval.</param>
         /// <exception cref="ArgumentException">Thrown when a required argument is empty not valid.</exception>
         internal CertificateStoreServiceProvider(
             string certificateFingerprint,
@@ -44,7 +44,7 @@ namespace Sign.SignatureProviders.CertificateStore
             string? certificateFilePath,
             string? certificateFilePassword,
             bool isMachineKeyContainer,
-            bool isUiAllowed)
+            bool isInteractive)
         {
             ArgumentException.ThrowIfNullOrEmpty(certificateFingerprint, nameof(certificateFingerprint));
 
@@ -61,7 +61,7 @@ namespace Sign.SignatureProviders.CertificateStore
             _cryptoServiceProvider = cryptoServiceProvider;
             _privateKeyContainer = privateKeyContainer;
             _isMachineKeyContainer = isMachineKeyContainer;
-            _isUiAllowed = isUiAllowed;
+            _isInteractive = isInteractive;
             _certificateFilePath = certificateFilePath;
             _certificateFilePassword = certificateFilePassword;
         }
@@ -103,7 +103,7 @@ namespace Sign.SignatureProviders.CertificateStore
                     _certificateFilePath,
                     _certificateFilePassword,
                     _isMachineKeyContainer,
-                    _isUiAllowed);
+                    _isInteractive);
             }
 
             return _certificateStoreService;

--- a/src/Sign.SignatureProviders.CertificateStore/CertificateStoreServiceProvider.cs
+++ b/src/Sign.SignatureProviders.CertificateStore/CertificateStoreServiceProvider.cs
@@ -19,6 +19,7 @@ namespace Sign.SignatureProviders.CertificateStore
         private readonly string? _certificateFilePath;
         private readonly string? _certificateFilePassword;
         private readonly bool _isMachineKeyContainer;
+        private readonly bool _isUserProtectedKey;
 
         private readonly object _lockObject = new();
         private CertificateStoreService? _certificateStoreService;
@@ -33,6 +34,7 @@ namespace Sign.SignatureProviders.CertificateStore
         /// <param name="certificateFilePath">Optional path to the PFX, P7B, or CER file with the certificate.</param>
         /// <param name="certificateFilePassword">Optional password used to open the provided certificate.</param>
         /// <param name="isMachineKeyContainer">Optional Flag used to denote per-machine key container should be used.</param>
+        /// <param name="isUserProtectedKey">Optional Flag used to denote when user interactions are expected during key retrieval.</param>
         /// <exception cref="ArgumentException">Thrown when a required argument is empty not valid.</exception>
         internal CertificateStoreServiceProvider(
             string certificateFingerprint,
@@ -41,7 +43,8 @@ namespace Sign.SignatureProviders.CertificateStore
             string? privateKeyContainer,
             string? certificateFilePath,
             string? certificateFilePassword,
-            bool isMachineKeyContainer)
+            bool isMachineKeyContainer,
+            bool isUserProtectedKey)
         {
             ArgumentException.ThrowIfNullOrEmpty(certificateFingerprint, nameof(certificateFingerprint));
 
@@ -58,6 +61,7 @@ namespace Sign.SignatureProviders.CertificateStore
             _cryptoServiceProvider = cryptoServiceProvider;
             _privateKeyContainer = privateKeyContainer;
             _isMachineKeyContainer = isMachineKeyContainer;
+            _isUserProtectedKey = isUserProtectedKey;
             _certificateFilePath = certificateFilePath;
             _certificateFilePassword = certificateFilePassword;
         }
@@ -98,7 +102,8 @@ namespace Sign.SignatureProviders.CertificateStore
                     _privateKeyContainer,
                     _certificateFilePath,
                     _certificateFilePassword,
-                    _isMachineKeyContainer);
+                    _isMachineKeyContainer,
+                    _isUserProtectedKey);
             }
 
             return _certificateStoreService;

--- a/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceProviderTests.cs
+++ b/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceProviderTests.cs
@@ -20,7 +20,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         private const string? CertificateFilePath = null;
         private const string? CertificateFilePassword = null;
         private const bool IsMachineKeyContainer = true;
-        private const bool IsUserProtectedKey = false;
+        private const bool IsUiAllowed = false;
         private readonly IServiceProvider serviceProvider;
 
         public CertificateStoreServiceProviderTests()
@@ -34,7 +34,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCertificateFingerprintIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new CertificateStoreServiceProvider(certificateFingerprint: null!, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
+                () => new CertificateStoreServiceProvider(certificateFingerprint: null!, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
 
             Assert.Equal("certificateFingerprint", exception.ParamName);
         }
@@ -43,7 +43,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCertificateFingerprintIsEmpty_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(certificateFingerprint: string.Empty, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
+                () => new CertificateStoreServiceProvider(certificateFingerprint: string.Empty, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
 
             Assert.Equal("certificateFingerprint", exception.ParamName);
         }
@@ -52,7 +52,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCryptoServiceProviderIsNullAndPrivateKeyContainerIsNot_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider: null, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider: null, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
 
             Assert.Equal("cryptoServiceProvider", exception.ParamName);
         }
@@ -61,7 +61,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCryptoServiceProviderIsEmptyAndPrivateKeyContainerIsNot_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider: string.Empty, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider: string.Empty, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
 
             Assert.Equal("cryptoServiceProvider", exception.ParamName);
         }
@@ -70,7 +70,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenPrivateKeyContainerIsNullAndCryptoServiceProviderIsNot_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, privateKeyContainer: null, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, privateKeyContainer: null, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
 
             Assert.Equal("privateKeyContainer", exception.ParamName);
         }
@@ -79,7 +79,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenPrivateKeyContainerIsEmptyAndCryptoServiceProviderIsNot_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, privateKeyContainer: string.Empty, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, privateKeyContainer: string.Empty, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
 
             Assert.Equal("privateKeyContainer", exception.ParamName);
         }
@@ -91,13 +91,13 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         [InlineData("", "")]
         public void Constructor_WhenPrivateKeyContainerAndCryptoServiceProviderAreBothNullOrEmpty_DoesNotThrow(string? cryptoServiceProvider, string? privateKeyContainer)
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider, privateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider, privateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed);
         }
 
         [Fact]
         public void GetSignatureAlgorithmProvider_WhenServiceProviderIsNull_Throws()
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed);
 
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => provider.GetSignatureAlgorithmProvider(serviceProvider: null!));
@@ -108,7 +108,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         [Fact]
         public void GetSignatureAlgorithmProvider_ReturnsSameInstance()
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed);
 
             ConcurrentBag<ISignatureAlgorithmProvider> signatureAlgorithmProviders = [];
             Parallel.For(0, 2, (_, _) =>
@@ -123,7 +123,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         [Fact]
         public void GetCertificateProvider_WhenServiceProviderIsNull_Throws()
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed);
 
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => provider.GetCertificateProvider(serviceProvider: null!));
@@ -134,7 +134,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         [Fact]
         public void GetCertificateProvider_ReturnsSameInstance()
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed);
 
             ConcurrentBag<ICertificateProvider> certificateProviders = [];
             Parallel.For(0, 2, (_, _) =>

--- a/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceProviderTests.cs
+++ b/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceProviderTests.cs
@@ -20,6 +20,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         private const string? CertificateFilePath = null;
         private const string? CertificateFilePassword = null;
         private const bool IsMachineKeyContainer = true;
+        private const bool IsUserProtectedKey = false;
         private readonly IServiceProvider serviceProvider;
 
         public CertificateStoreServiceProviderTests()
@@ -33,7 +34,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCertificateFingerprintIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new CertificateStoreServiceProvider(certificateFingerprint: null!, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+                () => new CertificateStoreServiceProvider(certificateFingerprint: null!, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
 
             Assert.Equal("certificateFingerprint", exception.ParamName);
         }
@@ -42,7 +43,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCertificateFingerprintIsEmpty_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(certificateFingerprint: string.Empty, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+                () => new CertificateStoreServiceProvider(certificateFingerprint: string.Empty, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
 
             Assert.Equal("certificateFingerprint", exception.ParamName);
         }
@@ -51,7 +52,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCryptoServiceProviderIsNullAndPrivateKeyContainerIsNot_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider: null, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider: null, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
 
             Assert.Equal("cryptoServiceProvider", exception.ParamName);
         }
@@ -60,7 +61,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCryptoServiceProviderIsEmptyAndPrivateKeyContainerIsNot_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider: string.Empty, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider: string.Empty, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
 
             Assert.Equal("cryptoServiceProvider", exception.ParamName);
         }
@@ -69,7 +70,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenPrivateKeyContainerIsNullAndCryptoServiceProviderIsNot_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, privateKeyContainer: null, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, privateKeyContainer: null, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
 
             Assert.Equal("privateKeyContainer", exception.ParamName);
         }
@@ -78,7 +79,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenPrivateKeyContainerIsEmptyAndCryptoServiceProviderIsNot_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, privateKeyContainer: string.Empty, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, privateKeyContainer: string.Empty, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
 
             Assert.Equal("privateKeyContainer", exception.ParamName);
         }
@@ -90,13 +91,13 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         [InlineData("", "")]
         public void Constructor_WhenPrivateKeyContainerAndCryptoServiceProviderAreBothNullOrEmpty_DoesNotThrow(string? cryptoServiceProvider, string? privateKeyContainer)
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider, privateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider, privateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey);
         }
 
         [Fact]
         public void GetSignatureAlgorithmProvider_WhenServiceProviderIsNull_Throws()
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey);
 
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => provider.GetSignatureAlgorithmProvider(serviceProvider: null!));
@@ -107,7 +108,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         [Fact]
         public void GetSignatureAlgorithmProvider_ReturnsSameInstance()
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey);
 
             ConcurrentBag<ISignatureAlgorithmProvider> signatureAlgorithmProviders = [];
             Parallel.For(0, 2, (_, _) =>
@@ -122,7 +123,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         [Fact]
         public void GetCertificateProvider_WhenServiceProviderIsNull_Throws()
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey);
 
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => provider.GetCertificateProvider(serviceProvider: null!));
@@ -133,7 +134,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         [Fact]
         public void GetCertificateProvider_ReturnsSameInstance()
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey);
 
             ConcurrentBag<ICertificateProvider> certificateProviders = [];
             Parallel.For(0, 2, (_, _) =>

--- a/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceProviderTests.cs
+++ b/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceProviderTests.cs
@@ -20,7 +20,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         private const string? CertificateFilePath = null;
         private const string? CertificateFilePassword = null;
         private const bool IsMachineKeyContainer = true;
-        private const bool IsUiAllowed = false;
+        private const bool IsInteractive = false;
         private readonly IServiceProvider serviceProvider;
 
         public CertificateStoreServiceProviderTests()
@@ -34,7 +34,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCertificateFingerprintIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new CertificateStoreServiceProvider(certificateFingerprint: null!, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
+                () => new CertificateStoreServiceProvider(certificateFingerprint: null!, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsInteractive));
 
             Assert.Equal("certificateFingerprint", exception.ParamName);
         }
@@ -43,7 +43,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCertificateFingerprintIsEmpty_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(certificateFingerprint: string.Empty, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
+                () => new CertificateStoreServiceProvider(certificateFingerprint: string.Empty, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsInteractive));
 
             Assert.Equal("certificateFingerprint", exception.ParamName);
         }
@@ -52,7 +52,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCryptoServiceProviderIsNullAndPrivateKeyContainerIsNot_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider: null, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider: null, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsInteractive));
 
             Assert.Equal("cryptoServiceProvider", exception.ParamName);
         }
@@ -61,7 +61,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCryptoServiceProviderIsEmptyAndPrivateKeyContainerIsNot_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider: string.Empty, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider: string.Empty, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsInteractive));
 
             Assert.Equal("cryptoServiceProvider", exception.ParamName);
         }
@@ -70,7 +70,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenPrivateKeyContainerIsNullAndCryptoServiceProviderIsNot_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, privateKeyContainer: null, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, privateKeyContainer: null, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsInteractive));
 
             Assert.Equal("privateKeyContainer", exception.ParamName);
         }
@@ -79,7 +79,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenPrivateKeyContainerIsEmptyAndCryptoServiceProviderIsNot_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, privateKeyContainer: string.Empty, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
+                () => new CertificateStoreServiceProvider(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, privateKeyContainer: string.Empty, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsInteractive));
 
             Assert.Equal("privateKeyContainer", exception.ParamName);
         }
@@ -91,13 +91,13 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         [InlineData("", "")]
         public void Constructor_WhenPrivateKeyContainerAndCryptoServiceProviderAreBothNullOrEmpty_DoesNotThrow(string? cryptoServiceProvider, string? privateKeyContainer)
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider, privateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, cryptoServiceProvider, privateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsInteractive);
         }
 
         [Fact]
         public void GetSignatureAlgorithmProvider_WhenServiceProviderIsNull_Throws()
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsInteractive);
 
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => provider.GetSignatureAlgorithmProvider(serviceProvider: null!));
@@ -108,7 +108,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         [Fact]
         public void GetSignatureAlgorithmProvider_ReturnsSameInstance()
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsInteractive);
 
             ConcurrentBag<ISignatureAlgorithmProvider> signatureAlgorithmProviders = [];
             Parallel.For(0, 2, (_, _) =>
@@ -123,7 +123,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         [Fact]
         public void GetCertificateProvider_WhenServiceProviderIsNull_Throws()
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsInteractive);
 
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
                 () => provider.GetCertificateProvider(serviceProvider: null!));
@@ -134,7 +134,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         [Fact]
         public void GetCertificateProvider_ReturnsSameInstance()
         {
-            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed);
+            CertificateStoreServiceProvider provider = new(CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsInteractive);
 
             ConcurrentBag<ICertificateProvider> certificateProviders = [];
             Parallel.For(0, 2, (_, _) =>

--- a/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceTests.cs
+++ b/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceTests.cs
@@ -18,6 +18,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         private const string? CertificateFilePath = null;
         private const string? CertificateFilePassword = null;
         private const bool IsMachineKeyContainer = true;
+        private const bool IsUserProtectedKey = false;
         private readonly IServiceProvider serviceProvider;
 
         public CertificateStoreServiceTests()
@@ -31,7 +32,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenServiceProviderIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new CertificateStoreService(serviceProvider: null!, CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+                () => new CertificateStoreService(serviceProvider: null!, CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
 
             Assert.Equal("serviceProvider", exception.ParamName);
         }
@@ -40,7 +41,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCertificateFingerprintIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new CertificateStoreService(serviceProvider, certificateFingerprint: null!, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+                () => new CertificateStoreService(serviceProvider, certificateFingerprint: null!, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
 
             Assert.Equal("certificateFingerprint", exception.ParamName);
         }
@@ -49,7 +50,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCertificateFingerprintIsEmpty_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreService(serviceProvider, certificateFingerprint: string.Empty, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer));
+                () => new CertificateStoreService(serviceProvider, certificateFingerprint: string.Empty, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
 
             Assert.Equal("certificateFingerprint", exception.ParamName);
         }

--- a/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceTests.cs
+++ b/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceTests.cs
@@ -18,7 +18,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         private const string? CertificateFilePath = null;
         private const string? CertificateFilePassword = null;
         private const bool IsMachineKeyContainer = true;
-        private const bool IsUiAllowed = false;
+        private const bool IsInteractive = false;
         private readonly IServiceProvider serviceProvider;
 
         public CertificateStoreServiceTests()
@@ -32,7 +32,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenServiceProviderIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new CertificateStoreService(serviceProvider: null!, CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
+                () => new CertificateStoreService(serviceProvider: null!, CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsInteractive));
 
             Assert.Equal("serviceProvider", exception.ParamName);
         }
@@ -41,7 +41,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCertificateFingerprintIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new CertificateStoreService(serviceProvider, certificateFingerprint: null!, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
+                () => new CertificateStoreService(serviceProvider, certificateFingerprint: null!, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsInteractive));
 
             Assert.Equal("certificateFingerprint", exception.ParamName);
         }
@@ -50,7 +50,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCertificateFingerprintIsEmpty_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreService(serviceProvider, certificateFingerprint: string.Empty, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
+                () => new CertificateStoreService(serviceProvider, certificateFingerprint: string.Empty, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsInteractive));
 
             Assert.Equal("certificateFingerprint", exception.ParamName);
         }

--- a/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceTests.cs
+++ b/test/Sign.SignatureProviders.CertificateStore.Test/CertificateStoreServiceTests.cs
@@ -18,7 +18,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         private const string? CertificateFilePath = null;
         private const string? CertificateFilePassword = null;
         private const bool IsMachineKeyContainer = true;
-        private const bool IsUserProtectedKey = false;
+        private const bool IsUiAllowed = false;
         private readonly IServiceProvider serviceProvider;
 
         public CertificateStoreServiceTests()
@@ -32,7 +32,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenServiceProviderIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new CertificateStoreService(serviceProvider: null!, CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
+                () => new CertificateStoreService(serviceProvider: null!, CertificateFingerprint, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
 
             Assert.Equal("serviceProvider", exception.ParamName);
         }
@@ -41,7 +41,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCertificateFingerprintIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new CertificateStoreService(serviceProvider, certificateFingerprint: null!, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
+                () => new CertificateStoreService(serviceProvider, certificateFingerprint: null!, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
 
             Assert.Equal("certificateFingerprint", exception.ParamName);
         }
@@ -50,7 +50,7 @@ namespace Sign.SignatureProviders.CertificateStore.Test
         public void Constructor_WhenCertificateFingerprintIsEmpty_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new CertificateStoreService(serviceProvider, certificateFingerprint: string.Empty, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUserProtectedKey));
+                () => new CertificateStoreService(serviceProvider, certificateFingerprint: string.Empty, CertificateFingerprintAlgorithm, CryptoServiceProvider, PrivateKeyContainer, CertificateFilePath, CertificateFilePassword, IsMachineKeyContainer, IsUiAllowed));
 
             Assert.Equal("certificateFingerprint", exception.ParamName);
         }


### PR DESCRIPTION
Sign needs to be able to use user-protected keys, such as keys stored in a USB eToken device. These generally require user interaction when the key is used and signing will fail when dialogs are blocked.

User interaction requires the 'Silent' flag to not be set in CertificateStoreService.GetRsaAsync method. The rest of this is plumbing to make a user option available to this code.

The new option is --user-protected-key/-upk to turn off the silent flag. The flag name corresponds to the enum value
CspProviderFlags.UseUserProtectedKey in
System.Security.Cryptography. I preferred this to not-silent or -silent false (with a true default).

I'm sure there is a process for translation, but I do not know if this is done with the initial pull request.