### PR TITLE
CI:  update xcopy-msbuild version

### DIFF
--- a/global.json
+++ b/global.json
@@ -6,7 +6,7 @@
                 "8.0.10"
             ]
         },
-        "xcopy-msbuild": "17.9.6"
+        "xcopy-msbuild": "17.10.0-pre.4.0"
     },
     "sdk": {
         "version": "9.0.100-rc.2.24474.11",


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/802.

This change should resolve Component Governance alerts.

See https://github.com/dotnet/msbuild/commit/977f965b0e18488a0768da26277177524f6d1107 for reference.

CC @clairernovotny, @javierdlg