### PR TITLE
Reject fragment delimiters in OPC part names

### DIFF
--- a/src/Sign.Core/Resources.Designer.cs
+++ b/src/Sign.Core/Resources.Designer.cs
@@ -356,6 +356,15 @@ namespace Sign.Core {
                 return ResourceManager.GetString("VSIXSignToolOpcContentTypeInvalid", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Package part name &apos;{0}&apos; contains the unsupported &apos;#&apos; character..
+        /// </summary>
+        internal static string VSIXSignToolOpcPartNameContainsFragmentDelimiter {
+            get {
+                return ResourceManager.GetString("VSIXSignToolOpcPartNameContainsFragmentDelimiter", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Unknown signing algorithm..

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -243,6 +243,10 @@
     <value>Specified {0} is invalid.</value>
     <comment>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</comment>
   </data>
+  <data name="VSIXSignToolOpcPartNameContainsFragmentDelimiter" xml:space="preserve">
+    <value>Package part name '{0}' contains the unsupported '#' character.</value>
+    <comment>{NumberedPlaceholder="{0}"} is the package part name.</comment>
+  </data>
   <data name="VSIXSignToolUnknownSigningAlgorithm" xml:space="preserve">
     <value>Unknown signing algorithm.</value>
   </data>

--- a/src/Sign.Core/Tools/VsixSignTool/OpcPart.cs
+++ b/src/Sign.Core/Tools/VsixSignTool/OpcPart.cs
@@ -20,7 +20,7 @@ namespace Sign.Core
         {
             if (path.Contains('#'))
             {
-                throw new InvalidDataException($"Package part name '{path}' contains the unsupported '#' character.");
+                throw new InvalidDataException(string.Format(Resources.VSIXSignToolOpcPartNameContainsFragmentDelimiter, path));
             }
 
             Uri = new Uri(OpcPackage.BasePackageUri, path);

--- a/src/Sign.Core/Tools/VsixSignTool/OpcPart.cs
+++ b/src/Sign.Core/Tools/VsixSignTool/OpcPart.cs
@@ -18,6 +18,11 @@ namespace Sign.Core
 
         internal OpcPart(OpcPackage package, string path, ZipArchiveEntry entry, OpcPackageFileMode mode)
         {
+            if (path.Contains('#'))
+            {
+                throw new InvalidDataException($"Package part name '{path}' contains the unsupported '#' character.");
+            }
+
             Uri = new Uri(OpcPackage.BasePackageUri, path);
             Package = package;
             _path = path;

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Zadaný režim {0} je neplatný.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
+      <trans-unit id="VSIXSignToolOpcPartNameContainsFragmentDelimiter">
+        <source>Package part name '{0}' contains the unsupported '#' character.</source>
+        <target state="new">Package part name '{0}' contains the unsupported '#' character.</target>
+        <note>{NumberedPlaceholder="{0}"} is the package part name.</note>
+      </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
         <target state="translated">Neznámý podpisový algoritmus.</target>

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Der angegebene {0} ist ungültig.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
+      <trans-unit id="VSIXSignToolOpcPartNameContainsFragmentDelimiter">
+        <source>Package part name '{0}' contains the unsupported '#' character.</source>
+        <target state="new">Package part name '{0}' contains the unsupported '#' character.</target>
+        <note>{NumberedPlaceholder="{0}"} is the package part name.</note>
+      </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
         <target state="translated">Unbekannter Signaturalgorithmus.</target>

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -162,6 +162,11 @@
         <target state="translated">El modo {0} especificado no es válido.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
+      <trans-unit id="VSIXSignToolOpcPartNameContainsFragmentDelimiter">
+        <source>Package part name '{0}' contains the unsupported '#' character.</source>
+        <target state="new">Package part name '{0}' contains the unsupported '#' character.</target>
+        <note>{NumberedPlaceholder="{0}"} is the package part name.</note>
+      </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
         <target state="translated">Algoritmo de firma desconocido.</target>

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Le mode {0} spécifié n’est pas valide.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
+      <trans-unit id="VSIXSignToolOpcPartNameContainsFragmentDelimiter">
+        <source>Package part name '{0}' contains the unsupported '#' character.</source>
+        <target state="new">Package part name '{0}' contains the unsupported '#' character.</target>
+        <note>{NumberedPlaceholder="{0}"} is the package part name.</note>
+      </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
         <target state="translated">Algorithme de signature inconnu.</target>

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -162,6 +162,11 @@
         <target state="translated">{0} specificato non valido.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
+      <trans-unit id="VSIXSignToolOpcPartNameContainsFragmentDelimiter">
+        <source>Package part name '{0}' contains the unsupported '#' character.</source>
+        <target state="new">Package part name '{0}' contains the unsupported '#' character.</target>
+        <note>{NumberedPlaceholder="{0}"} is the package part name.</note>
+      </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
         <target state="translated">Algoritmo di firma sconosciuto.</target>

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -162,6 +162,11 @@
         <target state="translated">指定された {0} は無効です。</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
+      <trans-unit id="VSIXSignToolOpcPartNameContainsFragmentDelimiter">
+        <source>Package part name '{0}' contains the unsupported '#' character.</source>
+        <target state="new">Package part name '{0}' contains the unsupported '#' character.</target>
+        <note>{NumberedPlaceholder="{0}"} is the package part name.</note>
+      </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
         <target state="translated">不明な署名アルゴリズムです。</target>

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -162,6 +162,11 @@
         <target state="translated">지정한 {0} 값이 잘못되었습니다.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
+      <trans-unit id="VSIXSignToolOpcPartNameContainsFragmentDelimiter">
+        <source>Package part name '{0}' contains the unsupported '#' character.</source>
+        <target state="new">Package part name '{0}' contains the unsupported '#' character.</target>
+        <note>{NumberedPlaceholder="{0}"} is the package part name.</note>
+      </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
         <target state="translated">알 수 없는 서명 알고리즘입니다.</target>

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Określony tryb {0} jest nieprawidłowy.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
+      <trans-unit id="VSIXSignToolOpcPartNameContainsFragmentDelimiter">
+        <source>Package part name '{0}' contains the unsupported '#' character.</source>
+        <target state="new">Package part name '{0}' contains the unsupported '#' character.</target>
+        <note>{NumberedPlaceholder="{0}"} is the package part name.</note>
+      </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
         <target state="translated">Nieznany algorytm podpisywania.</target>

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -162,6 +162,11 @@
         <target state="translated">O {0} especificado é inválido.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
+      <trans-unit id="VSIXSignToolOpcPartNameContainsFragmentDelimiter">
+        <source>Package part name '{0}' contains the unsupported '#' character.</source>
+        <target state="new">Package part name '{0}' contains the unsupported '#' character.</target>
+        <note>{NumberedPlaceholder="{0}"} is the package part name.</note>
+      </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
         <target state="translated">Algoritmo de assinatura desconhecido.</target>

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Указанный параметр ({0}) недопустим.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
+      <trans-unit id="VSIXSignToolOpcPartNameContainsFragmentDelimiter">
+        <source>Package part name '{0}' contains the unsupported '#' character.</source>
+        <target state="new">Package part name '{0}' contains the unsupported '#' character.</target>
+        <note>{NumberedPlaceholder="{0}"} is the package part name.</note>
+      </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
         <target state="translated">Неизвестный алгоритм подписывания.</target>

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -162,6 +162,11 @@
         <target state="translated">Belirtilen {0} geçersiz.</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
+      <trans-unit id="VSIXSignToolOpcPartNameContainsFragmentDelimiter">
+        <source>Package part name '{0}' contains the unsupported '#' character.</source>
+        <target state="new">Package part name '{0}' contains the unsupported '#' character.</target>
+        <note>{NumberedPlaceholder="{0}"} is the package part name.</note>
+      </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
         <target state="translated">Bilinmeyen imzalama algoritması.</target>

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -162,6 +162,11 @@
         <target state="translated">指定的 {0} 无效。</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
+      <trans-unit id="VSIXSignToolOpcPartNameContainsFragmentDelimiter">
+        <source>Package part name '{0}' contains the unsupported '#' character.</source>
+        <target state="new">Package part name '{0}' contains the unsupported '#' character.</target>
+        <note>{NumberedPlaceholder="{0}"} is the package part name.</note>
+      </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
         <target state="translated">未知签名算法。</target>

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -162,6 +162,11 @@
         <target state="translated">指定的 {0} 無效。</target>
         <note>{NumberedPlaceholder="{0}"} is the mode for reading OPC content. Either "default" or "override".</note>
       </trans-unit>
+      <trans-unit id="VSIXSignToolOpcPartNameContainsFragmentDelimiter">
+        <source>Package part name '{0}' contains the unsupported '#' character.</source>
+        <target state="new">Package part name '{0}' contains the unsupported '#' character.</target>
+        <note>{NumberedPlaceholder="{0}"} is the package part name.</note>
+      </trans-unit>
       <trans-unit id="VSIXSignToolUnknownSigningAlgorithm">
         <source>Unknown signing algorithm.</source>
         <target state="translated">未知的簽署演算法。</target>

--- a/test/Sign.Core.Test/Tools/VSIXSignTool/OpcPackageSigningTests.cs
+++ b/test/Sign.Core.Test/Tools/VSIXSignTool/OpcPackageSigningTests.cs
@@ -2,10 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE.txt file in the project root for more information.
 
+using System.IO.Compression;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Xml;
+using Microsoft.Extensions.Logging;
 using Sign.Core.Timestamp;
 using Xunit.Abstractions;
 
@@ -67,6 +69,40 @@ namespace Sign.Core.Test
                 yield return new object[] { 2048, HashAlgorithmName.SHA256, HashAlgorithmName.SHA512, OpcKnownUris.SignatureAlgorithms.RsaSHA512.AbsoluteUri };
                 yield return new object[] { 2048, HashAlgorithmName.SHA256, HashAlgorithmName.SHA384, OpcKnownUris.SignatureAlgorithms.RsaSHA384.AbsoluteUri };
                 yield return new object[] { 2048, HashAlgorithmName.SHA256, HashAlgorithmName.SHA256, OpcKnownUris.SignatureAlgorithms.RsaSHA256.AbsoluteUri };
+            }
+        }
+
+        [Theory]
+        [InlineData("ab#c.txt")]
+        [InlineData("folder/ab#c.txt")]
+        public async Task ShouldRejectPartNameContainingFragmentDelimiter(string entryName)
+        {
+            string path = CreatePackageWithEntry(entryName);
+            VsixSignTool signTool = new(Moq.Mock.Of<ILogger<IVsixSignTool>>());
+
+            using (X509Certificate2 certificate = _pfxFilesFixture.GetPfx(
+                keySizeInBits: 2048,
+                HashAlgorithmName.SHA256))
+            using (RSA? rsaPrivateKey = certificate.GetRSAPrivateKey())
+            {
+                SignConfigurationSet configuration = new(
+                    publicCertificate: certificate,
+                    signatureDigestAlgorithm: HashAlgorithmName.SHA256,
+                    fileDigestAlgorithm: HashAlgorithmName.SHA256,
+                    signingKey: rsaPrivateKey!);
+                SignOptions options = new(
+                    fileHashAlgorithm: HashAlgorithmName.SHA256,
+                    timestampService: null!);
+
+                InvalidDataException exception = await Assert.ThrowsAsync<InvalidDataException>(
+                    () => signTool.SignAsync(new FileInfo(path), configuration, options));
+
+                Assert.Contains(entryName, exception.Message, StringComparison.Ordinal);
+            }
+
+            using (OpcPackage package = OpcPackage.Open(path))
+            {
+                Assert.Empty(package.GetSignatures());
             }
         }
 
@@ -272,6 +308,21 @@ namespace Sign.Core.Test
             {
                 yield return new object[] { 2048, HashAlgorithmName.SHA256, HashAlgorithmName.SHA256 };
             }
+        }
+
+        private string CreatePackageWithEntry(string entryName)
+        {
+            string path = Path.GetTempFileName();
+            _shadowFiles.Add(path);
+            File.Copy(SamplePackage, path, overwrite: true);
+
+            using (ZipArchive archive = ZipFile.Open(path, ZipArchiveMode.Update))
+            using (StreamWriter writer = new(archive.CreateEntry(entryName).Open()))
+            {
+                writer.Write("test");
+            }
+
+            return path;
         }
 
         private OpcPackage ShadowCopyPackage(string packagePath, out string path, OpcPackageFileMode mode = OpcPackageFileMode.Read)


### PR DESCRIPTION
Fixes #998.

Rejects raw `#` characters in OPC part names before signing instead of producing an invalid signature. The tests cover both root and nested entries and verify that no signature is left behind.

This follows the approach in #1042, which was closed before review.

`eng/common/Build.ps1 -restore -build -test -sign -pack -publish -ci` passes.
