### PR TITLE
Warn if MSVCRT 14 not detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@
 
 This project aims to make it easier to integrate secure code signing into a CI pipeline by using cloud-based hardware security module(HSM)-protected keys. This project is part of the [.NET Foundation](https://www.dotnetfoundation.org/) and operates under their [code of conduct](https://www.dotnetfoundation.org/code-of-conduct). It is licensed under [MIT](https://opensource.org/licenses/MIT) (an OSI approved license).
 
+## Prerequisites
+
+- An up-to-date x64-based version of Windows currently in [mainstream support](https://learn.microsoft.com/lifecycle/products/)
+- [.NET 8 SDK or later](https://dotnet.microsoft.com/download)
+- [Microsoft Visual C++ 14 runtime](https://aka.ms/vs/17/release/vc_redist.x64.exe)
+
+## Install
+
+To install Sign CLI in the current directory, open a command prompt, path to the directory where Sign CLI will be installed, and execute:
+
+```
+dotnet new tool-manifest
+dotnet tool install --local --prerelease sign
+```
+
+To run Sign CLI, execute `dotnet sign` from the same directory.
+
 ## Design
 
 Given an initial file path or glob pattern, this tool recursively searches directories and containers to find signable files and containers.  For each signable artifact, the tool uses an implementation of [`System.Security.Cryptography.RSA`](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.rsa?view=net-7.0) that delegates the signing operation to Azure Key Vault.  The tool computes a digest (or hash) of the to-be-signed content and submits the digest --- not the original content --- to Azure Key Vault for digest signing.  The returned raw signature value is then incorporated in whatever signature format is appropriate for the file type.  Signable content is not sent to Azure Key Vault.
@@ -79,7 +96,6 @@ The following information is needed for the signing build:
 ## Creating a code signing certificate in Azure Key Vault
 
 Code signing certificates must use the `RSA-HSM` key type to ensure the private keys are stored in a FIPS 140-2 compliant manner. While you can import a certificate from a PFX file, if available, the most secure option is to create a new Certificate Signing Request to provide to your certificate authority, and then merge in the public certificate they issue. Detailed steps are available [here](https://learn.microsoft.com/en-us/answers/questions/732422/ev-code-signing-with-azure-keyvault-and-azure-pipe).
-
 
 ## Migrating from the legacy code signing service
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project aims to make it easier to integrate secure code signing into a CI p
 
 ## Install
 
-To install Sign CLI in the current directory, open a command prompt, and execute:
+To install Sign CLI in the current directory, open a command prompt and execute:
 
 ```
 dotnet tool install --tool-path . --prerelease sign

--- a/README.md
+++ b/README.md
@@ -12,14 +12,13 @@ This project aims to make it easier to integrate secure code signing into a CI p
 
 ## Install
 
-To install Sign CLI in the current directory, open a command prompt, path to the directory where Sign CLI will be installed, and execute:
+To install Sign CLI in the current directory, open a command prompt, and execute:
 
 ```
-dotnet new tool-manifest
-dotnet tool install --local --prerelease sign
+dotnet tool install --tool-path . --prerelease sign
 ```
 
-To run Sign CLI, execute `dotnet sign` from the same directory.
+To run Sign CLI, execute `sign` from the same directory.
 
 ## Design
 

--- a/src/Sign.Cli/PACKAGE.md
+++ b/src/Sign.Cli/PACKAGE.md
@@ -4,6 +4,12 @@ Sign CLI is a .NET tool that provides digital signing for .NET assemblies, packa
 
 The tool signs files inside-out, starting with the most nested files and then the outer files, ensuring everything is signed in the correct order.
 
+## Prerequisites
+
+- An up-to-date x64-based version of Windows currently in [mainstream support](https://learn.microsoft.com/lifecycle/products/)
+- [.NET 8 SDK or later](https://dotnet.microsoft.com/download)
+- [Microsoft Visual C++ 14 runtime](https://aka.ms/vs/17/release/vc_redist.x64.exe)
+
 ## Usage
 
 - For help with...

--- a/src/Sign.Cli/Program.cs
+++ b/src/Sign.Cli/Program.cs
@@ -51,9 +51,7 @@ namespace Sign.Cli
 
                 if (!File.Exists(vcRuntime140FilePath))
                 {
-                    Console.ForegroundColor = ConsoleColor.Yellow;
-                    Console.WriteLine(Resources.MsvcrtNotDetected);
-                    Console.ResetColor();
+                    WriteWarning(Resources.MsvcrtNotDetected);
                 }
 
                 try
@@ -69,6 +67,13 @@ namespace Sign.Cli
                     return ExitCode.Failed;
                 }
             }
+        }
+
+        private static void WriteWarning(string warning)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine(warning);
+            Console.ResetColor();
         }
 
         internal static Parser CreateParser(IServiceProviderFactory? serviceProviderFactory = null)

--- a/src/Sign.Cli/Program.cs
+++ b/src/Sign.Cli/Program.cs
@@ -44,6 +44,18 @@ namespace Sign.Cli
 
                 AddEnvironmentPath(netfxDir);
 
+                string systemDirectoryPath = Environment.GetFolderPath(Environment.SpecialFolder.System);
+
+                // NavSip.dll has a dependency on this.
+                string vcRuntime140FilePath = Path.Combine(systemDirectoryPath, "vcruntime140.dll");
+
+                if (!File.Exists(vcRuntime140FilePath))
+                {
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    Console.WriteLine(Resources.MsvcrtNotDetected);
+                    Console.ResetColor();
+                }
+
                 try
                 {
                     Parser parser = CreateParser();

--- a/src/Sign.Cli/Resources.Designer.cs
+++ b/src/Sign.Cli/Resources.Designer.cs
@@ -277,6 +277,15 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe.
+        /// </summary>
+        internal static string MsvcrtNotDetected {
+            get {
+                return ResourceManager.GetString("MsvcrtNotDetected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No inputs found to sign..
         /// </summary>
         internal static string NoFilesToSign {

--- a/src/Sign.Cli/Resources.resx
+++ b/src/Sign.Cli/Resources.resx
@@ -230,4 +230,8 @@
   <data name="x86NotSupported" xml:space="preserve">
     <value>Only Windows x64 is supported at this time. See https://github.com/dotnet/sign/issues/474 regarding Windows x86 support.</value>
   </data>
+  <data name="MsvcrtNotDetected" xml:space="preserve">
+    <value>Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</value>
+    <comment>{Locked="https://aka.ms/vs/17/release/vc_redist.x64.exe"} is a URL.</comment>
+  </data>
 </root>

--- a/src/Sign.Cli/xlf/Resources.cs.xlf
+++ b/src/Sign.Cli/xlf/Resources.cs.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Vyžaduje se soubor nebo glob.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MsvcrtNotDetected">
+        <source>Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</source>
+        <target state="new">Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</target>
+        <note>{Locked="https://aka.ms/vs/17/release/vc_redist.x64.exe"} is a URL.</note>
+      </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
         <target state="translated">Nenašly se žádné vstupy, které by bylo možné podepsat.</target>

--- a/src/Sign.Cli/xlf/Resources.de.xlf
+++ b/src/Sign.Cli/xlf/Resources.de.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Eine Datei oder ein Glob ist erforderlich.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MsvcrtNotDetected">
+        <source>Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</source>
+        <target state="new">Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</target>
+        <note>{Locked="https://aka.ms/vs/17/release/vc_redist.x64.exe"} is a URL.</note>
+      </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
         <target state="translated">Es wurden keine Eingaben zum Signieren gefunden.</target>

--- a/src/Sign.Cli/xlf/Resources.es.xlf
+++ b/src/Sign.Cli/xlf/Resources.es.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Se requiere un archivo o glob.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MsvcrtNotDetected">
+        <source>Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</source>
+        <target state="new">Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</target>
+        <note>{Locked="https://aka.ms/vs/17/release/vc_redist.x64.exe"} is a URL.</note>
+      </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
         <target state="translated">No se encontraron entradas para firmar.</target>

--- a/src/Sign.Cli/xlf/Resources.fr.xlf
+++ b/src/Sign.Cli/xlf/Resources.fr.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Un fichier ou un glob est requis.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MsvcrtNotDetected">
+        <source>Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</source>
+        <target state="new">Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</target>
+        <note>{Locked="https://aka.ms/vs/17/release/vc_redist.x64.exe"} is a URL.</note>
+      </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
         <target state="translated">Aucune entrée à signer.</target>

--- a/src/Sign.Cli/xlf/Resources.it.xlf
+++ b/src/Sign.Cli/xlf/Resources.it.xlf
@@ -122,6 +122,11 @@
         <target state="translated">È necessario specificare un file o un GLOB.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MsvcrtNotDetected">
+        <source>Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</source>
+        <target state="new">Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</target>
+        <note>{Locked="https://aka.ms/vs/17/release/vc_redist.x64.exe"} is a URL.</note>
+      </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
         <target state="translated">Non sono stati trovati input da firmare.</target>

--- a/src/Sign.Cli/xlf/Resources.ja.xlf
+++ b/src/Sign.Cli/xlf/Resources.ja.xlf
@@ -122,6 +122,11 @@
         <target state="translated">ファイルまたは glob が必要です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MsvcrtNotDetected">
+        <source>Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</source>
+        <target state="new">Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</target>
+        <note>{Locked="https://aka.ms/vs/17/release/vc_redist.x64.exe"} is a URL.</note>
+      </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
         <target state="translated">署名する入力が見つかりません。</target>

--- a/src/Sign.Cli/xlf/Resources.ko.xlf
+++ b/src/Sign.Cli/xlf/Resources.ko.xlf
@@ -122,6 +122,11 @@
         <target state="translated">파일 또는 글로브가 필요합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MsvcrtNotDetected">
+        <source>Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</source>
+        <target state="new">Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</target>
+        <note>{Locked="https://aka.ms/vs/17/release/vc_redist.x64.exe"} is a URL.</note>
+      </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
         <target state="translated">서명할 입력이 없습니다.</target>

--- a/src/Sign.Cli/xlf/Resources.pl.xlf
+++ b/src/Sign.Cli/xlf/Resources.pl.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Wymagany jest plik lub element globalny.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MsvcrtNotDetected">
+        <source>Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</source>
+        <target state="new">Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</target>
+        <note>{Locked="https://aka.ms/vs/17/release/vc_redist.x64.exe"} is a URL.</note>
+      </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
         <target state="translated">Nie znaleziono danych wejściowych do podpisania.</target>

--- a/src/Sign.Cli/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/Resources.pt-BR.xlf
@@ -122,6 +122,11 @@
         <target state="translated">É necessário um arquivo ou um glob.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MsvcrtNotDetected">
+        <source>Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</source>
+        <target state="new">Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</target>
+        <note>{Locked="https://aka.ms/vs/17/release/vc_redist.x64.exe"} is a URL.</note>
+      </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
         <target state="translated">Nenhuma entrada encontrada para autenticar.</target>

--- a/src/Sign.Cli/xlf/Resources.ru.xlf
+++ b/src/Sign.Cli/xlf/Resources.ru.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Требуется файл или стандартная маска.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MsvcrtNotDetected">
+        <source>Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</source>
+        <target state="new">Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</target>
+        <note>{Locked="https://aka.ms/vs/17/release/vc_redist.x64.exe"} is a URL.</note>
+      </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
         <target state="translated">Не найдены входящие данные для подписи.</target>

--- a/src/Sign.Cli/xlf/Resources.tr.xlf
+++ b/src/Sign.Cli/xlf/Resources.tr.xlf
@@ -122,6 +122,11 @@
         <target state="translated">Dosya veya glob gerekiyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MsvcrtNotDetected">
+        <source>Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</source>
+        <target state="new">Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</target>
+        <note>{Locked="https://aka.ms/vs/17/release/vc_redist.x64.exe"} is a URL.</note>
+      </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
         <target state="translated">İmzalanacak giriş dosyası yok.</target>

--- a/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hans.xlf
@@ -122,6 +122,11 @@
         <target state="translated">文件或 glob 是必需的。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MsvcrtNotDetected">
+        <source>Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</source>
+        <target state="new">Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</target>
+        <note>{Locked="https://aka.ms/vs/17/release/vc_redist.x64.exe"} is a URL.</note>
+      </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
         <target state="translated">找不到要签名的输入。</target>

--- a/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/Resources.zh-Hant.xlf
@@ -122,6 +122,11 @@
         <target state="translated">需要檔案或 Glob。</target>
         <note />
       </trans-unit>
+      <trans-unit id="MsvcrtNotDetected">
+        <source>Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</source>
+        <target state="new">Warning:  The Microsoft Visual C++ 14 runtime is required but was not detected on your system.  Download and install from https://aka.ms/vs/17/release/vc_redist.x64.exe</target>
+        <note>{Locked="https://aka.ms/vs/17/release/vc_redist.x64.exe"} is a URL.</note>
+      </trans-unit>
       <trans-unit id="NoFilesToSign">
         <source>No inputs found to sign.</source>
         <target state="translated">找不到要簽署的輸入。</target>


### PR DESCRIPTION
Address https://github.com/dotnet/sign/issues/684

This change warns if MSVCRT 14 is not installed and updates documentation prerequisites.

<img width="847" alt="image" src="https://github.com/user-attachments/assets/f61f8a03-8665-4dc8-8b16-190f72da558a">

CC @clairernovotny, @javierdlg