### PR TITLE
Add RecurseContainers option for signing process

### DIFF
--- a/src/Sign.Cli/CertificateStoreResources.Designer.cs
+++ b/src/Sign.Cli/CertificateStoreResources.Designer.cs
@@ -88,6 +88,15 @@ namespace Sign.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sign container contents.
+        /// </summary>
+        internal static string ContainersDescription {
+            get {
+                return ResourceManager.GetString("ContainersDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cryptographic Service Provider containing the private key container. Requires /k and optionally /km..
         /// </summary>
         internal static string CspOptionDescription {

--- a/src/Sign.Cli/CertificateStoreResources.resx
+++ b/src/Sign.Cli/CertificateStoreResources.resx
@@ -149,4 +149,7 @@
   <data name="UseMachineKeyContainerOptionDescription" xml:space="preserve">
     <value>Use a machine-level private key container.  (The default is user-level.)</value>
   </data>
+  <data name="ContainersDescription" xml:space="preserve">
+    <value>Sign container contents</value>
+  </data>
 </root>

--- a/src/Sign.Cli/CertificateStoreResources.resx
+++ b/src/Sign.Cli/CertificateStoreResources.resx
@@ -150,6 +150,6 @@
     <value>Use a machine-level private key container.  (The default is user-level.)</value>
   </data>
   <data name="ContainersDescription" xml:space="preserve">
-    <value>Sign container contents</value>
+    <value>Sign container contents.</value>
   </data>
 </root>

--- a/src/Sign.Cli/CodeCommand.cs
+++ b/src/Sign.Cli/CodeCommand.cs
@@ -25,6 +25,7 @@ namespace Sign.Cli
         internal Option<Uri?> DescriptionUrlOption { get; } = new(["--description-url", "-u"], ParseUrl, description: Resources.DescriptionUrlOptionDescription);
         internal Option<HashAlgorithmName> FileDigestOption { get; } = new(["--file-digest", "-fd"], HashAlgorithmParser.ParseHashAlgorithmName, description: Resources.FileDigestOptionDescription);
         internal Option<string?> FileListOption = new(["--file-list", "-fl"], Resources.FileListOptionDescription);
+        internal Option<bool> RecurseContainersOption { get; } = new(["--recurse-containers", "-rc"], getDefaultValue: () => true, description: CertificateStoreResources.ContainersDescription);
         internal Option<int> MaxConcurrencyOption { get; } = new(["--max-concurrency", "-m"], ParseMaxConcurrencyOption, description: Resources.MaxConcurrencyOptionDescription);
         internal Option<string?> OutputOption { get; } = new(["--output", "-o"], Resources.OutputOptionDescription);
         internal Option<string?> PublisherNameOption { get; } = new(["--publisher-name", "-pn"], Resources.PublisherNameOptionDescription);
@@ -51,6 +52,7 @@ namespace Sign.Cli
             AddGlobalOption(OutputOption);
             AddGlobalOption(PublisherNameOption);
             AddGlobalOption(FileListOption);
+            AddGlobalOption(RecurseContainersOption);
             AddGlobalOption(FileDigestOption);
             AddGlobalOption(TimestampUrlOption);
             AddGlobalOption(TimestampDigestOption);
@@ -68,6 +70,7 @@ namespace Sign.Cli
             string? description = context.ParseResult.GetValueForOption(DescriptionOption);
             Uri? descriptionUrl = context.ParseResult.GetValueForOption(DescriptionUrlOption);
             string? fileListFilePath = context.ParseResult.GetValueForOption(FileListOption);
+            bool recurseContainers = context.ParseResult.GetValueForOption(RecurseContainersOption);
             HashAlgorithmName fileHashAlgorithmName = context.ParseResult.GetValueForOption(FileDigestOption);
             HashAlgorithmName timestampHashAlgorithmName = context.ParseResult.GetValueForOption(TimestampDigestOption);
             Uri timestampUrl = context.ParseResult.GetValueForOption(TimestampUrlOption)!;
@@ -179,6 +182,7 @@ namespace Sign.Cli
                 inputFiles,
                 output,
                 fileList,
+                recurseContainers,
                 baseDirectory,
                 applicationName,
                 publisherName,

--- a/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Heslo pro soubor certifikátu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainersDescription">
+        <source>Sign container contents</source>
+        <target state="new">Sign container contents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Zprostředkovatel kryptografických služeb obsahující kontejner privátního klíče. Vyžaduje /k a volitelně /km.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Kennwort für Zertifikatdatei.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainersDescription">
+        <source>Sign container contents</source>
+        <target state="new">Sign container contents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Kryptografiedienstanbieter, der den privaten Schlüsselcontainer enthält. Erfordert /k und optional /km.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Contraseña del archivo de certificado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainersDescription">
+        <source>Sign container contents</source>
+        <target state="new">Sign container contents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Proveedor de servicios criptográficos que contiene el contenedor de claves privadas. Requiere /k y, opcionalmente, /km.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Mot de passe du fichier du certificat.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainersDescription">
+        <source>Sign container contents</source>
+        <target state="new">Sign container contents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Fournisseur de services de chiffrement contenant le conteneur de clé privée. Nécessite /k et éventuellement /km.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Password per file certificato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainersDescription">
+        <source>Sign container contents</source>
+        <target state="new">Sign container contents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Provider del servizio di crittografia contenente il contenitore di chiavi private. Richiede /k e facoltativamente /km.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
@@ -17,6 +17,11 @@
         <target state="translated">証明書ファイルのパスワード。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainersDescription">
+        <source>Sign container contents</source>
+        <target state="new">Sign container contents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">秘密キー コンテナーを含む暗号化サービス プロバイダー。/k および必要に応じて /km が必要です。</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
@@ -17,6 +17,11 @@
         <target state="translated">인증서 파일의 암호입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainersDescription">
+        <source>Sign container contents</source>
+        <target state="new">Sign container contents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">프라이빗 키 컨테이너를 포함하는 암호화 서비스 공급자입니다. /k 및 선택적으로 /km이 필요합니다.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Hasło dla pliku certyfikatu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainersDescription">
+        <source>Sign container contents</source>
+        <target state="new">Sign container contents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Dostawca usług kryptograficznych zawierający kontener kluczy prywatnych. Wymaga opcji /k i opcjonalnie /km.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Senha do arquivo do certificado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainersDescription">
+        <source>Sign container contents</source>
+        <target state="new">Sign container contents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Provedor de Serviços Criptográficos que contém o contêiner de chave privada. Requer /k e, opcionalmente, /km.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Пароль для файла сертификата.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainersDescription">
+        <source>Sign container contents</source>
+        <target state="new">Sign container contents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Поставщик служб шифрования, содержащий контейнер закрытого ключа. Требуется /k и /km (необязательно).</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Sertifika dosyasının parolası.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainersDescription">
+        <source>Sign container contents</source>
+        <target state="new">Sign container contents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">Özel anahtar kapsayıcısını içeren Şifreleme Hizmeti Sağlayıcısı. /k ve alternatif olarak /km gerektirir.</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="translated">证书文件的密码。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainersDescription">
+        <source>Sign container contents</source>
+        <target state="new">Sign container contents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">包含私钥容器的加密服务提供程序。需要 /k 和 /km (可选)。</target>

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="translated">憑證檔案的密碼。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContainersDescription">
+        <source>Sign container contents</source>
+        <target state="new">Sign container contents</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CspOptionDescription">
         <source>Cryptographic Service Provider containing the private key container. Requires /k and optionally /km.</source>
         <target state="translated">包含私密金鑰容器的加密服務提供者。需要 /k 並選擇性地 /km。</target>

--- a/src/Sign.Core/DataFormatSigners/AggregatingSigner.cs
+++ b/src/Sign.Core/DataFormatSigners/AggregatingSigner.cs
@@ -62,6 +62,38 @@ namespace Sign.Core
             ArgumentNullException.ThrowIfNull(files, nameof(files));
             ArgumentNullException.ThrowIfNull(options, nameof(options));
 
+            if (options.RecurseContainers)
+            {
+                await SignContainersAsync(files, options);
+            }
+
+            // split by code sign service and fallback to default
+
+            var grouped = (from signer in _signers
+                           from file in files
+                           where signer.CanSign(file)
+                           group file by signer into groups
+                           select groups).ToList();
+
+            // get all files and exclude existing; 
+
+            // This is to catch PE files that don't have the correct extension set
+            var defaultFiles = files.Except(grouped.SelectMany(g => g))
+                                    .Where(_fileMetadataService.IsPortableExecutable)
+                                    .Select(f => new { _defaultSigner.Signer, f })
+                                    .GroupBy(a => a.Signer, k => k.f)
+                                    .SingleOrDefault(); // one group here
+
+            if (defaultFiles != null)
+            {
+                grouped.Add(defaultFiles);
+            }
+
+            await Task.WhenAll(grouped.Select(g => g.Key.SignAsync(g.ToList(), options)));
+        }
+
+        private async Task SignContainersAsync(IEnumerable<FileInfo> files, SignOptions options)
+        {
             // See if any of them are archives
             List<FileInfo> archives = (from file in files
                                        where _containerProvider.IsZipContainer(file) || _containerProvider.IsNuGetContainer(file)
@@ -178,31 +210,8 @@ namespace Sign.Core
                 containers.ForEach(tz => tz.Dispose());
                 containers.Clear();
             }
-
-            // split by code sign service and fallback to default
-
-            var grouped = (from signer in _signers
-                           from file in files
-                           where signer.CanSign(file)
-                           group file by signer into groups
-                           select groups).ToList();
-
-            // get all files and exclude existing; 
-
-            // This is to catch PE files that don't have the correct extension set
-            var defaultFiles = files.Except(grouped.SelectMany(g => g))
-                                    .Where(_fileMetadataService.IsPortableExecutable)
-                                    .Select(f => new { _defaultSigner.Signer, f })
-                                    .GroupBy(a => a.Signer, k => k.f)
-                                    .SingleOrDefault(); // one group here
-
-            if (defaultFiles != null)
-            {
-                grouped.Add(defaultFiles);
-            }
-
-            await Task.WhenAll(grouped.Select(g => g.Key.SignAsync(g.ToList(), options)));
         }
+
 
         public void CopySigningDependencies(FileInfo file, DirectoryInfo destination, SignOptions options)
         {

--- a/src/Sign.Core/DataFormatSigners/AggregatingSigner.cs
+++ b/src/Sign.Core/DataFormatSigners/AggregatingSigner.cs
@@ -64,7 +64,7 @@ namespace Sign.Core
 
             if (options.RecurseContainers)
             {
-                await SignContainersAsync(files, options);
+                await SignContainerContentsAsync(files, options);
             }
 
             // split by code sign service and fallback to default
@@ -92,7 +92,7 @@ namespace Sign.Core
             await Task.WhenAll(grouped.Select(g => g.Key.SignAsync(g.ToList(), options)));
         }
 
-        private async Task SignContainersAsync(IEnumerable<FileInfo> files, SignOptions options)
+        private async Task SignContainerContentsAsync(IEnumerable<FileInfo> files, SignOptions options)
         {
             // See if any of them are archives
             List<FileInfo> archives = (from file in files

--- a/src/Sign.Core/DataFormatSigners/SignOptions.cs
+++ b/src/Sign.Core/DataFormatSigners/SignOptions.cs
@@ -18,6 +18,7 @@ namespace Sign.Core
         internal HashAlgorithmName FileHashAlgorithm { get; } = HashAlgorithmName.SHA256;
         internal HashAlgorithmName TimestampHashAlgorithm { get; } = HashAlgorithmName.SHA256;
         internal Uri TimestampService { get; }
+        internal bool RecurseContainers { get; }
 
         internal SignOptions(
             string? applicationName,
@@ -28,7 +29,8 @@ namespace Sign.Core
             HashAlgorithmName timestampHashAlgorithm,
             Uri timestampService,
             Matcher? matcher,
-            Matcher? antiMatcher)
+            Matcher? antiMatcher,
+            bool recurseContainers)
         {
             ApplicationName = applicationName;
             PublisherName = publisherName;
@@ -39,12 +41,13 @@ namespace Sign.Core
             TimestampService = timestampService;
             Matcher = matcher;
             AntiMatcher = antiMatcher;
+            RecurseContainers = recurseContainers;
         }
 
         internal SignOptions(HashAlgorithmName fileHashAlgorithm, Uri timestampService)
             : this(applicationName: null, publisherName: null, description: null, descriptionUrl: null,
                   fileHashAlgorithm, HashAlgorithmName.SHA256, timestampService, matcher: null,
-                  antiMatcher: null)
+                  antiMatcher: null, recurseContainers: true)
         {
         }
     }

--- a/src/Sign.Core/ISigner.cs
+++ b/src/Sign.Core/ISigner.cs
@@ -12,6 +12,7 @@ namespace Sign.Core
             IReadOnlyList<FileInfo> inputFiles,
             string? outputFile,
             FileInfo? fileList,
+            bool recurseContainers,
             DirectoryInfo baseDirectory,
             string? applicationName,
             string? publisherName,

--- a/src/Sign.Core/Signer.cs
+++ b/src/Sign.Core/Signer.cs
@@ -31,6 +31,7 @@ namespace Sign.Core
             IReadOnlyList<FileInfo> inputFiles,
             string? outputFile,
             FileInfo? fileList,
+            bool recurseContainers,
             DirectoryInfo baseDirectory,
             string? applicationName,
             string? publisherName,
@@ -70,7 +71,8 @@ namespace Sign.Core
                 timestampHashAlgorithm,
                 timestampUrl,
                 matcher,
-                antiMatcher);
+                antiMatcher,
+                recurseContainers);
 
             try
             {

--- a/test/Sign.Cli.Test/TestInfrastructure/SignerSpy.cs
+++ b/test/Sign.Cli.Test/TestInfrastructure/SignerSpy.cs
@@ -13,6 +13,7 @@ namespace Sign.Cli.Test
         internal string? OutputFile { get; private set; }
         internal FileInfo? FileList { get; private set; }
         internal DirectoryInfo? BaseDirectory { get; private set; }
+        internal bool RecurseContainers { get; private set; }
         internal string? ApplicationName { get; private set; }
         internal string? PublisherName { get; private set; }
         internal string? Description { get; private set; }
@@ -32,6 +33,7 @@ namespace Sign.Cli.Test
             IReadOnlyList<FileInfo> inputFiles,
             string? outputFile,
             FileInfo? fileList,
+            bool recurseContainers,
             DirectoryInfo baseDirectory,
             string? applicationName,
             string? publisherName,
@@ -45,6 +47,7 @@ namespace Sign.Cli.Test
             InputFiles = inputFiles;
             OutputFile = outputFile;
             FileList = fileList;
+            RecurseContainers = recurseContainers;
             BaseDirectory = baseDirectory;
             ApplicationName = applicationName;
             PublisherName = publisherName;

--- a/test/Sign.Core.Test/DataFormatSigners/AggregatingSignerTests.Containers.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/AggregatingSignerTests.Containers.cs
@@ -61,6 +61,41 @@ namespace Sign.Core.Test
         }
 
         [Fact]
+        public async Task SignAsync_WhenRecurseFilesIsFalse_SignsOnlyAppxItself()
+        {
+            AggregatingSignerTest test = new(
+                $"{AppxBundleContainerName}/nestedcontainer.appx/a.dll",
+                $"{AppxBundleContainerName}/nestedcontainer.msix/b.dll");
+
+            SignOptions options = new(
+                applicationName: null,
+                publisherName: null,
+                description: null,
+                new Uri("https://description.test"),
+                HashAlgorithmName.SHA256,
+                HashAlgorithmName.SHA256,
+                new Uri("https://timestamp.test"),
+                null,
+                null,
+                false);
+
+            await test.Signer.SignAsync(test.Files, options);
+
+            ContainerSpy container = test.Containers[AppxBundleContainerName];
+
+            Assert.Equal(0, container.OpenAsync_CallCount);
+            Assert.Equal(0, container.GetFiles_CallCount);
+            Assert.Equal(0, container.GetFilesWithMatcher_CallCount);
+            Assert.Equal(0, container.SaveAsync_CallCount);
+            Assert.Equal(0, container.Dispose_CallCount);
+
+            // The only file should be the appx bundle container itself, since we did not recurse into it
+            Assert.Collection(
+                test.SignerSpy.SignedFiles,
+                signedFile => Assert.Equal(AppxBundleContainerName, signedFile.Name));
+        }
+
+        [Fact]
         public async Task SignAsync_WhenFileIsAppxBundleContainerAndGlobAndAntiGlobPatternsAreUsed_SignsOnlyMatchingFiles()
         {
             const string fileListContents =
@@ -79,7 +114,8 @@ namespace Sign.Core.Test
                 HashAlgorithmName.SHA256,
                 new Uri("https://timestamp.test"),
                 matcher,
-                antiMatcher);
+                antiMatcher,
+                true);
 
             AggregatingSignerTest test = new(
                 $"{AppxBundleContainerName}/a.dll",
@@ -219,7 +255,8 @@ namespace Sign.Core.Test
                 HashAlgorithmName.SHA256,
                 new Uri("https://timestamp.test"),
                 matcher,
-                antiMatcher);
+                antiMatcher,
+                true);
 
             AggregatingSignerTest test = new(
                 $"{AppxContainerName}/a.dll",
@@ -361,7 +398,8 @@ namespace Sign.Core.Test
                 HashAlgorithmName.SHA256,
                 new Uri("https://timestamp.test"),
                 matcher,
-                antiMatcher);
+                antiMatcher,
+                true);
 
             AggregatingSignerTest test = new(
                 $"{ZipContainerName}/a.dll",

--- a/test/Sign.Core.Test/DataFormatSigners/AggregatingSignerTests.Containers.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/AggregatingSignerTests.Containers.cs
@@ -71,13 +71,13 @@ namespace Sign.Core.Test
                 applicationName: null,
                 publisherName: null,
                 description: null,
-                new Uri("https://description.test"),
-                HashAlgorithmName.SHA256,
-                HashAlgorithmName.SHA256,
-                new Uri("https://timestamp.test"),
-                null,
-                null,
-                false);
+                descriptionUrl: new Uri("https://description.test"),
+                fileHashAlgorithm: HashAlgorithmName.SHA256,
+                timestampHashAlgorithm: HashAlgorithmName.SHA256,
+                timestampService: new Uri("https://timestamp.test"),
+                matcher: null,
+                antiMatcher: null,
+                recurseContainers: false);
 
             await test.Signer.SignAsync(test.Files, options);
 

--- a/test/Sign.Core.Test/DataFormatSigners/AggregatingSignerTests.Containers.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/AggregatingSignerTests.Containers.cs
@@ -61,7 +61,7 @@ namespace Sign.Core.Test
         }
 
         [Fact]
-        public async Task SignAsync_WhenRecurseFilesIsFalse_SignsOnlyAppxItself()
+        public async Task SignAsync_WhenRecurseContainersIsFalse_SignsOnlyAppxItself()
         {
             AggregatingSignerTest test = new(
                 $"{AppxBundleContainerName}/nestedcontainer.appx/a.dll",
@@ -115,7 +115,7 @@ namespace Sign.Core.Test
                 new Uri("https://timestamp.test"),
                 matcher,
                 antiMatcher,
-                true);
+                recurseContainers: true);
 
             AggregatingSignerTest test = new(
                 $"{AppxBundleContainerName}/a.dll",
@@ -256,7 +256,7 @@ namespace Sign.Core.Test
                 new Uri("https://timestamp.test"),
                 matcher,
                 antiMatcher,
-                true);
+                recurseContainers: true);
 
             AggregatingSignerTest test = new(
                 $"{AppxContainerName}/a.dll",
@@ -399,7 +399,7 @@ namespace Sign.Core.Test
                 new Uri("https://timestamp.test"),
                 matcher,
                 antiMatcher,
-                true);
+                recurseContainers: true);
 
             AggregatingSignerTest test = new(
                 $"{ZipContainerName}/a.dll",

--- a/test/Sign.Core.Test/DataFormatSigners/AzureSignToolSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/AzureSignToolSignerTests.cs
@@ -139,7 +139,8 @@ namespace Sign.Core.Test
                     HashAlgorithmName.SHA256,
                     timestampService: null!,
                     matcher: null,
-                    antiMatcher: null);
+                    antiMatcher: null,
+                    true);
 
                 X509Certificate2 certificate = _certificateFixture.TrustedCertificate;
 

--- a/test/Sign.Core.Test/DataFormatSigners/AzureSignToolSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/AzureSignToolSignerTests.cs
@@ -140,7 +140,7 @@ namespace Sign.Core.Test
                     timestampService: null!,
                     matcher: null,
                     antiMatcher: null,
-                    true);
+                    recurseContainers: true);
 
                 X509Certificate2 certificate = _certificateFixture.TrustedCertificate;
 

--- a/test/Sign.Core.Test/DataFormatSigners/ClickOnceSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/ClickOnceSignerTests.cs
@@ -225,7 +225,8 @@ namespace Sign.Core.Test
                     HashAlgorithmName.SHA256,
                     new Uri("http://timestamp.test"),
                     matcher: null,
-                    antiMatcher: null);
+                    antiMatcher: null,
+                    recurseContainers: true);
 
                 using (X509Certificate2 certificate = SelfIssuedCertificateCreator.CreateCertificate())
                 using (RSA privateKey = certificate.GetRSAPrivateKey()!)
@@ -333,7 +334,8 @@ namespace Sign.Core.Test
                     HashAlgorithmName.SHA256,
                     new Uri("http://timestamp.test"),
                     matcher: null,
-                    antiMatcher: null);
+                    antiMatcher: null,
+                    recurseContainers: true);
 
                 using (X509Certificate2 certificate = SelfIssuedCertificateCreator.CreateCertificate())
                 using (RSA privateKey = certificate.GetRSAPrivateKey()!)
@@ -458,7 +460,8 @@ namespace Sign.Core.Test
                     HashAlgorithmName.SHA256,
                     new Uri("http://timestamp.test"),
                     matcher: null,
-                    antiMatcher: null);
+                    antiMatcher: null,
+                    recurseContainers: true);
 
                 using (X509Certificate2 certificate = SelfIssuedCertificateCreator.CreateCertificate())
                 using (RSA privateKey = certificate.GetRSAPrivateKey()!)
@@ -590,7 +593,8 @@ namespace Sign.Core.Test
                         HashAlgorithmName.SHA256,
                         new Uri("http://timestamp.test"),
                         matcher: null,
-                        antiMatcher: null
+                        antiMatcher: null,
+                        recurseContainers: true
                     );
 
                     manifestSigner.Setup(

--- a/test/Sign.Core.Test/DataFormatSigners/NuGetSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/NuGetSignerTests.cs
@@ -133,7 +133,8 @@ namespace Sign.Core.Test
                 HashAlgorithmName.SHA384,
                 new Uri("http://timestamp.test"),
                 matcher: null,
-                antiMatcher: null);
+                antiMatcher: null,
+                recurseContainers: true);
 
             using (DirectoryService directoryService = new(Mock.Of<ILogger<IDirectoryService>>()))
             using (TemporaryDirectory temporaryDirectory = new(directoryService))

--- a/test/Sign.Core.Test/DataFormatSigners/VsixSignerTests.cs
+++ b/test/Sign.Core.Test/DataFormatSigners/VsixSignerTests.cs
@@ -117,7 +117,8 @@ namespace Sign.Core.Test
                 HashAlgorithmName.SHA384,
                 new Uri("http://timestamp.test"),
                 matcher: null,
-                antiMatcher: null);
+                antiMatcher: null,
+                recurseContainers: true);
 
             using (DirectoryService directoryService = new(Mock.Of<ILogger<IDirectoryService>>()))
             using (TemporaryDirectory temporaryDirectory = new(directoryService))

--- a/test/Sign.Core.Test/SignerTests.cs
+++ b/test/Sign.Core.Test/SignerTests.cs
@@ -231,6 +231,7 @@ namespace Sign.Core.Test
                 files,
                 outputFile: outputFile,
                 fileList: null,
+                recurseContainers: true,
                 temporaryDirectory.Directory,
                 applicationName: "a",
                 publisherName: null,


### PR DESCRIPTION
Add a new `--recurse-containers`/`-rc` option that allows users to specify whether to sign the contents of container files recursively. 

This is enabled by default but can be disabled using `--recurse-containers=false`.

Disabling this feature will prevent sign tool from signing files in containers such as `appx` but will still sign the `appx` file itself. This is useful for those who sign their files before packaging them into a container.

Fixes #775 