### PR TITLE
Add Azure Key Vault certificate version option

### DIFF
--- a/src/Sign.Cli/AzureKeyVaultCommand.cs
+++ b/src/Sign.Cli/AzureKeyVaultCommand.cs
@@ -18,6 +18,7 @@ namespace Sign.Cli
     internal sealed class AzureKeyVaultCommand : Command
     {
         internal Option<Uri> UrlOption { get; }
+        internal Option<string> CertificateVersionOption { get; }
         internal Option<string> CertificateOption { get; }
         internal AzureCredentialOptions AzureCredentialOptions { get; } = new();
 
@@ -40,6 +41,10 @@ namespace Sign.Cli
                 Description = AzureKeyVaultResources.CertificateOptionDescription,
                 Required = true
             };
+            CertificateVersionOption = new Option<string>("--azure-key-vault-certificate-version", "-kvcv")
+            {
+                Description = AzureKeyVaultResources.CertificateVersionOptionDescription
+            };
             FilesArgument = new Argument<List<string>?>("file(s)")
             {
                 Description = Resources.FilesArgumentDescription,
@@ -48,6 +53,7 @@ namespace Sign.Cli
 
             Options.Add(UrlOption);
             Options.Add(CertificateOption);
+            Options.Add(CertificateVersionOption);
             AzureCredentialOptions.AddOptionsToCommand(this);
 
             Arguments.Add(FilesArgument);
@@ -82,9 +88,11 @@ namespace Sign.Cli
                 // the null-forgiving operator (!) to simplify the code.
                 Uri url = parseResult.GetValue(UrlOption)!;
                 string certificateId = parseResult.GetValue(CertificateOption)!;
+                string? certificateVersion = parseResult.GetValue(CertificateVersionOption);
+                string certificateVersionPath = string.IsNullOrEmpty(certificateVersion) ? string.Empty : $"/{certificateVersion}";
 
                 // Construct the URI for the certificate and the key from user parameters. We'll validate those with the SDK
-                var certUri = new Uri($"{url.Scheme}://{url.Authority}/certificates/{certificateId}");
+                var certUri = new Uri($"{url.Scheme}://{url.Authority}/certificates/{certificateId}{certificateVersionPath}");
 
                 if (!KeyVaultCertificateIdentifier.TryCreate(certUri, out var certId))
                 {
@@ -94,7 +102,7 @@ namespace Sign.Cli
                 }
 
                 // The key uri is similar and the key name matches the certificate name
-                var keyUri = new Uri($"{url.Scheme}://{url.Authority}/keys/{certificateId}");
+                var keyUri = new Uri($"{url.Scheme}://{url.Authority}/keys/{certificateId}{certificateVersionPath}");
 
                 serviceProviderFactory.AddServices(services =>
                 {
@@ -112,6 +120,7 @@ namespace Sign.Cli
                             serviceProvider.GetRequiredService<CertificateClient>(),
                             serviceProvider.GetRequiredService<CryptographyClient>(),
                             certId.Name,
+                            certId.Version,
                             serviceProvider.GetRequiredService<ILogger<KeyVaultService>>());
                     });
                 });

--- a/src/Sign.Cli/AzureKeyVaultResources.Designer.cs
+++ b/src/Sign.Cli/AzureKeyVaultResources.Designer.cs
@@ -69,6 +69,12 @@ namespace Sign.Cli {
             }
         }
         
+        internal static string CertificateVersionOptionDescription {
+            get {
+                return ResourceManager.GetString("CertificateVersionOptionDescription", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation..
         /// </summary>

--- a/src/Sign.Cli/AzureKeyVaultResources.resx
+++ b/src/Sign.Cli/AzureKeyVaultResources.resx
@@ -120,6 +120,9 @@
   <data name="CertificateOptionDescription" xml:space="preserve">
     <value>Name of the certificate in Azure Key Vault.</value>
   </data>
+  <data name="CertificateVersionOptionDescription" xml:space="preserve">
+    <value>Optional version of the Azure Key Vault certificate.</value>
+  </data>
   <data name="ClickOnceExtensionNotSupported" xml:space="preserve">
     <value>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</value>
   </data>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Název certifikátu v Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateVersionOptionDescription">
+        <source>Optional version of the Azure Key Vault certificate.</source>
+        <target state="new">Optional version of the Azure Key Vault certificate.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
         <target state="translated">Podepisování ClickOnce prostřednictvím starší verze alternativního řešení .clickonce ZIP se už nepodporuje. Projděte si dokumentaci.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Name des Zertifikats in Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateVersionOptionDescription">
+        <source>Optional version of the Azure Key Vault certificate.</source>
+        <target state="new">Optional version of the Azure Key Vault certificate.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
         <target state="translated">Die ClickOnce-Signierung über die Legacy-.clickonce-ZIP-Problemumgehung wird nicht mehr unterstützt. Siehe Dokumentation.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nombre del certificado en Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateVersionOptionDescription">
+        <source>Optional version of the Azure Key Vault certificate.</source>
+        <target state="new">Optional version of the Azure Key Vault certificate.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
         <target state="translated">Ya no se admite la firma ClickOnce a través de la solución zip heredada .clickonce. Consulte la documentación.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nom du certificat dans Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateVersionOptionDescription">
+        <source>Optional version of the Azure Key Vault certificate.</source>
+        <target state="new">Optional version of the Azure Key Vault certificate.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
         <target state="translated">La signature ClickOnce via la solution de contournement zip .clickonce héritée n’est plus prise en charge. Consulter la documentation.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nome del certificato in Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateVersionOptionDescription">
+        <source>Optional version of the Azure Key Vault certificate.</source>
+        <target state="new">Optional version of the Azure Key Vault certificate.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
         <target state="translated">La firma ClickOnce tramite la soluzione alternativa legacy .clickonce ZIP non è più supportata. Vedere la documentazione.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Azure Key Vault 内の証明書の名前。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateVersionOptionDescription">
+        <source>Optional version of the Azure Key Vault certificate.</source>
+        <target state="new">Optional version of the Azure Key Vault certificate.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
         <target state="translated">従来の .clickonce ZIP 回避策による ClickOnce 署名はサポートされなくなりました。ドキュメントを参照してください。</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Azure Key Vault의 인증서 이름입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateVersionOptionDescription">
+        <source>Optional version of the Azure Key Vault certificate.</source>
+        <target state="new">Optional version of the Azure Key Vault certificate.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
         <target state="translated">레거시 .clickonce ZIP 해결 방법을 통한 ClickOnce 서명은 더 이상 지원되지 않습니다. 설명서를 참조하세요.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nazwa certyfikatu w usłudze Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateVersionOptionDescription">
+        <source>Optional version of the Azure Key Vault certificate.</source>
+        <target state="new">Optional version of the Azure Key Vault certificate.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
         <target state="translated">Podpisywanie clickOnce za pośrednictwem starszego obejścia .clickonce ZIP nie jest już obsługiwane. Zobacz dokumentację.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nome do certificado no Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateVersionOptionDescription">
+        <source>Optional version of the Azure Key Vault certificate.</source>
+        <target state="new">Optional version of the Azure Key Vault certificate.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
         <target state="translated">Não há mais suporte para a assinatura do ClickOnce por meio da solução alternativa .clickonce ZIP herdada. Consulte a documentação.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Имя сертификата в Azure Key Vault.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateVersionOptionDescription">
+        <source>Optional version of the Azure Key Vault certificate.</source>
+        <target state="new">Optional version of the Azure Key Vault certificate.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
         <target state="translated">Подписание ClickOnce с помощью устаревшего обходного пути .clickonce ZIP больше не поддерживается. См. документацию.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Azure Key Vault’taki sertifikanın adı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateVersionOptionDescription">
+        <source>Optional version of the Azure Key Vault certificate.</source>
+        <target state="new">Optional version of the Azure Key Vault certificate.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
         <target state="translated">Eski .clickonce ZIP geçici çözümü aracılığıyla ClickOnce imzalama işlemi artık desteklenmiyor. Belgelere bakın.</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Azure Key Vault 中的证书名称。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateVersionOptionDescription">
+        <source>Optional version of the Azure Key Vault certificate.</source>
+        <target state="new">Optional version of the Azure Key Vault certificate.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
         <target state="translated">不再支持通过旧版 .clickonce ZIP 解决方法进行 ClickOnce 签名。参阅文档。</target>

--- a/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
+++ b/src/Sign.Cli/xlf/AzureKeyVaultResources.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Azure Key Vault 中的憑證名稱。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CertificateVersionOptionDescription">
+        <source>Optional version of the Azure Key Vault certificate.</source>
+        <target state="new">Optional version of the Azure Key Vault certificate.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ClickOnceExtensionNotSupported">
         <source>ClickOnce signing via the legacy .clickonce ZIP workaround is no longer supported. See documentation.</source>
         <target state="translated">已不再支援透過舊版 .clickonce ZIP 因應措施進行 ClickOnce 簽署。請參閱文件。</target>

--- a/src/Sign.SignatureProviders.KeyVault/KeyVaultService.cs
+++ b/src/Sign.SignatureProviders.KeyVault/KeyVaultService.cs
@@ -17,6 +17,7 @@ namespace Sign.SignatureProviders.KeyVault
     {
         private readonly CertificateClient _certificateClient;
         private readonly CryptographyClient _cryptographyClient;
+        private readonly string? _certificateVersion;
         private readonly string _certificateName;
         private readonly ILogger<KeyVaultService> _logger;
         private readonly SemaphoreSlim _mutex = new(1);
@@ -26,6 +27,7 @@ namespace Sign.SignatureProviders.KeyVault
             CertificateClient certificateClient,
             CryptographyClient cryptographyClient,
             string certificateName,
+            string? certificateVersion,
             ILogger<KeyVaultService> logger)
         {
             ArgumentNullException.ThrowIfNull(certificateClient, nameof(certificateClient));
@@ -34,6 +36,7 @@ namespace Sign.SignatureProviders.KeyVault
             ArgumentNullException.ThrowIfNull(logger, nameof(logger));
 
             _certificateName = certificateName;
+            _certificateVersion = certificateVersion;
             _certificateClient = certificateClient;
             _cryptographyClient = cryptographyClient;
             _logger = logger;
@@ -63,11 +66,22 @@ namespace Sign.SignatureProviders.KeyVault
 
                     _logger.LogTrace(Resources.FetchingCertificate);
 
-                    Response<KeyVaultCertificateWithPolicy> response = await _certificateClient.GetCertificateAsync(_certificateName, cancellationToken);
+                    byte[] certificateBytes;
+                    if (string.IsNullOrEmpty(_certificateVersion))
+                    {
+                        Response<KeyVaultCertificateWithPolicy> response = await _certificateClient.GetCertificateAsync(_certificateName, cancellationToken);
+                        certificateBytes = response.Value.Cer;
+                    }
+                    else
+                    {
+                        Response<KeyVaultCertificate> response =
+                            await _certificateClient.GetCertificateVersionAsync(_certificateName, _certificateVersion, cancellationToken);
+                        certificateBytes = response.Value.Cer;
+                    }
 
                     _logger.LogTrace(Resources.FetchedCertificate, stopwatch.Elapsed.TotalMilliseconds);
 
-                    _certificate = new X509Certificate2(response.Value.Cer);
+                    _certificate = new X509Certificate2(certificateBytes);
 
                     //print the certificate info
                     _logger.LogTrace($"{Resources.CertificateDetails}{Environment.NewLine}{_certificate.ToString(verbose: true)}");

--- a/test/Sign.Cli.Test/AzureKeyVaultCommandTests.cs
+++ b/test/Sign.Cli.Test/AzureKeyVaultCommandTests.cs
@@ -43,6 +43,18 @@ namespace Sign.Cli.Test
         }
 
         [Fact]
+        public void CertificateVersionOption_Always_HasArityOfExactlyOne()
+        {
+            Assert.Equal(ArgumentArity.ExactlyOne, _command.CertificateVersionOption.Arity);
+        }
+
+        [Fact]
+        public void CertificateVersionOption_Always_IsOptional()
+        {
+            Assert.False(_command.CertificateVersionOption.Required);
+        }
+
+        [Fact]
         public void UrlOption_Always_HasArityOfExactlyOne()
         {
             Assert.Equal(ArgumentArity.ExactlyOne, _command.UrlOption.Arity);
@@ -92,11 +104,24 @@ namespace Sign.Cli.Test
             [Theory]
             [InlineData("code azure-key-vault -kvu https://keyvault.test -kvc a b")]
             [InlineData("code azure-key-vault -kvu https://keyvault.test -kvc a -kvt b -kvi c -kvs d e")]
+            [InlineData("code azure-key-vault -kvu https://keyvault.test -kvc a -kvcv b c")]
+            [InlineData("code azure-key-vault -kvu https://keyvault.test -kvc a --azure-key-vault-certificate-version b c")]
             public void Command_WhenRequiredArgumentsArePresent_HasNoError(string command)
             {
                 ParseResult result = _rootCommand.Parse(command);
 
                 Assert.Empty(result.Errors);
+            }
+
+            [Theory]
+            [InlineData("-kvcv")]
+            [InlineData("--azure-key-vault-certificate-version")]
+            public void Command_WhenCertificateVersionIsSpecified_ParsesCorrectly(string option)
+            {
+                ParseResult result = _rootCommand.Parse($"code azure-key-vault -kvu https://keyvault.test -kvc a {option} b c");
+
+                Assert.Empty(result.Errors);
+                Assert.Equal("b", result.GetValue(_command.CertificateVersionOption));
             }
 
             [Theory]

--- a/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceProviderTests.cs
+++ b/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceProviderTests.cs
@@ -25,7 +25,9 @@ namespace Sign.SignatureProviders.KeyVault.Test
                 return new KeyVaultService(
                     Mock.Of<CertificateClient>(),
                     Mock.Of<CryptographyClient>(),
-                    "a", sp.GetRequiredService<ILogger<KeyVaultService>>());
+                    "a",
+                    null,
+                    sp.GetRequiredService<ILogger<KeyVaultService>>());
             });
             serviceProvider = services.BuildServiceProvider();
         }

--- a/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceTests.cs
+++ b/test/Sign.SignatureProviders.KeyVault.Test/KeyVaultServiceTests.cs
@@ -16,6 +16,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
     public class KeyVaultServiceTests
     {
         private const string CertificateName = "a";
+        private const string CertificateVersion = "b";
         private static readonly ILogger<KeyVaultService> Logger = Mock.Of<ILogger<KeyVaultService>>();
 
         private readonly Mock<CertificateClient> _certificateClient = new();
@@ -25,7 +26,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenCertificateClientIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new KeyVaultService(certificateClient: null!, _cryptographyClient.Object, CertificateName, Logger));
+                () => new KeyVaultService(certificateClient: null!, _cryptographyClient.Object, CertificateName, null, Logger));
 
             Assert.Equal("certificateClient", exception.ParamName);
         }
@@ -34,7 +35,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenCryptographyClientIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new KeyVaultService(_certificateClient.Object, cryptographyClient: null!, CertificateName, Logger));
+                () => new KeyVaultService(_certificateClient.Object, cryptographyClient: null!, CertificateName, null, Logger));
 
             Assert.Equal("cryptographyClient", exception.ParamName);
         }
@@ -43,7 +44,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenCertificateNameIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new KeyVaultService(_certificateClient.Object, _cryptographyClient.Object, certificateName: null!, Logger));
+                () => new KeyVaultService(_certificateClient.Object, _cryptographyClient.Object, certificateName: null!, null, Logger));
 
             Assert.Equal("certificateName", exception.ParamName);
         }
@@ -52,7 +53,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenCertificateNameIsEmpty_Throws()
         {
             ArgumentException exception = Assert.Throws<ArgumentException>(
-                () => new KeyVaultService(_certificateClient.Object, _cryptographyClient.Object, certificateName: string.Empty, Logger));
+                () => new KeyVaultService(_certificateClient.Object, _cryptographyClient.Object, certificateName: string.Empty, null, Logger));
 
             Assert.Equal("certificateName", exception.ParamName);
         }
@@ -61,7 +62,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
         public void Constructor_WhenLoggerIsNull_Throws()
         {
             ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
-                () => new KeyVaultService(_certificateClient.Object, _cryptographyClient.Object, CertificateName, logger: null!));
+                () => new KeyVaultService(_certificateClient.Object, _cryptographyClient.Object, CertificateName, null, logger: null!));
 
             Assert.Equal("logger", exception.ParamName);
         }
@@ -81,12 +82,44 @@ namespace Sign.SignatureProviders.KeyVault.Test
                 .Setup(_ => _.GetCertificateAsync(CertificateName, cancellationToken))
                 .ReturnsAsync(response.Object);
 
-            using KeyVaultService service = new(_certificateClient.Object, _cryptographyClient.Object, CertificateName, Logger);
+            using KeyVaultService service = new(_certificateClient.Object, _cryptographyClient.Object, CertificateName, null, Logger);
 
             using X509Certificate2 certificate1 = await service.GetCertificateAsync(cancellationToken);
             using X509Certificate2 certificate2 = await service.GetCertificateAsync(cancellationToken);
 
             _certificateClient.Verify(_ => _.GetCertificateAsync(CertificateName, cancellationToken), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetCertificateAsync_WhenCertificateVersionIsSpecified_RetrievesVersion()
+        {
+            CancellationToken cancellationToken = CancellationToken.None;
+            byte[] publicKey = SelfIssuedCertificateCreator.CreateCertificate().Export(X509ContentType.Cert);
+            KeyVaultCertificate certificate = CertificateModelFactory.KeyVaultCertificate(
+                new CertificateProperties(CertificateName),
+                cer: publicKey);
+            Mock<Response<KeyVaultCertificate>> response = new();
+
+            response
+                .Setup(_ => _.Value)
+                .Returns(certificate);
+
+            _certificateClient
+                .Setup(_ => _.GetCertificateVersionAsync(CertificateName, CertificateVersion, cancellationToken))
+                .ReturnsAsync(response.Object);
+
+            using KeyVaultService service = new(
+                _certificateClient.Object,
+                _cryptographyClient.Object,
+                CertificateName,
+                CertificateVersion,
+                Logger);
+
+            using X509Certificate2 result = await service.GetCertificateAsync(cancellationToken);
+
+            _certificateClient.Verify(
+                _ => _.GetCertificateVersionAsync(CertificateName, CertificateVersion, cancellationToken),
+                Times.Once);
         }
 
         [Fact]
@@ -109,7 +142,7 @@ namespace Sign.SignatureProviders.KeyVault.Test
                 .Setup(_ => _.CreateRSAAsync(cancellationToken))
                 .ReturnsAsync(rsaKeyVault.Object);
 
-            using KeyVaultService service = new(_certificateClient.Object, _cryptographyClient.Object, CertificateName, Logger);
+            using KeyVaultService service = new(_certificateClient.Object, _cryptographyClient.Object, CertificateName, null, Logger);
 
             using RSA rsa = await service.GetRsaAsync(cancellationToken);
 


### PR DESCRIPTION
Adds `--azure-key-vault-certificate-version` / `-kvcv` and uses the selected certificate and key version.

Resolves #1005
