### PR TITLE
Better manifest file detection

### DIFF
--- a/src/Sign.Core/DataFormatSigners/ClickOnceSigner.cs
+++ b/src/Sign.Core/DataFormatSigners/ClickOnceSigner.cs
@@ -127,8 +127,8 @@ namespace Sign.Core
 
                     // Inner files are now signed
                     // now look for the manifest file and sign that if we have one
-
-                    FileInfo? manifestFile = filteredFiles.SingleOrDefault(f => ".manifest".Equals(f.Extension, StringComparison.OrdinalIgnoreCase));
+                    var appManifestFromDeploymentManifest = GetApplicationManifestForDeploymentManifest(file);
+                    FileInfo? manifestFile = filteredFiles.SingleOrDefault(f => f.Name.Equals(appManifestFromDeploymentManifest?.Name, StringComparison.OrdinalIgnoreCase));
 
                     string fileArgs = $@"-update ""{manifestFile}"" {args}";
 

--- a/src/Sign.Core/Resources.Designer.cs
+++ b/src/Sign.Core/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Sign.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty &apos;codebase&apos; attribute within the deployment manifest..
+        /// </summary>
+        internal static string ApplicationManifestNotFound {
+            get {
+                return ResourceManager.GetString("ApplicationManifestNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Signing SignTool job with {count} files..
         /// </summary>
         internal static string AzureSignToolSignatureProviderSigning {

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -275,4 +275,7 @@
   <data name="VSIXSignToolUnsupportedAlgorithm" xml:space="preserve">
     <value>The algorithm selected is not supported.</value>
   </data>
+  <data name="ApplicationManifestNotFound" xml:space="preserve">
+    <value>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</value>
+  </data>
 </root>

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Podepisování úlohy SignTool s tímto počtem souborů: {count}.</target>

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Der SignTool-Auftrag wird mit {count} Dateien signiert.</target>

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Firmando el trabajo de SignTool con {count} archivos.</target>

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Signature du travail SignTool avec {count} fichiers.</target>

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Firma del processo SignTool con {count} file.</target>

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">{count} 個のファイルを使用して SignTool ジョブに署名しています。</target>

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">{count} 파일로 SignTool 작업에 서명하는 중입니다.</target>

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Podpisywanie zadania SignTool przy użyciu {count} plików.</target>

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Autenticando o trabalho SignTool com {count} arquivos.</target>

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Задание подписывания SignTool с несколькими файлами ({count}).</target>

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">SignTool işi {count} dosya ile imzalanıyor.</target>

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">正在对包含 {count} 个文件的 SignTool 作业进行签名。</target>

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">正在簽署具有 {count} 個檔案的 SignTool 工作。</target>

--- a/test/Sign.Core.Test/SignatureProviders/ClickOnceSignerTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/ClickOnceSignerTests.cs
@@ -16,15 +16,15 @@ namespace Sign.Core.Test
 
         private const string DeploymentManifestValidContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
             <asmv1:assembly xsi:schemaLocation=""urn:schemas-microsoft-com:asm.v1 assembly.adaptive.xsd"" manifestVersion=""1.0"" xmlns:asmv1=""urn:schemas-microsoft-com:asm.v1"" xmlns=""urn:schemas-microsoft-com:asm.v2"" xmlns:asmv2=""urn:schemas-microsoft-com:asm.v2"" xmlns:xrml=""urn:mpeg:mpeg21:2003:01-REL-R-NS"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:asmv3=""urn:schemas-microsoft-com:asm.v3"" xmlns:dsig=""http://www.w3.org/2000/09/xmldsig#"" xmlns:co.v1=""urn:schemas-microsoft-com:clickonce.v1"" xmlns:co.v2=""urn:schemas-microsoft-com:clickonce.v2"">
-                <assemblyIdentity name=""MyApp.application"" version=""0.0.1.15"" publicKeyToken=""0000000000000000"" language=""neutral"" processorArchitecture=""msil"" xmlns=""urn:schemas-microsoft-com:asm.v1"" />
+                <assemblyIdentity name=""MyApp.application"" version=""1.0.0.0"" publicKeyToken=""0000000000000000"" language=""neutral"" processorArchitecture=""msil"" xmlns=""urn:schemas-microsoft-com:asm.v1"" />
                 <description asmv2:publisher=""Contoso Limited"" asmv2:product=""MyApp"" xmlns=""urn:schemas-microsoft-com:asm.v1"" />
                 <deployment install=""false"" />
                 <compatibleFrameworks xmlns=""urn:schemas-microsoft-com:clickonce.v2"">
                     <framework targetVersion=""4.8"" profile=""Full"" supportedRuntime=""4.0.30319"" />
                 </compatibleFrameworks>
                 <dependency>
-                    <dependentAssembly dependencyType=""install"" codebase=""MyApp.dll.manifest"" size=""14853"">
-                        <assemblyIdentity name=""MyApp.dll"" version=""0.0.1.15"" publicKeyToken=""0000000000000000"" language=""neutral"" processorArchitecture=""msil"" type=""win32"" />
+                    <dependentAssembly dependencyType=""install"" codebase=""MyApp_1_0_0_0\MyApp.dll.manifest"" size=""14853"">
+                        <assemblyIdentity name=""MyApp.dll"" version=""1.0.0.0"" publicKeyToken=""0000000000000000"" language=""neutral"" processorArchitecture=""msil"" type=""win32"" />
                     </dependentAssembly>
                 </dependency>
             </asmv1:assembly>

--- a/test/Sign.Core.Test/SignatureProviders/ClickOnceSignerTests.cs
+++ b/test/Sign.Core.Test/SignatureProviders/ClickOnceSignerTests.cs
@@ -14,6 +14,22 @@ namespace Sign.Core.Test
         private readonly DirectoryService _directoryService = new(Mock.Of<ILogger<IDirectoryService>>());
         private readonly ClickOnceSigner _signer;
 
+        private const string DeploymentManifestValidContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+            <asmv1:assembly xsi:schemaLocation=""urn:schemas-microsoft-com:asm.v1 assembly.adaptive.xsd"" manifestVersion=""1.0"" xmlns:asmv1=""urn:schemas-microsoft-com:asm.v1"" xmlns=""urn:schemas-microsoft-com:asm.v2"" xmlns:asmv2=""urn:schemas-microsoft-com:asm.v2"" xmlns:xrml=""urn:mpeg:mpeg21:2003:01-REL-R-NS"" xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:asmv3=""urn:schemas-microsoft-com:asm.v3"" xmlns:dsig=""http://www.w3.org/2000/09/xmldsig#"" xmlns:co.v1=""urn:schemas-microsoft-com:clickonce.v1"" xmlns:co.v2=""urn:schemas-microsoft-com:clickonce.v2"">
+                <assemblyIdentity name=""MyApp.application"" version=""0.0.1.15"" publicKeyToken=""0000000000000000"" language=""neutral"" processorArchitecture=""msil"" xmlns=""urn:schemas-microsoft-com:asm.v1"" />
+                <description asmv2:publisher=""Contoso Limited"" asmv2:product=""MyApp"" xmlns=""urn:schemas-microsoft-com:asm.v1"" />
+                <deployment install=""false"" />
+                <compatibleFrameworks xmlns=""urn:schemas-microsoft-com:clickonce.v2"">
+                    <framework targetVersion=""4.8"" profile=""Full"" supportedRuntime=""4.0.30319"" />
+                </compatibleFrameworks>
+                <dependency>
+                    <dependentAssembly dependencyType=""install"" codebase=""MyApp.dll.manifest"" size=""14853"">
+                        <assemblyIdentity name=""MyApp.dll"" version=""0.0.1.15"" publicKeyToken=""0000000000000000"" language=""neutral"" processorArchitecture=""msil"" type=""win32"" />
+                    </dependentAssembly>
+                </dependency>
+            </asmv1:assembly>
+";
+
         public ClickOnceSignerTests()
         {
             _signer = new ClickOnceSigner(
@@ -215,7 +231,7 @@ namespace Sign.Core.Test
                 FileInfo applicationFile = AddFile(
                     containerSpy,
                     temporaryDirectory.Directory,
-                    string.Empty,
+                    DeploymentManifestValidContent,
                     "MyApp.application");
                 FileInfo dllDeployFile = AddFile(
                     containerSpy,
@@ -364,7 +380,7 @@ namespace Sign.Core.Test
                 FileInfo applicationFile = AddFile(
                     containerSpy,
                     temporaryDirectory.Directory,
-                    string.Empty,
+                    DeploymentManifestValidContent,
                     "MyApp.application");
 
                 SignOptions options = new(


### PR DESCRIPTION
This PR changes the ClickOnce signer to better detect which .dll.manifest or .exe.manifest Application manifest file to sign. It reads the supplied .vsto/.application Deployment manifest file and parses out the name of the Application manifest that's referenced, and then passes that to `mage` for updating.