### PR TITLE
VSIX:  fix signature timestamp format string bug

### DIFF
--- a/src/Sign.Core/Tools/VsixSignTool/XmlSignatureBuilder.cs
+++ b/src/Sign.Core/Tools/VsixSignTool/XmlSignatureBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
+using System.Globalization;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.Xml;
 using System.Xml;
@@ -226,7 +227,7 @@ namespace Sign.Core
             var signatureTimeFormatElement = _document.CreateElement("Format", OpcKnownUris.XmlDigitalSignature.AbsoluteUri);
             var signatureTimeValueElement = _document.CreateElement("Value", OpcKnownUris.XmlDigitalSignature.AbsoluteUri);
             signatureTimeFormatElement.InnerText = "YYYY-MM-DDThh:mm:ss.sTZD";
-            signatureTimeValueElement.InnerText = _signingContext.ContextCreationTime.ToString("yyyy-MM-ddTHH:mm:ss.fzzz");
+            signatureTimeValueElement.InnerText = _signingContext.ContextCreationTime.ToString("yyyy-MM-ddTHH:mm:ss.fzzz", CultureInfo.InvariantCulture);
 
             signatureTimeElement.AppendChild(signatureTimeFormatElement);
             signatureTimeElement.AppendChild(signatureTimeValueElement);


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/837.

By default, `DateTimeOffset.ToString(string)` uses the current culture.  For en-DK, the time separator is `.` not `:`.  So, the result is a value which doesn't follow the [OPC signature timestamp format](https://learn.microsoft.com/windows/win32/api/msopc/ne-msopc-opc_signature_time_format).

This change forces the `DateTimeOffset.ToString(...)` call to use `CultureInfo.InvariantCulture`.  This produces the expected result regardless of the current culture.