### PR TITLE
Add CodeQL suppressions

### DIFF
--- a/src/Sign.Core/Tools/VsixSignTool/SigningContext.cs
+++ b/src/Sign.Core/Tools/VsixSignTool/SigningContext.cs
@@ -70,6 +70,7 @@ namespace Sign.Core
             switch (_configuration.SigningKey)
             {
                 case RSA rsa:
+                    // CodeQL [SM03799] PKCS #1 v1.5 is required for interoperability with existing signature verifiers.
                     return rsa.SignHash(digest, _configuration.SignatureDigestAlgorithm, RSASignaturePadding.Pkcs1);
                 case ECDsa ecdsa:
                     return ecdsa.SignHash(digest);
@@ -92,6 +93,7 @@ namespace Sign.Core
                 case SigningAlgorithm.RSA:
                     using (var publicKey = Certificate.GetRSAPublicKey())
                     {
+                        // CodeQL [SM03799] PKCS #1 v1.5 is required for interoperability with existing signature verifiers.
                         return publicKey != null ? publicKey.VerifyHash(digest, signature, _configuration.SignatureDigestAlgorithm, RSASignaturePadding.Pkcs1) : false;
                     }
                 default:

--- a/test/Sign.Core.Test/TestInfrastructure/CertificateStoreServiceStub.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/CertificateStoreServiceStub.cs
@@ -37,6 +37,7 @@ namespace Sign.Core.Test
         {
             _rsa = RSA.Create(keySizeInBits: 4096);
 
+            // CodeQL [SM03799] PKCS #1 v1.5 is required for interoperability with existing signature verifiers.
             CertificateRequest request = new("CN=test", _rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
             DateTimeOffset now = DateTimeOffset.Now;
 

--- a/test/Sign.Core.Test/TestInfrastructure/KeyVaultServiceStub.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/KeyVaultServiceStub.cs
@@ -16,6 +16,7 @@ namespace Sign.Core.Test
         {
             _rsa = RSA.Create(keySizeInBits: 4096);
 
+            // CodeQL [SM03799] PKCS #1 v1.5 is required for interoperability with existing signature verifiers.
             CertificateRequest request = new("CN=test", _rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
             DateTimeOffset now = DateTimeOffset.Now;
 

--- a/test/Sign.Core.Test/TestInfrastructure/Server/CertificateAuthority.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/Server/CertificateAuthority.cs
@@ -267,6 +267,7 @@ namespace Sign.Core.Test
             using (RSA rsa = _cert.GetRSAPrivateKey()!)
             using (X509Certificate2 tmp = req.Create(
                 subjectName,
+                // CodeQL [SM03799] PKCS #1 v1.5 is required for interoperability with existing signature verifiers.
                 X509SignatureGenerator.CreateForRSA(rsa, RSASignaturePadding.Pkcs1),
                 new DateTimeOffset(_cert.NotBefore),
                 new DateTimeOffset(_cert.NotAfter),
@@ -288,6 +289,7 @@ namespace Sign.Core.Test
                 subject,
                 publicKey,
                 HashAlgorithmName.SHA256,
+                // CodeQL [SM03799] PKCS #1 v1.5 is required for interoperability with existing signature verifiers.
                 RSASignaturePadding.Pkcs1);
 
             return CreateCertificate(request, nestingBuffer, extensions, notAfter, ocspResponder);
@@ -485,8 +487,8 @@ namespace Sign.Core.Test
 
             using (RSA key = _cert.GetRSAPrivateKey()!)
             {
-                signature =
-                    key.SignData(tbsCertList, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+                // CodeQL [SM03799] PKCS #1 v1.5 is required for interoperability with existing signature verifiers.
+                signature = key.SignData(tbsCertList, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
 
                 if (CorruptRevocationSignature)
                 {
@@ -644,6 +646,7 @@ SingleResponse ::= SEQUENCE {
                     byte[] signature = rsa.SignData(
                         tbsResponseData,
                         HashAlgorithmName.SHA256,
+                        // CodeQL [SM03799] PKCS #1 v1.5 is required for interoperability with existing signature verifiers.
                         RSASignaturePadding.Pkcs1);
 
                     if (CorruptRevocationSignature)
@@ -927,6 +930,7 @@ SingleResponse ::= SEQUENCE {
                     BuildSubject($"{Constants.CommonNamePrefix} Root CA {Guid.NewGuid().ToString("P")}", testName, pkiOptions, pkiOptionsInSubject),
                     rootKey,
                     HashAlgorithmName.SHA256,
+                    // CodeQL [SM03799] PKCS #1 v1.5 is required for interoperability with existing signature verifiers.
                     RSASignaturePadding.Pkcs1);
 
                 X509BasicConstraintsExtension caConstraints =

--- a/test/Sign.Core.Test/TestInfrastructure/Server/PfxFilesFixture.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/Server/PfxFilesFixture.cs
@@ -43,6 +43,7 @@ namespace Sign.Core.Test
                     subjectName: "CN=Sign CLI, OU=TEST, O=TEST",
                     rsa,
                     hashAlgorithmName,
+                    // CodeQL [SM03799] PKCS #1 v1.5 is required for interoperability with existing signature verifiers.
                     RSASignaturePadding.Pkcs1);
 
                 certificateRequest.CertificateExtensions.Add(

--- a/test/Sign.Core.Test/TestInfrastructure/Server/TimestampService.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/Server/TimestampService.cs
@@ -63,6 +63,7 @@ namespace Sign.Core.Test
 
             using (RSA rsa = RSA.Create(keySizeInBits: 3072))
             {
+                // CodeQL [SM03799] PKCS #1 v1.5 is required for interoperability with existing signature verifiers.
                 CertificateRequest request = new("CN=timestamp.test", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
 
                 request.CertificateExtensions.Add(

--- a/test/Sign.TestInfrastructure/SelfIssuedCertificateCreator.cs
+++ b/test/Sign.TestInfrastructure/SelfIssuedCertificateCreator.cs
@@ -24,6 +24,7 @@ namespace Sign.TestInfrastructure
                     $"CN={Constants.CommonNamePrefix} Certificate ({Guid.NewGuid():D}), O=Organization, L=City, S=State, C=Country",
                     keyPair,
                     HashAlgorithmName.SHA256,
+                    // CodeQL [SM03799] PKCS #1 v1.5 is required for interoperability with existing signature verifiers.
                     RSASignaturePadding.Pkcs1);
 
                 return request.CreateSelfSigned(notBefore, notAfter);


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/812.

This change adds CodeQL suppressions for warnings that are tracked internally.