### PR TITLE
Allow 'code' commands to accept multiple file arguments

### DIFF
--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -22,7 +22,7 @@ namespace Sign.Cli
         internal Option<string> CertificateOption { get; } = new(["--azure-key-vault-certificate", "-kvc"], AzureKeyVaultResources.CertificateOptionDescription);
         internal AzureCredentialOptions AzureCredentialOptions { get; } = new();
 
-        internal Argument<string?> FileArgument { get; } = new("file(s)", Resources.FilesArgumentDescription);
+        internal Argument<List<string>?> FilesArgument { get; } = new("file(s)", Resources.FilesArgumentDescription) { Arity = ArgumentArity.OneOrMore };
 
         internal AzureKeyVaultCommand(CodeCommand codeCommand, IServiceProviderFactory serviceProviderFactory)
             : base("azure-key-vault", AzureKeyVaultResources.CommandDescription)
@@ -37,13 +37,13 @@ namespace Sign.Cli
             AddOption(CertificateOption);
             AzureCredentialOptions.AddOptionsToCommand(this);
 
-            AddArgument(FileArgument);
+            AddArgument(FilesArgument);
 
             this.SetHandler(async (InvocationContext context) =>
             {
-                string? fileArgument = context.ParseResult.GetValueForArgument(FileArgument);
+                List<string>? filesArgument = context.ParseResult.GetValueForArgument(FilesArgument);
 
-                if (string.IsNullOrEmpty(fileArgument))
+                if (filesArgument is not { Count: > 0 })
                 {
                     context.Console.Error.WriteLine(Resources.MissingFileValue);
                     context.ExitCode = ExitCode.InvalidOptions;
@@ -52,7 +52,7 @@ namespace Sign.Cli
 
                 // this check exists as a courtesy to users who may have been signing .clickonce files via the old workaround.
                 // at some point we should remove this check, probably once we hit v1.0
-                if (fileArgument.EndsWith(".clickonce", StringComparison.OrdinalIgnoreCase))
+                if (filesArgument.Any(x => x.EndsWith(".clickonce", StringComparison.OrdinalIgnoreCase)))
                 {
                     context.Console.Error.WriteLine(AzureKeyVaultResources.ClickOnceExtensionNotSupported);
                     context.ExitCode = ExitCode.InvalidOptions;
@@ -105,7 +105,7 @@ namespace Sign.Cli
 
                 KeyVaultServiceProvider keyVaultServiceProvider = new();
 
-                await codeCommand.HandleAsync(context, serviceProviderFactory, keyVaultServiceProvider, fileArgument);
+                await codeCommand.HandleAsync(context, serviceProviderFactory, keyVaultServiceProvider, filesArgument);
             });
         }
     }

--- a/src/Sign.Cli/CertificateStoreCommand.cs
+++ b/src/Sign.Cli/CertificateStoreCommand.cs
@@ -23,7 +23,7 @@ namespace Sign.Cli
         internal Option<bool> UseMachineKeyContainerOption { get; } = new(["--use-machine-key-container", "-km"], getDefaultValue: () => false, description: CertificateStoreResources.UseMachineKeyContainerOptionDescription);
         internal Option<bool> InteractiveOption { get; } = new(["--interactive", "-i"], getDefaultValue: () => false, description: CertificateStoreResources.InteractiveDescription);
 
-        internal Argument<string?> FileArgument { get; } = new("file(s)", Resources.FilesArgumentDescription);
+        internal Argument<List<string>?> FilesArgument { get; } = new("file(s)", Resources.FilesArgumentDescription) { Arity = ArgumentArity.OneOrMore };
 
         internal CertificateStoreCommand(CodeCommand codeCommand, IServiceProviderFactory serviceProviderFactory)
             : base("certificate-store", Resources.CertificateStoreCommandDescription)
@@ -40,13 +40,13 @@ namespace Sign.Cli
             AddOption(PrivateKeyContainerOption);
             AddOption(UseMachineKeyContainerOption);
             AddOption(InteractiveOption);
-            AddArgument(FileArgument);
+            AddArgument(FilesArgument);
 
             this.SetHandler(async (InvocationContext context) =>
             {
-                string? fileArgument = context.ParseResult.GetValueForArgument(FileArgument);
+                List<string>? filesArgument = context.ParseResult.GetValueForArgument(FilesArgument);
 
-                if (string.IsNullOrEmpty(fileArgument))
+                if (filesArgument is not { Count: > 0 })
                 {
                     context.Console.Error.WriteLine(Resources.MissingFileValue);
                     context.ExitCode = ExitCode.InvalidOptions;
@@ -111,7 +111,7 @@ namespace Sign.Cli
                     useMachineKeyContainer,
                     isInteractive);
 
-                await codeCommand.HandleAsync(context, serviceProviderFactory, certificateStoreServiceProvider, fileArgument);
+                await codeCommand.HandleAsync(context, serviceProviderFactory, certificateStoreServiceProvider, filesArgument);
             });
         }
 

--- a/src/Sign.Cli/TrustedSigningCommand.cs
+++ b/src/Sign.Cli/TrustedSigningCommand.cs
@@ -23,7 +23,7 @@ namespace Sign.Cli
         internal Option<string> CertificateProfileOption { get; } = new(["--trusted-signing-certificate-profile", "-tscp"], TrustedSigningResources.CertificateProfileOptionDescription);
         internal AzureCredentialOptions AzureCredentialOptions { get; } = new();
 
-        internal Argument<string?> FileArgument { get; } = new("file(s)", Resources.FilesArgumentDescription);
+        internal Argument<List<string>?> FilesArgument { get; } = new("file(s)", Resources.FilesArgumentDescription) { Arity = ArgumentArity.OneOrMore };
 
         internal TrustedSigningCommand(CodeCommand codeCommand, IServiceProviderFactory serviceProviderFactory)
             : base("trusted-signing", TrustedSigningResources.CommandDescription)
@@ -40,13 +40,13 @@ namespace Sign.Cli
             AddOption(CertificateProfileOption);
             AzureCredentialOptions.AddOptionsToCommand(this);
 
-            AddArgument(FileArgument);
+            AddArgument(FilesArgument);
 
             this.SetHandler(async (InvocationContext context) =>
             {
-                string? fileArgument = context.ParseResult.GetValueForArgument(FileArgument);
+                List<string>? filesArgument = context.ParseResult.GetValueForArgument(FilesArgument);
 
-                if (string.IsNullOrEmpty(fileArgument))
+                if (filesArgument is not { Count: > 0 })
                 {
                     context.Console.Error.WriteLine(Resources.MissingFileValue);
                     context.ExitCode = ExitCode.InvalidOptions;
@@ -87,7 +87,7 @@ namespace Sign.Cli
 
                 TrustedSigningServiceProvider trustedSigningServiceProvider = new();
 
-                await codeCommand.HandleAsync(context, serviceProviderFactory, trustedSigningServiceProvider, fileArgument);
+                await codeCommand.HandleAsync(context, serviceProviderFactory, trustedSigningServiceProvider, filesArgument);
             });
         }
     }

--- a/test/Sign.Cli.Test/SignCommandTests.cs
+++ b/test/Sign.Cli.Test/SignCommandTests.cs
@@ -93,7 +93,7 @@ namespace Sign.Cli.Test
             Assert.Equal(KeyVaultUrl, result.GetValueForOption(_azureKeyVaultCommand.UrlOption)!.OriginalString);
             Assert.Equal(CertificateName, result.GetValueForOption(_azureKeyVaultCommand.CertificateOption));
             Assert.Equal(TimestampUrl, result.GetValueForOption(_codeCommand.TimestampUrlOption)!.OriginalString);
-            Assert.Equal(File, result.GetValueForArgument(_azureKeyVaultCommand.FileArgument));
+            Assert.Equal([File], result.GetValueForArgument(_azureKeyVaultCommand.FilesArgument));
         }
     }
 }


### PR DESCRIPTION
Fixes #815

The command documentation specifies that these commands take a "file(s)" parameter. They currently accept only a single argument, although it can be a glob to specify multiple files. This changes them to accept multiple filenames as separate arguments, similar to the existing behavior of signtool and azuresigntool.