### PR TITLE
Azure Key Vault:  fix regression in Azure Key Vault signing

### DIFF
--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -96,7 +96,7 @@ namespace Sign.Cli
                     services.AddAzureClients(builder =>
                     {
                         builder.AddCertificateClient(certId.VaultUri);
-                        builder.AddCryptographyClient(keyId.VaultUri);
+                        builder.AddCryptographyClient(keyUri);
                         builder.UseCredential(credential);
                         builder.ConfigureDefaults(options => options.Retry.Mode = RetryMode.Exponential);
                     });


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/827

https://github.com/dotnet/sign/pull/808 introduced a regression.

In Azure Key Vault:

* a Key Vault has a unique URI of the form:   `<scheme>://<authority>`
* a certificate has a unique URI of the form:  `<scheme>://<authority>/certificates/<certificateId>`
* a private key has a unique URI of the form:  `<scheme>://<authority>/keys/<certificateId>`

https://github.com/dotnet/sign/pull/808 added calls to [`CertificateClientBuilderExtensions.AddCertificateClient(...)`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.azure.certificateclientbuilderextensions.addcertificateclient?view=azure-dotnet#microsoft-extensions-azure-certificateclientbuilderextensions-addcertificateclient-1(-0-system-uri)) and [`KeyClientBuilderExtensions.AddCryptographyClient(...)`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.azure.keyclientbuilderextensions.addcryptographyclient?view=azure-dotnet#microsoft-extensions-azure-keyclientbuilderextensions-addcryptographyclient-1(-0-system-uri)).  `AddCertificateClient(...)` has a `vaultUri` parameter which must be the Key Vault URI, while `AddCryptographyClient(...)` has a `vaultUri` parameter which must be the private key's URI.  Documentation for the latter says, `vaultUri` should be "[t]he URI to a specific key in an Azure Key Vault, for example: https://my-vault.vault.azure.net/keys/my-key."

However, `KeyVaultKeyIdentifier.VaultUri` was passed to `AddCryptographyClient(...)`, and that returns the Key Vault URI.  The fix is to use the private key URI we already constructed ourselves.