### PR TITLE
CI:  add package source mappings for CI tools

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -15,6 +15,8 @@
     <packageSource key="dotnet-public">
       <package pattern="Azure.*" />
       <package pattern="AzureSign.Core" />
+      <!-- Used by Arcade -->
+      <package pattern="binlogtool" />
       <package pattern="Castle.Core" />
       <package pattern="coverlet.collector" />
       <package pattern="MicroBuild.Core" />
@@ -22,6 +24,8 @@
       <package pattern="Moq" />
       <package pattern="Newtonsoft.Json" />
       <package pattern="NuGet.*" />
+      <!-- Used by Arcade -->
+      <package pattern="sourcelink" />
       <package pattern="System.*" />
       <package pattern="vswhere" />
       <package pattern="xunit.*" />


### PR DESCRIPTION
Resolve https://github.com/dotnet/sign/issues/906.

After enabling package source mapping, the internal CI build has been unable to download a couple of .NET tools.

This change adds package source mappings for those tools.