### PR TITLE
Test:  remove residual test certificates in root store at start of test run

### DIFF
--- a/test/Sign.Core.Test/AssemblyInitializer.cs
+++ b/test/Sign.Core.Test/AssemblyInitializer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE.txt file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Sign.TestInfrastructure;
 
 namespace Sign.Core.Test
 {
@@ -12,6 +13,8 @@ namespace Sign.Core.Test
         public static void Initialize()
         {
             AppInitializer.Initialize();
+
+            EphemeralTrust.RemoveResidualTestCertificates();
         }
     }
 }

--- a/test/Sign.Core.Test/TestInfrastructure/Server/CertificateAuthority.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/Server/CertificateAuthority.cs
@@ -5,6 +5,7 @@
 using System.Formats.Asn1;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using Sign.TestInfrastructure;
 
 namespace Sign.Core.Test
 {
@@ -909,7 +910,7 @@ SingleResponse ::= SEQUENCE {
             using (RSA eeKey = RSA.Create(keySize))
             {
                 CertificateRequest rootReq = new(
-                    BuildSubject($"Test root CA {Guid.NewGuid().ToString("P")}", testName, pkiOptions, pkiOptionsInSubject),
+                    BuildSubject($"{Constants.CommonNamePrefix} Root CA {Guid.NewGuid().ToString("P")}", testName, pkiOptions, pkiOptionsInSubject),
                     rootKey,
                     HashAlgorithmName.SHA256,
                     RSASignaturePadding.Pkcs1);
@@ -951,7 +952,7 @@ SingleResponse ::= SEQUENCE {
 
                     {
                         X509Certificate2 intermedPub = issuingAuthority.CreateSubordinateCA(
-                            BuildSubject($"Test intermediate CA {intermediateIndex} {Guid.NewGuid().ToString("P")}", testName, pkiOptions, pkiOptionsInSubject),
+                            BuildSubject($"{Constants.CommonNamePrefix} Intermediate CA {intermediateIndex} {Guid.NewGuid().ToString("P")}", testName, pkiOptions, pkiOptionsInSubject),
                             intermediateKey);
                         intermedCert = intermedPub.CopyWithPrivateKey(intermediateKey);
                         intermedPub.Dispose();
@@ -975,7 +976,7 @@ SingleResponse ::= SEQUENCE {
                 }
 
                 endEntityCert = issuingAuthority.CreateEndEntity(
-                    BuildSubject(subjectName ?? $"Test End Certificate {Guid.NewGuid().ToString("P")}", testName, pkiOptions, pkiOptionsInSubject),
+                    BuildSubject(subjectName ?? $"{Constants.CommonNamePrefix} End Certificate {Guid.NewGuid().ToString("P")}", testName, pkiOptions, pkiOptionsInSubject),
                     eeKey,
                     extensions);
 

--- a/test/Sign.TestInfrastructure/Constants.cs
+++ b/test/Sign.TestInfrastructure/Constants.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.TestInfrastructure
+{
+    public static class Constants
+    {
+        public const string CommonNamePrefix = "Sign CLI Test";
+        // This random GUID gives us a simple and robust way of identifying certificates created and trusted by these tests.
+        public const string FriendlyName = "25d8c5cb-ee59-488e-a505-7ba664c255f2";
+    }
+}

--- a/test/Sign.TestInfrastructure/ResidualTestCertificatesFoundInRootStoreException.cs
+++ b/test/Sign.TestInfrastructure/ResidualTestCertificatesFoundInRootStoreException.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.TestInfrastructure
+{
+    public sealed class ResidualTestCertificatesFoundInRootStoreException : Exception
+    {
+        public ResidualTestCertificatesFoundInRootStoreException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/test/Sign.TestInfrastructure/SelfIssuedCertificateCreator.cs
+++ b/test/Sign.TestInfrastructure/SelfIssuedCertificateCreator.cs
@@ -21,7 +21,7 @@ namespace Sign.TestInfrastructure
             using (RSA keyPair = RSA.Create(keySizeInBits: 3072))
             {
                 CertificateRequest request = new(
-                    $"CN=TEST ({Guid.NewGuid():D}) TEST, O=Organization, L=City, S=State, C=Country",
+                    $"CN={Constants.CommonNamePrefix} Certificate ({Guid.NewGuid():D}), O=Organization, L=City, S=State, C=Country",
                     keyPair,
                     HashAlgorithmName.SHA256,
                     RSASignaturePadding.Pkcs1);

--- a/test/Sign.TestInfrastructure/TrustedCertificateFixture.cs
+++ b/test/Sign.TestInfrastructure/TrustedCertificateFixture.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
+using System.Runtime.Versioning;
 using System.Security.Cryptography.X509Certificates;
 using Xunit;
 
@@ -28,6 +29,7 @@ namespace Sign.TestInfrastructure
             }
         }
 
+        [SupportedOSPlatform("windows")]
         public TrustedCertificateFixture()
         {
             if (Environment.IsPrivilegedProcess)


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/786.

During normal test execution, some tests may add test certificates to the root store and remove them during cleanup.  However, if the cleanup doesn't execute normally --- say, the test execution process crashed ---, test certificates would still be in the root store.

This change looks for residual test certificates in the root store at the start of test execution.

* If no certificates were found, we'll resume test execution.
* If certificates were found and the process is elevated, we'll remove the certificates and resume execution.
* If certificates were found and the process is not elevated, we'll report this as an error and fail execution.