### PR TITLE
Update dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,9 +6,9 @@
   <ItemGroup>
     <PackageVersion Include="Azure.CodeSigning.Sdk" Version="0.1.135" />
     <PackageVersion Include="Azure.Core" Version="1.46.2" />
-    <PackageVersion Include="Azure.Identity" Version="1.14.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.14.1" />
     <PackageVersion Include="Azure.Security.KeyVault.Certificates" Version="4.8.0" />
-    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Keys" Version="4.8.0" />
     <PackageVersion Include="AzureSign.Core" Version="4.0.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.0" />

--- a/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.cs.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ContainersDescription">
-        <source>Sign container contents</source>
-        <target state="new">Sign container contents</target>
+        <source>Sign container contents.</source>
+        <target state="new">Sign container contents.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">

--- a/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.de.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ContainersDescription">
-        <source>Sign container contents</source>
-        <target state="new">Sign container contents</target>
+        <source>Sign container contents.</source>
+        <target state="new">Sign container contents.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">

--- a/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.es.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ContainersDescription">
-        <source>Sign container contents</source>
-        <target state="new">Sign container contents</target>
+        <source>Sign container contents.</source>
+        <target state="new">Sign container contents.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">

--- a/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.fr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ContainersDescription">
-        <source>Sign container contents</source>
-        <target state="new">Sign container contents</target>
+        <source>Sign container contents.</source>
+        <target state="new">Sign container contents.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">

--- a/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.it.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ContainersDescription">
-        <source>Sign container contents</source>
-        <target state="new">Sign container contents</target>
+        <source>Sign container contents.</source>
+        <target state="new">Sign container contents.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ja.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ContainersDescription">
-        <source>Sign container contents</source>
-        <target state="new">Sign container contents</target>
+        <source>Sign container contents.</source>
+        <target state="new">Sign container contents.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ko.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ContainersDescription">
-        <source>Sign container contents</source>
-        <target state="new">Sign container contents</target>
+        <source>Sign container contents.</source>
+        <target state="new">Sign container contents.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pl.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ContainersDescription">
-        <source>Sign container contents</source>
-        <target state="new">Sign container contents</target>
+        <source>Sign container contents.</source>
+        <target state="new">Sign container contents.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">

--- a/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.pt-BR.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ContainersDescription">
-        <source>Sign container contents</source>
-        <target state="new">Sign container contents</target>
+        <source>Sign container contents.</source>
+        <target state="new">Sign container contents.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">

--- a/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.ru.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ContainersDescription">
-        <source>Sign container contents</source>
-        <target state="new">Sign container contents</target>
+        <source>Sign container contents.</source>
+        <target state="new">Sign container contents.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">

--- a/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.tr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ContainersDescription">
-        <source>Sign container contents</source>
-        <target state="new">Sign container contents</target>
+        <source>Sign container contents.</source>
+        <target state="new">Sign container contents.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hans.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ContainersDescription">
-        <source>Sign container contents</source>
-        <target state="new">Sign container contents</target>
+        <source>Sign container contents.</source>
+        <target state="new">Sign container contents.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">

--- a/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/CertificateStoreResources.zh-Hant.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ContainersDescription">
-        <source>Sign container contents</source>
-        <target state="new">Sign container contents</target>
+        <source>Sign container contents.</source>
+        <target state="new">Sign container contents.</target>
         <note />
       </trans-unit>
       <trans-unit id="CspOptionDescription">


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/904

This PR also contains automatically generated updates to .xlf files.  This is because https://github.com/dotnet/sign/pull/895 added a new resource string and updated the .resx file directly without regenerating .xlf files.