### PR TITLE
Explicitly fail if all deployment manifests are excluded from signing

### DIFF
--- a/src/Sign.Core/DataFormatSigners/ClickOnceSigner.cs
+++ b/src/Sign.Core/DataFormatSigners/ClickOnceSigner.cs
@@ -162,6 +162,13 @@ namespace Sign.Core
                         .Select(f => f.file)
                         .ToList();
 
+                    // If the user supplies the path to a deployment manifest as the file to sign, and also supplies
+                    // a file path filter via --file-list which DOES NOT match the deployment manifest path, then
+                    // it won't be signed even though the rest of the files were. This is not an expected configuration
+                    // so we should explicitly reject such a situation.
+                    if (!deploymentManifestFiles.Any())
+                        throw new InvalidOperationException(Resources.NoDeploymentManifestsSelectedForSigning);
+
                     foreach (FileInfo deploymentManifestFile in deploymentManifestFiles)
                     {
                         fileArgs = $@"-update ""{deploymentManifestFile.FullName}"" {args} {publisherParam}";

--- a/src/Sign.Core/Resources.Designer.cs
+++ b/src/Sign.Core/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Sign.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty &apos;codebase&apos; attribute within the deployment manifest..
+        /// </summary>
+        internal static string ApplicationManifestNotFound {
+            get {
+                return ResourceManager.GetString("ApplicationManifestNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Signing SignTool job with {count} files..
         /// </summary>
         internal static string AzureSignToolSignatureProviderSigning {
@@ -246,6 +255,15 @@ namespace Sign.Core {
         internal static string MultiplePrivateKeyContainersError {
             get {
                 return ResourceManager.GetString("MultiplePrivateKeyContainersError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No deployment manifest files have been detected for signing, possibly because they&apos;ve been excluded via file path filters.
+        /// </summary>
+        internal static string NoDeploymentManifestsSelectedForSigning {
+            get {
+                return ResourceManager.GetString("NoDeploymentManifestsSelectedForSigning", resourceCulture);
             }
         }
         

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -275,4 +275,10 @@
   <data name="VSIXSignToolUnsupportedAlgorithm" xml:space="preserve">
     <value>The algorithm selected is not supported.</value>
   </data>
+  <data name="ApplicationManifestNotFound" xml:space="preserve">
+    <value>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</value>
+  </data>
+  <data name="NoDeploymentManifestsSelectedForSigning" xml:space="preserve">
+    <value>No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</value>
+  </data>
 </root>

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Podepisování úlohy SignTool s tímto počtem souborů: {count}.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="translated">Poskytlo se několik kontejnerů privátních klíčů. Pro úložiště uživatele použijte /k a pro úložiště počítače použijte /km.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoDeploymentManifestsSelectedForSigning">
+        <source>No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</source>
+        <target state="new">No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Der SignTool-Auftrag wird mit {count} Dateien signiert.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="translated">Es wurden mehrere Container mit privatem Schlüssel bereitgestellt. Verwenden Sie entweder "/k" für Benutzerspeicher oder "/km" für Computerspeicher.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoDeploymentManifestsSelectedForSigning">
+        <source>No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</source>
+        <target state="new">No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Firmando el trabajo de SignTool con {count} archivos.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="translated">Se proporcionaron varios contenedores de clave privada. Use /k para almacenes de usuarios o /km para almacenes de máquinas.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoDeploymentManifestsSelectedForSigning">
+        <source>No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</source>
+        <target state="new">No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Signature du travail SignTool avec {count} fichiers.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="translated">Plusieurs conteneurs de clé privée ont été fournis. Utilisez /k pour les magasins d’utilisateurs ou /km pour les magasins d’ordinateurs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoDeploymentManifestsSelectedForSigning">
+        <source>No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</source>
+        <target state="new">No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Firma del processo SignTool con {count} file.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="translated">Sono stati specificati più contenitori di chiavi private. Utilizzare /k per gli archivi utente o /km per gli archivi computer.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoDeploymentManifestsSelectedForSigning">
+        <source>No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</source>
+        <target state="new">No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">{count} 個のファイルを使用して SignTool ジョブに署名しています。</target>
@@ -105,6 +110,11 @@
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="translated">複数の秘密キー コンテナーが提供されています。ユーザー ストアの場合は /k、コンピューター ストアの場合は /km を使用します。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoDeploymentManifestsSelectedForSigning">
+        <source>No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</source>
+        <target state="new">No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">{count} 파일로 SignTool 작업에 서명하는 중입니다.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="translated">여러 프라이빗 키 컨테이너가 제공되었습니다. 사용자 저장소에는 /k를, 컴퓨터 저장소에는 /km를 사용합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoDeploymentManifestsSelectedForSigning">
+        <source>No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</source>
+        <target state="new">No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Podpisywanie zadania SignTool przy użyciu {count} plików.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="translated">Podano wiele kontenerów kluczy prywatnych. Użyj opcji /k dla magazynów użytkowników lub opcji /km dla magazynów komputerów.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoDeploymentManifestsSelectedForSigning">
+        <source>No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</source>
+        <target state="new">No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Autenticando o trabalho SignTool com {count} arquivos.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="translated">Vários contêineres de chave privada fornecidos. Use /k para repositórios de usuários ou /km para repositórios de computadores.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoDeploymentManifestsSelectedForSigning">
+        <source>No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</source>
+        <target state="new">No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Задание подписывания SignTool с несколькими файлами ({count}).</target>
@@ -105,6 +110,11 @@
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="translated">Предоставлено несколько контейнеров закрытых ключей. Используйте /k для хранилищ пользователей или /km для хранилищ компьютеров.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoDeploymentManifestsSelectedForSigning">
+        <source>No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</source>
+        <target state="new">No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">SignTool işi {count} dosya ile imzalanıyor.</target>
@@ -105,6 +110,11 @@
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="translated">Birden çok özel anahtar kapsayıcısı sağlandı. Kullanıcı depoları için /k veya makine depoları için /km kullanın.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoDeploymentManifestsSelectedForSigning">
+        <source>No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</source>
+        <target state="new">No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">正在对包含 {count} 个文件的 SignTool 作业进行签名。</target>
@@ -105,6 +110,11 @@
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="translated">提供了多个私钥容器。对用户存储使用 /k，或者对计算机存储使用 /km。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoDeploymentManifestsSelectedForSigning">
+        <source>No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</source>
+        <target state="new">No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
+      <trans-unit id="ApplicationManifestNotFound">
+        <source>Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</source>
+        <target state="new">Did not find exactly 1 &lt;dependentAssembly&gt; element with a non-empty 'codebase' attribute within the deployment manifest.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">正在簽署具有 {count} 個檔案的 SignTool 工作。</target>
@@ -105,6 +110,11 @@
       <trans-unit id="MultiplePrivateKeyContainersError">
         <source>Multiple private key containers provided. Use either /k for user stores or /km for machine stores.</source>
         <target state="translated">已提供多個私密金鑰。使用者存放區使用 /k，機器存放區則使用 /km。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoDeploymentManifestsSelectedForSigning">
+        <source>No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</source>
+        <target state="new">No deployment manifest files have been detected for signing, possibly because they've been excluded via file path filters</target>
         <note />
       </trans-unit>
       <trans-unit id="NoPrivateKeyContainerError">


### PR DESCRIPTION
There's not really any good reason to sign a clickonce deployment manifest and then use --file-list filters to exclude it from being signed. This PR causes such a situation to fail loudly rather than silently signing the rest of the files but not the deployment manifest.

I considered just having the ClickOnceSigner add the deployment manifest file back into `deploymentManifestFiles` if it's otherwise empty, but I decided in the end that it's better if the user is required to configure things properly rather than silently fixing it for them.