### PR TITLE
Update dependencies

### DIFF
--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -53,7 +53,7 @@ stages:
         - task: PublishBuildArtifacts@1
           displayName: 'Publish log files on failure'
           inputs:
-            PathtoPublish: '$(ArtifactsLogDir)'
+            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(Configuration)'
             ArtifactName: 'Logs'
             publishLocation: 'Container'
           condition: failed()

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -53,7 +53,7 @@ stages:
         - task: PublishBuildArtifacts@1
           displayName: 'Publish log files on failure'
           inputs:
-            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(Configuration)'
+            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
             ArtifactName: 'Logs'
             publishLocation: 'Container'
           condition: failed()

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -50,3 +50,10 @@ stages:
             searchFolder: $(System.DefaultWorkingDirectory)
             testRunTitle: sign unit tests - $(Agent.JobName)
           condition: succeededOrFailed()
+        - task: PublishBuildArtifacts@1
+          displayName: 'Publish log files on failure'
+          inputs:
+            PathtoPublish: '$(ArtifactsLogDir)'
+            ArtifactName: 'Logs'
+            publishLocation: 'Container'
+          condition: failed()

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,21 +5,21 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.CodeSigning.Sdk" Version="0.1.127" />
-    <PackageVersion Include="Azure.Core" Version="1.44.1" />
-    <PackageVersion Include="Azure.Identity" Version="1.13.1" />
+    <PackageVersion Include="Azure.Core" Version="1.45.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.13.2" />
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.7.0" />
     <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
     <PackageVersion Include="AzureSign.Core" Version="4.0.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.0" />
     <PackageVersion Include="Microsoft.Dynamics.BusinessCentral.Sip.Main" Version="24.0.15760" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
     <!-- Lift this dependency to enable Sign.Core.Test override the version. -->
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="9.0.1" />
     <!-- Only use release versions.  Pre-release versions are signed with an untrusted certificate. -->
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
     <!-- We're staying on 4.18.4 until we migrate to another mocking framework.
@@ -29,8 +29,8 @@
     <PackageVersion Include="NuGet.Packaging" Version="6.12.1" />
     <PackageVersion Include="NuGet.Protocol" Version="6.12.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.0" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="9.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="9.0.1" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="9.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,9 +1,9 @@
 {
     "tools": {
-        "dotnet": "9.0.100",
+        "dotnet": "9.0.102",
         "runtimes": {
             "dotnet/x64": [
-                "8.0.11"
+                "9.0.1"
             ]
         },
         "xcopy-msbuild": "17.10.0-pre.4.0"

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
     "tools": {
-        "_comment": "Because this affects the runtime environment of Sign CLI *when run from this directory*, the dotnet and runtime properties should reference the latest .NET SDK and runtime versions for Sign CLI's target framework, which is specified in Directory.Build.props.",
-        "dotnet": "8.0.405",
+        "_comment": "Because this affects the runtime environment of Sign CLI *when run from this directory*, the dotnet and runtime properties should reference the latest .NET SDK and runtime versions for Sign CLI's target framework, which is specified in Directory.Build.props.  However, the SDK and runtime versions are currently out of sync because of vulnerabilities in older versions of xcopy-msbuild.  The current version requires .NET 9 SDK.",
+        "dotnet": "9.0.102",
         "runtimes": {
             "dotnet/x64": [
                 "8.0.12"

--- a/global.json
+++ b/global.json
@@ -1,9 +1,10 @@
 {
     "tools": {
-        "dotnet": "9.0.102",
+        "_comment": "Because this affects the runtime environment of Sign CLI *when run from this directory*, the dotnet and runtime properties should reference the latest .NET SDK and runtime versions for Sign CLI's target framework, which is specified in Directory.Build.props.",
+        "dotnet": "8.0.405",
         "runtimes": {
             "dotnet/x64": [
-                "9.0.1"
+                "8.0.12"
             ]
         },
         "xcopy-msbuild": "17.10.0-pre.4.0"


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/810.

This change updates dependencies used to build, run, and package Sign CLI.