### PR TITLE
Update MSBuild

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,7 +7,7 @@
                 "8.0.12"
             ]
         },
-        "xcopy-msbuild": "17.10.0-pre.4.0"
+        "xcopy-msbuild": "17.12.0"
     },
     "sdk": {
         "version": "9.0.100",


### PR DESCRIPTION
Attempting to resolve https://github.com/dotnet/sign/issues/819.

[The only available version greater than 17.10.0-pre.4.0 is 17.12.0.](https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DotNet.Arcade.MSBuild.Xcopy/versions)

It's possible that this may not work, and I may have to update both the SDK and MSBuild.