### PR TITLE
Silence CA2255 (The ModuleInitializer attribute should not be used in libraries) through the .editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,9 @@ csharp_prefer_simple_using_statement = false
 # See https://github.com/dotnet/roslyn-analyzers/issues/5626
 dotnet_diagnostic.CA2254.severity = none
 
+# CA2255: The ModuleInitializer attribute should not be used in libraries
+dotnet_diagnostic.CA2255.severity = none
+
 # IDE0073: File header
 dotnet_diagnostic.IDE0073.severity = warning
 file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.\nSee the LICENSE.txt file in the project root for more information.


### PR DESCRIPTION
While building the library today I suddenly got a build error due to CA2255 that mentions that we should not be using the ModuleInitializer attribute. This small patch updates the `.editorconfig` to silence that warning/error.