### PR TITLE
Test:  add diagnostic logging for some flaky timestamping tests

### DIFF
--- a/src/Sign.Core/Tools/VsixSignTool/Interop/Crypt32.cs
+++ b/src/Sign.Core/Tools/VsixSignTool/Interop/Crypt32.cs
@@ -13,7 +13,7 @@ namespace Sign.Core.Interop
             [param: In, MarshalAs(UnmanagedType.SysInt)] IntPtr pv
         );
 
-        [method: DllImport("crypt32.dll", CallingConvention = CallingConvention.Winapi)]
+        [method: DllImport("crypt32.dll", CallingConvention = CallingConvention.Winapi, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool CryptRetrieveTimeStamp(
             [param: In, MarshalAs(UnmanagedType.LPWStr)] string wszUrl,

--- a/test/Sign.Core.Test/TestInfrastructure/Server/CertificatesFixture.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/Server/CertificatesFixture.cs
@@ -23,6 +23,11 @@ namespace Sign.Core.Test
             get => _timestampService.Certificate;
         }
 
+        internal DirectoryInfo TimestampServiceLogDirectory
+        {
+            get => _timestampService.LogDirectory;
+        }
+
         public CertificatesFixture()
         {
             TestUtility.RemoveTestIntermediateCertificates();

--- a/test/Sign.Core.Test/TestInfrastructure/Server/TimestampService.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/Server/TimestampService.cs
@@ -8,6 +8,8 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
 
 namespace Sign.Core.Test
 {
@@ -20,6 +22,8 @@ namespace Sign.Core.Test
         private readonly HashSet<BigInteger> _serialNumbers;
         private BigInteger _nextSerialNumber;
         private IDisposable? _disposable;
+        private readonly DirectoryService _directoryService;
+        private readonly TemporaryDirectory _temporaryDirectory;
 
         /// <summary>
         /// Gets this certificate authority's certificate.
@@ -36,6 +40,11 @@ namespace Sign.Core.Test
         /// </summary>
         internal CertificateAuthority CertificateAuthority { get; }
 
+        internal DirectoryInfo LogDirectory
+        {
+            get => _temporaryDirectory.Directory;
+        }
+
         private TimestampService(
             CertificateAuthority certificateAuthority,
             X509Certificate2 certificate,
@@ -46,11 +55,15 @@ namespace Sign.Core.Test
             Url = uri;
             _serialNumbers = new HashSet<BigInteger>();
             _nextSerialNumber = BigInteger.One;
+            _directoryService = new DirectoryService(Mock.Of<ILogger<IDirectoryService>>());
+            _temporaryDirectory = new TemporaryDirectory(_directoryService);
         }
 
         public void Dispose()
         {
             _disposable?.Dispose();
+            _temporaryDirectory.Dispose();
+            _directoryService.Dispose();
         }
 
         internal static TimestampService Create(
@@ -107,49 +120,89 @@ namespace Sign.Core.Test
 
         public override Task RespondAsync(HttpContext context)
         {
-            if (!string.Equals(context.Request.ContentType, RequestContentType, StringComparison.OrdinalIgnoreCase))
+            RequestAndResponse reqAndResp = new();
+
+            try
             {
-                context.Response.StatusCode = 400;
+                reqAndResp.RequestContentType = context.Request.ContentType;
 
-                return Task.CompletedTask;
+                if (!string.Equals(context.Request.ContentType, RequestContentType, StringComparison.OrdinalIgnoreCase))
+                {
+                    context.Response.StatusCode = 400;
+                    reqAndResp.ResponseStatus = 400;
+
+                    return Task.CompletedTask;
+                }
+
+                byte[] bytes = ReadRequestBody(context.Request);
+
+                reqAndResp.RequestBody = Convert.ToBase64String(bytes);
+
+                if (!Rfc3161TimestampRequest.TryDecode(bytes, out Rfc3161TimestampRequest? request, out int _))
+                {
+                    context.Response.StatusCode = 400;
+                    reqAndResp.ResponseStatus = 400;
+
+                    return Task.CompletedTask;
+                }
+
+                ReadOnlyMemory<byte> response;
+
+                if (request.HashAlgorithmId.IsEqualTo(Oids.Sha1))
+                {
+                    response = CreateResponse(PkiStatus.Rejection, signedCms: null);
+                }
+                else
+                {
+                    ReadOnlyMemory<byte> tstInfo = CreateTstInfo(
+                        request.HashAlgorithmId,
+                        request.GetMessageHash(),
+                        _nextSerialNumber,
+                        request.GetNonce());
+
+                    _serialNumbers.Add(_nextSerialNumber);
+
+                    ++_nextSerialNumber;
+
+                    SignedCms timestamp = GenerateTimestamp(request!, tstInfo);
+                    response = CreateResponse(PkiStatus.Granted, timestamp);
+                }
+
+                context.Response.ContentType = ResponseContentType;
+                context.Response.StatusCode = 200;
+
+                reqAndResp.ResponseStatus = 200;
+                reqAndResp.ResponseBody = Convert.ToBase64String(response.Span);
+
+                WriteResponseBody(context.Response, response);
             }
-
-            byte[] bytes = ReadRequestBody(context.Request);
-            if (!Rfc3161TimestampRequest.TryDecode(bytes, out Rfc3161TimestampRequest? request, out int _))
+            finally
             {
-                context.Response.StatusCode = 400;
-
-                return Task.CompletedTask;
+                Write(reqAndResp);
             }
-
-            ReadOnlyMemory<byte> response;
-
-            if (request.HashAlgorithmId.IsEqualTo(Oids.Sha1))
-            {
-                response = CreateResponse(PkiStatus.Rejection, signedCms: null);
-            }
-            else
-            {
-                ReadOnlyMemory<byte> tstInfo = CreateTstInfo(
-                    request.HashAlgorithmId,
-                    request.GetMessageHash(),
-                    _nextSerialNumber,
-                    request.GetNonce());
-
-                _serialNumbers.Add(_nextSerialNumber);
-
-                ++_nextSerialNumber;
-
-                SignedCms timestamp = GenerateTimestamp(request!, tstInfo);
-                response = CreateResponse(PkiStatus.Granted, timestamp);
-            }
-
-            context.Response.ContentType = ResponseContentType;
-            context.Response.StatusCode = 200;
-
-            WriteResponseBody(context.Response, response);
 
             return Task.CompletedTask;
+        }
+
+        private void Write(RequestAndResponse reqAndResp)
+        {
+            string filePath = Path.Combine(
+                _temporaryDirectory.Directory.FullName,
+                $"TimestampServer_{DateTimeOffset.UtcNow:yyyyMMdd-HHmmss.fffffffZ}_{Guid.NewGuid():N}.txt");
+            FileInfo file = new(filePath);
+
+            using (FileStream stream = file.OpenWrite())
+            using (StreamWriter writer = new(stream))
+            {
+                writer.Write($"Request Content-Type:  ");
+                writer.WriteLine(reqAndResp.RequestContentType);
+                writer.Write($"Request body:  ");
+                writer.WriteLine(reqAndResp.RequestBody);
+                writer.Write($"Response status:  ");
+                writer.WriteLine(reqAndResp.ResponseStatus);
+                writer.Write($"Response body:  ");
+                writer.WriteLine(reqAndResp.ResponseBody);
+            }
         }
 
         private SignedCms GenerateTimestamp(Rfc3161TimestampRequest request, ReadOnlyMemory<byte> tstInfo)
@@ -255,6 +308,14 @@ namespace Sign.Core.Test
             unacceptedExtension = 16,
             addInfoNotAvailable = 17,
             systemFailure = 25
+        }
+
+        private sealed class RequestAndResponse
+        {
+            internal string? RequestContentType { get; set; }
+            internal string? RequestBody { get; set; }
+            internal int? ResponseStatus { get; set; }
+            internal string? ResponseBody { get; set; }
         }
     }
 }


### PR DESCRIPTION
Progress on https://github.com/dotnet/sign/issues/671.

These 2 tests occasionally fail in CI runs but always succeed on rerun.  This change adds some additional logging to test output in the hopes that I'll be able to diagnose the issue when it happens again.

In short, this change modifies the test timestamp server to write details about every request and response to a file.  The tests append the contents of this file to the test output log.

The files are temporary and deleted after test execution.

CC @javierdlg