### PR TITLE
Test:  dispose DirectoryService

### DIFF
--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -7,7 +7,6 @@ using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using Azure.Core;
 using Azure.Security.KeyVault.Certificates;
-using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Sign.Core/DataFormatSigners/ClickOnceSigner.cs
+++ b/src/Sign.Core/DataFormatSigners/ClickOnceSigner.cs
@@ -143,7 +143,7 @@ namespace Sign.Core
                     if (string.IsNullOrEmpty(options.PublisherName))
                     {
                         string publisherName = certificate.SubjectName.Name;
- 
+
                         // get the DN. it may be quoted
                         publisherParam = $@"-pub ""{publisherName.Replace("\"", "")}""";
                     }

--- a/src/Sign.Core/DataFormatSigners/SignOptions.cs
+++ b/src/Sign.Core/DataFormatSigners/SignOptions.cs
@@ -42,7 +42,7 @@ namespace Sign.Core
         }
 
         internal SignOptions(HashAlgorithmName fileHashAlgorithm, Uri timestampService)
-            : this(applicationName: null, publisherName: null, description: null, descriptionUrl: null, 
+            : this(applicationName: null, publisherName: null, description: null, descriptionUrl: null,
                   fileHashAlgorithm, HashAlgorithmName.SHA256, timestampService, matcher: null,
                   antiMatcher: null)
         {

--- a/test/Sign.Cli.Test/SignCommandTests.Globbing.cs
+++ b/test/Sign.Cli.Test/SignCommandTests.Globbing.cs
@@ -14,6 +14,7 @@ namespace Sign.Cli.Test
     {
         public sealed class GlobbingTests : IDisposable
         {
+            private readonly DirectoryService _directoryService;
             private readonly Parser _parser;
             private readonly SignerSpy _signerSpy;
             private readonly TemporaryDirectory _temporaryDirectory;
@@ -33,7 +34,8 @@ namespace Sign.Cli.Test
 
                 _parser = Program.CreateParser(serviceProviderFactory);
 
-                _temporaryDirectory = new TemporaryDirectory(new DirectoryService(Mock.Of<ILogger<IDirectoryService>>()));
+                _directoryService = new DirectoryService(Mock.Of<ILogger<IDirectoryService>>());
+                _temporaryDirectory = new TemporaryDirectory(_directoryService);
 
                 CreateFileSystemInfos(
                     _temporaryDirectory,
@@ -52,6 +54,7 @@ namespace Sign.Cli.Test
             public void Dispose()
             {
                 _temporaryDirectory.Dispose();
+                _directoryService.Dispose();
 
                 GC.SuppressFinalize(this);
             }

--- a/test/Sign.Core.Test/DataFormatSigners/AggregatingSignerTests.Containers.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/AggregatingSignerTests.Containers.cs
@@ -345,7 +345,7 @@ namespace Sign.Core.Test
         [Fact]
         public async Task SignAsync_WhenFileIsZipContainerAndGlobAndAntiGlobPatternsAreUsed_SignsOnlyMatchingFiles()
         {
-            const string fileListContents = 
+            const string fileListContents =
 @"**/*.dll
 **/*.exe
 !**/*.txt

--- a/test/Sign.Core.Test/DataFormatSigners/AzureSignToolSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/AzureSignToolSignerTests.cs
@@ -12,10 +12,10 @@ using Sign.TestInfrastructure;
 namespace Sign.Core.Test
 {
     [Collection(SigningTestsCollection.Name)]
-    public class AzureSignToolSignerTests
+    public sealed class AzureSignToolSignerTests : IDisposable
     {
         private readonly TrustedCertificateFixture _certificateFixture;
-        private readonly DirectoryService _directoryService = new(Mock.Of<ILogger<IDirectoryService>>());
+        private readonly DirectoryService _directoryService;
         private readonly AzureSignToolSigner _signer;
 
         public AzureSignToolSignerTests(TrustedCertificateFixture certificateFixture)
@@ -23,11 +23,17 @@ namespace Sign.Core.Test
             ArgumentNullException.ThrowIfNull(certificateFixture, nameof(certificateFixture));
 
             _certificateFixture = certificateFixture;
+            _directoryService = new(Mock.Of<ILogger<IDirectoryService>>());
             _signer = new AzureSignToolSigner(
                 Mock.Of<IToolConfigurationProvider>(),
                 Mock.Of<ISignatureAlgorithmProvider>(),
                 Mock.Of<ICertificateProvider>(),
                 Mock.Of<ILogger<IDataFormatSigner>>());
+        }
+
+        public void Dispose()
+        {
+            _directoryService.Dispose();
         }
 
         [Fact]

--- a/test/Sign.Core.Test/DataFormatSigners/ClickOnceSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/ClickOnceSignerTests.cs
@@ -12,11 +12,12 @@ namespace Sign.Core.Test
 {
     public sealed class ClickOnceSignerTests : IDisposable
     {
-        private readonly DirectoryService _directoryService = new(Mock.Of<ILogger<IDirectoryService>>());
+        private readonly DirectoryService _directoryService;
         private readonly ClickOnceSigner _signer;
 
         public ClickOnceSignerTests()
         {
+            _directoryService = new(Mock.Of<ILogger<IDirectoryService>>());
             _signer = new ClickOnceSigner(
                 Mock.Of<ISignatureAlgorithmProvider>(),
                 Mock.Of<ICertificateProvider>(),

--- a/test/Sign.Core.Test/DataFormatSigners/NuGetSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/NuGetSignerTests.cs
@@ -135,8 +135,7 @@ namespace Sign.Core.Test
                 matcher: null,
                 antiMatcher: null);
 
-            DirectoryService directoryService = new(Mock.Of<ILogger<IDirectoryService>>());
-
+            using (DirectoryService directoryService = new(Mock.Of<ILogger<IDirectoryService>>()))
             using (TemporaryDirectory temporaryDirectory = new(directoryService))
             {
                 FileInfo nupkgFile = TestFileCreator.CreateEmptyZipFile(temporaryDirectory, fileExtension: ".nupkg");

--- a/test/Sign.Core.Test/DataFormatSigners/VsixSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/VsixSignerTests.cs
@@ -119,8 +119,7 @@ namespace Sign.Core.Test
                 matcher: null,
                 antiMatcher: null);
 
-            DirectoryService directoryService = new(Mock.Of<ILogger<IDirectoryService>>());
-
+            using (DirectoryService directoryService = new(Mock.Of<ILogger<IDirectoryService>>()))
             using (TemporaryDirectory temporaryDirectory = new(directoryService))
             {
                 FileInfo vsixFile = TestFileCreator.CreateEmptyZipFile(temporaryDirectory, fileExtension: ".vsix");
@@ -155,7 +154,5 @@ namespace Sign.Core.Test
                 }
             }
         }
-
-
     }
 }

--- a/test/Sign.Core.Test/TestInfrastructure/Server/PfxFilesFixture.cs
+++ b/test/Sign.Core.Test/TestInfrastructure/Server/PfxFilesFixture.cs
@@ -12,12 +12,14 @@ namespace Sign.Core.Test
 {
     public sealed class PfxFilesFixture : IDisposable
     {
+        private readonly DirectoryService _directoryService;
         private readonly TemporaryDirectory _directory;
         private readonly ConcurrentDictionary<Tuple<int, HashAlgorithmName>, FileInfo> _pfxFiles;
 
         public PfxFilesFixture()
         {
-            _directory = new TemporaryDirectory(new DirectoryService(Mock.Of<ILogger<IDirectoryService>>()));
+            _directoryService = new DirectoryService(Mock.Of<ILogger<IDirectoryService>>());
+            _directory = new TemporaryDirectory(_directoryService);
             _pfxFiles = new ConcurrentDictionary<Tuple<int, HashAlgorithmName>, FileInfo>();
         }
 
@@ -33,6 +35,7 @@ namespace Sign.Core.Test
         public void Dispose()
         {
             _directory.Dispose();
+            _directoryService.Dispose();
         }
 
         private FileInfo CreateSelfIssuedCertificate(int keySizeInBits, HashAlgorithmName hashAlgorithmName)


### PR DESCRIPTION
This change ensures that the `DirectoryService` is properly disposed of after use.  This ensures test files are deleted after test execution.

Also, some very minor reformatting changes.

Use https://github.com/dotnet/sign/pull/845/files?w=1 to ignore whitespace changes.