### PR TITLE
Improve detection of Dynamics Business Central `.app` files

### DIFF
--- a/src/Sign.Core/DataFormatSigners/DynamicsBusinessCentralAppFileType.cs
+++ b/src/Sign.Core/DataFormatSigners/DynamicsBusinessCentralAppFileType.cs
@@ -8,7 +8,7 @@ namespace Sign.Core
     {
         private const string FileExtension = ".app";
 
-        private readonly ReadOnlyMemory<byte> _expectedHeader;
+        private readonly byte[] _expectedHeader;
 
         internal DynamicsBusinessCentralAppFileType()
         {
@@ -33,7 +33,7 @@ namespace Sign.Core
                     return false;
                 }
 
-                return header.AsSpan().SequenceEqual(_expectedHeader.Span);
+                return header.SequenceEqual(_expectedHeader);
             }
         }
     }

--- a/src/Sign.Core/DataFormatSigners/DynamicsBusinessCentralAppFileType.cs
+++ b/src/Sign.Core/DataFormatSigners/DynamicsBusinessCentralAppFileType.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.Core
+{
+    internal sealed class DynamicsBusinessCentralAppFileType : ISignableFileType
+    {
+        private const string FileExtension = ".app";
+
+        private readonly ReadOnlyMemory<byte> _expectedHeader;
+
+        internal DynamicsBusinessCentralAppFileType()
+        {
+            _expectedHeader = new byte[] { 0x4e, 0x41, 0x56, 0x58 }; // NAVX
+        }
+
+        public bool IsMatch(FileInfo file)
+        {
+            ArgumentNullException.ThrowIfNull(file, nameof(file));
+
+            if (!FileExtension.Equals(file.Extension, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            using (FileStream stream = file.OpenRead())
+            {
+                var header = new byte[_expectedHeader.Length];
+
+                if (stream.Read(header, offset: 0, header.Length) != header.Length)
+                {
+                    return false;
+                }
+
+                return header.AsSpan().SequenceEqual(_expectedHeader.Span);
+            }
+        }
+    }
+}

--- a/src/Sign.Core/DataFormatSigners/ISignableFileType.cs
+++ b/src/Sign.Core/DataFormatSigners/ISignableFileType.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.Core
+{
+    internal interface ISignableFileType
+    {
+        bool IsMatch(FileInfo file);
+    }
+}

--- a/src/Sign.Core/DataFormatSigners/SignableFileTypeByExtension.cs
+++ b/src/Sign.Core/DataFormatSigners/SignableFileTypeByExtension.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.Core
+{
+    internal sealed class SignableFileTypeByExtension : ISignableFileType
+    {
+        private readonly HashSet<string> _fileExtensions;
+
+        internal SignableFileTypeByExtension(params string[] fileExtensions)
+        {
+            ArgumentNullException.ThrowIfNull(fileExtensions, nameof(fileExtensions));
+
+            if (fileExtensions.Length == 0)
+            {
+                throw new ArgumentException(Resources.ArgumentCannotBeEmpty, nameof(fileExtensions));
+            }
+
+            _fileExtensions = new HashSet<string>(fileExtensions, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public bool IsMatch(FileInfo file)
+        {
+            ArgumentNullException.ThrowIfNull(file, nameof(file));
+
+            return _fileExtensions.Contains(file.Extension);
+        }
+    }
+}

--- a/src/Sign.Core/Resources.Designer.cs
+++ b/src/Sign.Core/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace Sign.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The argument cannot be empty..
+        /// </summary>
+        internal static string ArgumentCannotBeEmpty {
+            get {
+                return ResourceManager.GetString("ArgumentCannotBeEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Signing SignTool job with {count} files..
         /// </summary>
         internal static string AzureSignToolSignatureProviderSigning {

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ArgumentCannotBeEmpty" xml:space="preserve">
+    <value>The argument cannot be empty.</value>
+  </data>
   <data name="AzureSignToolSignatureProviderSigning" xml:space="preserve">
     <value>Signing SignTool job with {count} files.</value>
     <comment>{Placeholder="{count}"} is the number of files to be signed.</comment>

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentCannotBeEmpty">
+        <source>The argument cannot be empty.</source>
+        <target state="new">The argument cannot be empty.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Podepisování úlohy SignTool s tímto počtem souborů: {count}.</target>

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentCannotBeEmpty">
+        <source>The argument cannot be empty.</source>
+        <target state="new">The argument cannot be empty.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Der SignTool-Auftrag wird mit {count} Dateien signiert.</target>

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentCannotBeEmpty">
+        <source>The argument cannot be empty.</source>
+        <target state="new">The argument cannot be empty.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Firmando el trabajo de SignTool con {count} archivos.</target>

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentCannotBeEmpty">
+        <source>The argument cannot be empty.</source>
+        <target state="new">The argument cannot be empty.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Signature du travail SignTool avec {count} fichiers.</target>

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentCannotBeEmpty">
+        <source>The argument cannot be empty.</source>
+        <target state="new">The argument cannot be empty.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Firma del processo SignTool con {count} file.</target>

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentCannotBeEmpty">
+        <source>The argument cannot be empty.</source>
+        <target state="new">The argument cannot be empty.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">{count} 個のファイルを使用して SignTool ジョブに署名しています。</target>

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentCannotBeEmpty">
+        <source>The argument cannot be empty.</source>
+        <target state="new">The argument cannot be empty.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">{count} 파일로 SignTool 작업에 서명하는 중입니다.</target>

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentCannotBeEmpty">
+        <source>The argument cannot be empty.</source>
+        <target state="new">The argument cannot be empty.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Podpisywanie zadania SignTool przy użyciu {count} plików.</target>

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentCannotBeEmpty">
+        <source>The argument cannot be empty.</source>
+        <target state="new">The argument cannot be empty.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Autenticando o trabalho SignTool com {count} arquivos.</target>

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentCannotBeEmpty">
+        <source>The argument cannot be empty.</source>
+        <target state="new">The argument cannot be empty.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">Задание подписывания SignTool с несколькими файлами ({count}).</target>

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentCannotBeEmpty">
+        <source>The argument cannot be empty.</source>
+        <target state="new">The argument cannot be empty.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">SignTool işi {count} dosya ile imzalanıyor.</target>

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentCannotBeEmpty">
+        <source>The argument cannot be empty.</source>
+        <target state="new">The argument cannot be empty.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">正在对包含 {count} 个文件的 SignTool 作业进行签名。</target>

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
+      <trans-unit id="ArgumentCannotBeEmpty">
+        <source>The argument cannot be empty.</source>
+        <target state="new">The argument cannot be empty.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AzureSignToolSignatureProviderSigning">
         <source>Signing SignTool job with {count} files.</source>
         <target state="translated">正在簽署具有 {count} 個檔案的 SignTool 工作。</target>

--- a/test/Sign.Core.Test/DataFormatSigners/AzureSignToolSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/AzureSignToolSignerTests.cs
@@ -46,7 +46,6 @@ namespace Sign.Core.Test
         }
 
         [Theory]
-        [InlineData(".app")]
         [InlineData(".appx")]
         [InlineData(".appxbundle")]
         [InlineData(".cab")]
@@ -79,6 +78,33 @@ namespace Sign.Core.Test
             FileInfo file = new($"file{extension}");
 
             Assert.True(_signer.CanSign(file));
+        }
+
+
+        [Fact]
+        public void CanSign_WithNonDynamicsBusinessCentralAppFile_ReturnsFalse()
+        {
+            using (TemporaryDirectory temporaryDirectory = new(_directoryService))
+            {
+                FileInfo file = new(Path.Combine(temporaryDirectory.Directory.FullName, "file.app"));
+
+                File.WriteAllText(file.FullName, "{}");
+
+                Assert.False(_signer.CanSign(file));
+            }
+        }
+
+        [Fact]
+        public void CanSign_WithDynamicsBusinessCentralAppFile_ReturnsTrue()
+        {
+            using (TemporaryDirectory temporaryDirectory = new(_directoryService))
+            {
+                FileInfo file = new(Path.Combine(temporaryDirectory.Directory.FullName, "file.app"));
+
+                File.WriteAllBytes(file.FullName, new byte[] { 0x4e, 0x41, 0x56, 0x58 });
+
+                Assert.True(_signer.CanSign(file));
+            }
         }
 
         [Theory]

--- a/test/Sign.Core.Test/DataFormatSigners/DynamicsBusinessCentralAppFileTypeTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/DynamicsBusinessCentralAppFileTypeTests.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Sign.Core.Test
+{
+    public sealed class DynamicsBusinessCentralAppFileTypeTests : IDisposable
+    {
+        private readonly DirectoryService _directoryService;
+        private readonly DynamicsBusinessCentralAppFileType _fileType;
+        private readonly TemporaryDirectory _temporaryDirectory;
+
+        public DynamicsBusinessCentralAppFileTypeTests()
+        {
+            _directoryService = new DirectoryService(Mock.Of<ILogger<IDirectoryService>>());
+            _fileType = new DynamicsBusinessCentralAppFileType();
+            _temporaryDirectory = new TemporaryDirectory(_directoryService);
+        }
+
+        public void Dispose()
+        {
+            _temporaryDirectory.Dispose();
+            _directoryService.Dispose();
+        }
+
+        [Fact]
+        public void IsMatch_WhenExtensionDoesNotMatch_ReturnsFalse()
+        {
+            FileInfo file = new(Path.Combine(_temporaryDirectory.Directory.FullName, "file.abc"));
+
+            Assert.False(_fileType.IsMatch(file));
+        }
+
+        [Fact]
+        public void IsMatch_WhenContentIsEmpty_ReturnsFalse()
+        {
+            FileInfo file = new(Path.Combine(_temporaryDirectory.Directory.FullName, "file.app"));
+
+            File.WriteAllBytes(file.FullName, Array.Empty<byte>());
+
+            Assert.False(_fileType.IsMatch(file));
+        }
+
+        [Fact]
+        public void IsMatch_WhenContentDoesNotMatch_ReturnsFalse()
+        {
+            FileInfo file = new(Path.Combine(_temporaryDirectory.Directory.FullName, "file.app"));
+
+            File.WriteAllText(file.FullName, "orange");
+
+            Assert.False(_fileType.IsMatch(file));
+        }
+
+        [Theory]
+        [InlineData(".app")]
+        [InlineData(".APP")]
+        public void IsMatch_WhenExtensionAndContentMatch_ReturnsTrue(string fileExtension)
+        {
+            FileInfo file = new(Path.Combine(_temporaryDirectory.Directory.FullName, $"file{fileExtension}"));
+
+            File.WriteAllBytes(file.FullName, new byte[] { 0x4e, 0x41, 0x56, 0x58 });
+
+            Assert.True(_fileType.IsMatch(file));
+        }
+    }
+}

--- a/test/Sign.Core.Test/DataFormatSigners/SignableFileTypeByExtensionTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/SignableFileTypeByExtensionTests.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.Core.Test
+{
+    public class SignableFileTypeByExtensionTests
+    {
+        [Fact]
+        public void Constructor_WhenFileExtensionsIsNull_Throws()
+        {
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => new SignableFileTypeByExtension(fileExtensions: null!));
+            Assert.Equal("fileExtensions", exception.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_WhenFileExtensionsIsEmpty_Throws()
+        {
+            ArgumentException exception = Assert.Throws<ArgumentException>(
+                () => new SignableFileTypeByExtension());
+            Assert.Equal("fileExtensions", exception.ParamName);
+        }
+
+        [Fact]
+        public void IsMatch_WhenFileIsNull_Throws()
+        {
+            SignableFileTypeByExtension fileType = new(fileExtensions: ".exe");
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => fileType.IsMatch(file: null!));
+            Assert.Equal("file", exception.ParamName);
+        }
+
+        [Fact]
+        public void IsMatch_WhenFileDoesNotMatch_ReturnsFalse()
+        {
+            FileInfo file = new(Path.Combine(Path.GetTempPath(), "file.abc"));
+            SignableFileTypeByExtension fileType = new(fileExtensions: ".exe");
+
+            Assert.False(fileType.IsMatch(file));
+        }
+
+        [Theory]
+        [InlineData(".exe")]
+        [InlineData(".EXE")]
+        public void IsMatch_WhenFileMatches_ReturnsTrue(string fileExtension)
+        {
+            FileInfo file = new(Path.Combine(Path.GetTempPath(), $"file{fileExtension}"));
+            SignableFileTypeByExtension fileType = new(fileExtensions: ".exe");
+
+            Assert.True(fileType.IsMatch(file));
+        }
+    }
+}


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/824.

https://github.com/dotnet/sign/pull/652 added support for signing Dynamics Business Central `.app` files, but the `.app` file extension is not exclusive to Dynamics Business Central apps.  In this bug, Sign CLI fails to sign a JSON file with an `.app` file extension.

This change updates Sign CLI to be smarter about detecting Dynamics Business Central `.app` files.  These files begin with a 4-byte header `4e 41 56 58` (NAVX), so we should only try signing if an `.app` file starts with this header.

CC @aholstrup1