### PR TITLE
Update global.json references to latest available versions

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,16 +1,16 @@
 {
     "tools": {
         "_comment": "Because this affects the runtime environment of Sign CLI *when run from this directory*, the dotnet and runtime properties should reference the latest .NET SDK and runtime versions for Sign CLI's target framework, which is specified in Directory.Build.props.  However, the SDK and runtime versions are currently out of sync because of vulnerabilities in older versions of xcopy-msbuild.  The current version requires .NET 9 SDK.",
-        "dotnet": "9.0.102",
+        "dotnet": "9.0.200",
         "runtimes": {
             "dotnet/x64": [
-                "8.0.12"
+                "8.0.13"
             ]
         },
         "xcopy-msbuild": "17.13.0"
     },
     "sdk": {
-        "version": "9.0.100",
+        "version": "9.0.200",
         "rollForward": "latestFeature"
     },
     "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -7,7 +7,7 @@
                 "8.0.12"
             ]
         },
-        "xcopy-msbuild": "17.12.0"
+        "xcopy-msbuild": "17.13.0"
     },
     "sdk": {
         "version": "9.0.100",


### PR DESCRIPTION
- Updated `xcopy-msbuild` in `global.json` to the latest available version on dotnet-eng
- Updated the dotnet 9 sdk references to the latest available version (these were out of sync)
- Updated the dotnet 8 runtime reference to the latest available version

I am raising this as I made the change to update xcopy-msbuild in [aspnetcore](https://github.com/dotnet/aspnetcore) via https://github.com/dotnet/aspnetcore/pull/60666 and spotted this repository was using the previous version also