### PR TITLE
NuGet/VSIX:  propagate SignAsync(...) failures

### DIFF
--- a/src/Sign.Core/DataFormatSigners/ClickOnceSigner.cs
+++ b/src/Sign.Core/DataFormatSigners/ClickOnceSigner.cs
@@ -135,7 +135,7 @@ namespace Sign.Core
                     {
                         string message = string.Format(CultureInfo.CurrentCulture, Resources.SigningFailed, manifestFile.FullName);
 
-                        throw new Exception(message);
+                        throw new SigningException(message);
                     }
 
                     string publisherParam = string.Empty;
@@ -178,7 +178,7 @@ namespace Sign.Core
                         {
                             string message = string.Format(CultureInfo.CurrentCulture, Resources.SigningFailed, deploymentManifestFile.FullName);
 
-                            throw new Exception(message);
+                            throw new SigningException(message);
                         }
                     }
 

--- a/src/Sign.Core/DataFormatSigners/RetryingSigner.cs
+++ b/src/Sign.Core/DataFormatSigners/RetryingSigner.cs
@@ -12,6 +12,9 @@ namespace Sign.Core
     {
         protected ILogger Logger { get; }
 
+        // Non-private for testing purposes.
+        internal TimeSpan Retry { get; set; } = TimeSpan.FromSeconds(5);
+
         protected RetryingSigner(ILogger logger)
         {
             ArgumentNullException.ThrowIfNull(logger, nameof(logger));
@@ -24,7 +27,7 @@ namespace Sign.Core
         // Inspired from https://github.com/squaredup/bettersigntool/blob/master/bettersigntool/bettersigntool/SignCommand.cs
         protected async Task<bool> SignAsync(string? args, FileInfo file, RSA rsaPrivateKey, X509Certificate2 publicCertificate, SignOptions options)
         {
-            var retry = TimeSpan.FromSeconds(5);
+            TimeSpan retry = Retry;
             const int maxAttempts = 3;
             var attempt = 1;
 

--- a/src/Sign.Core/DataFormatSigners/VsixSigner.cs
+++ b/src/Sign.Core/DataFormatSigners/VsixSigner.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
@@ -48,9 +49,28 @@ namespace Sign.Core
             using (X509Certificate2 certificate = await _certificateProvider.GetCertificateAsync())
             using (RSA rsa = await _signatureAlgorithmProvider.GetRsaAsync())
             {
-                IEnumerable<Task<bool>> tasks = files.Select(file => SignAsync(args: null, file, rsa, certificate, options));
+                var fileTaskPairs = files
+                    .Select(file => new
+                    {
+                        File = file,
+                        Task = SignAsync(args: null, file, rsa, certificate, options)
+                    })
+                    .ToList();
 
-                await Task.WhenAll(tasks);
+                await Task.WhenAll(fileTaskPairs.Select(pair => pair.Task));
+
+                List<string> failedFiles = fileTaskPairs
+                    .Where(pair => !pair.Task.Result)
+                    .Select(pair => pair.File.FullName)
+                    .ToList();
+
+                if (failedFiles.Count > 0)
+                {
+                    string failedFilePaths = string.Join(", ", failedFiles);
+                    string message = string.Format(CultureInfo.CurrentCulture, Resources.SigningFailed, failedFilePaths);
+
+                    throw new SigningException(message);
+                }
             }
         }
 

--- a/src/Sign.Core/Sign.Core.csproj
+++ b/src/Sign.Core/Sign.Core.csproj
@@ -31,6 +31,7 @@
     <InternalsVisibleTo Include="Sign.SignatureProviders.KeyVault.Test" />
     <InternalsVisibleTo Include="Sign.SignatureProviders.TrustedSigning" />
     <InternalsVisibleTo Include="Sign.SignatureProviders.TrustedSigning.Test" />
+    <InternalsVisibleTo Include="Sign.TestInfrastructure" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sign.Core/Tools/IVsixSignTool.cs
+++ b/src/Sign.Core/Tools/IVsixSignTool.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
-using Sign.Core;
-
 namespace Sign.Core
 {
     internal interface IVsixSignTool : ITool

--- a/test/Sign.TestInfrastructure/Sign.TestInfrastructure.csproj
+++ b/test/Sign.TestInfrastructure/Sign.TestInfrastructure.csproj
@@ -18,4 +18,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Sign.Core\Sign.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Sign.Core.Test" />
+  </ItemGroup>
 </Project>

--- a/test/Sign.TestInfrastructure/TestFileCreator.cs
+++ b/test/Sign.TestInfrastructure/TestFileCreator.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System.IO.Compression;
+using Sign.Core;
+
+namespace Sign.TestInfrastructure
+{
+    public static class TestFileCreator
+    {
+        internal static FileInfo CreateEmptyZipFile(TemporaryDirectory temporaryDirectory, string fileExtension)
+        {
+            FileInfo file = new(Path.Combine(temporaryDirectory.Directory.FullName, $"{Path.GetRandomFileName()}{fileExtension}"));
+
+            using (FileStream stream = file.OpenWrite())
+            using (ZipArchive zip = new(stream, ZipArchiveMode.Create))
+            {
+            }
+
+            return file;
+        }
+    }
+}


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/798.

This change updates `ClickOnceSigner`, `NuGetSigner`, and `VsixSigner` to all throw a `SigningException` when signing fails.  Previously, some failures were not observed, so Sign CLI's exit code was 0.  With this change, these failures propagate up with a non-zero exit code.