### PR TITLE
Add safe ClickOnce publish-layout staging

### DIFF
--- a/src/Sign.Core/Resources.Designer.cs
+++ b/src/Sign.Core/Resources.Designer.cs
@@ -257,6 +257,51 @@ namespace Sign.Core {
                 return ResourceManager.GetString("ClickOnceSignatureProviderSigning", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to prepare file &apos;{0}&apos; for the signing operation..
+        /// </summary>
+        internal static string ClickOnceStagingCopyFailed {
+            get {
+                return ResourceManager.GetString("ClickOnceStagingCopyFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Source files &apos;{0}&apos; and &apos;{1}&apos; have conflicting target paths &apos;{2}&apos; and &apos;{3}&apos;..
+        /// </summary>
+        internal static string ClickOnceStagingDestinationCollision {
+            get {
+                return ResourceManager.GetString("ClickOnceStagingDestinationCollision", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to rename file &apos;{0}&apos; while updating manifest file information..
+        /// </summary>
+        internal static string ClickOnceStagingMappedSuffixFailed {
+            get {
+                return ResourceManager.GetString("ClickOnceStagingMappedSuffixFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Source file &apos;{0}&apos; is referenced with conflicting target paths &apos;{1}&apos; and &apos;{2}&apos;..
+        /// </summary>
+        internal static string ClickOnceStagingReferenceDestinationConflict {
+            get {
+                return ResourceManager.GetString("ClickOnceStagingReferenceDestinationConflict", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Manifest target path &apos;{0}&apos; for source file &apos;{1}&apos; is invalid or unsupported..
+        /// </summary>
+        internal static string ClickOnceStagingUnsafeTargetPath {
+            get {
+                return ResourceManager.GetString("ClickOnceStagingUnsafeTargetPath", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to {fileName} returned the error {error}.

--- a/src/Sign.Core/Resources.resx
+++ b/src/Sign.Core/Resources.resx
@@ -203,6 +203,26 @@
     <value>File '{0}' is not a deployment manifest.</value>
     <comment>{NumberedPlaceholder="{0}"} is a file path.</comment>
   </data>
+  <data name="ClickOnceStagingCopyFailed" xml:space="preserve">
+    <value>Failed to prepare file '{0}' for the signing operation.</value>
+    <comment>{NumberedPlaceholder="{0}"} is a source file path.</comment>
+  </data>
+  <data name="ClickOnceStagingDestinationCollision" xml:space="preserve">
+    <value>Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</value>
+    <comment>{NumberedPlaceholder="{0}"} and {NumberedPlaceholder="{1}"} are source file paths. {NumberedPlaceholder="{2}"} and {NumberedPlaceholder="{3}"} are manifest target paths.</comment>
+  </data>
+  <data name="ClickOnceStagingMappedSuffixFailed" xml:space="preserve">
+    <value>Failed to rename file '{0}' while updating manifest file information.</value>
+    <comment>{NumberedPlaceholder="{0}"} is a manifest target path.</comment>
+  </data>
+  <data name="ClickOnceStagingReferenceDestinationConflict" xml:space="preserve">
+    <value>Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</value>
+    <comment>{NumberedPlaceholder="{0}"} is a source file path. {NumberedPlaceholder="{1}"} and {NumberedPlaceholder="{2}"} are manifest target paths.</comment>
+  </data>
+  <data name="ClickOnceStagingUnsafeTargetPath" xml:space="preserve">
+    <value>Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</value>
+    <comment>{NumberedPlaceholder="{0}"} is a manifest target path. {NumberedPlaceholder="{1}"} is a source file path.</comment>
+  </data>
   <data name="CliStandardError" xml:space="preserve">
     <value>{fileName} returned the error {error}</value>
     <comment>{Placeholder="{fileName}"} is a file name, and {Placeholder="{error}"} is verbose output from a tool.</comment>

--- a/src/Sign.Core/Tools/ClickOnce/ClickOnceFileGraphStager.cs
+++ b/src/Sign.Core/Tools/ClickOnce/ClickOnceFileGraphStager.cs
@@ -1,0 +1,916 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System.Globalization;
+using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
+
+namespace Sign.Core
+{
+    internal sealed class ClickOnceFileGraphStager
+    {
+        private readonly IDirectoryService _directoryService;
+
+        internal ClickOnceFileGraphStager(IDirectoryService directoryService)
+        {
+            ArgumentNullException.ThrowIfNull(
+                directoryService,
+                nameof(directoryService));
+
+            _directoryService = directoryService;
+        }
+
+        internal ClickOnceStagingResult Stage(
+            ClickOnceFileGraph graph,
+            ClickOnceSigningMode mode)
+        {
+            ArgumentNullException.ThrowIfNull(graph, nameof(graph));
+
+            if (!Enum.IsDefined(mode))
+            {
+                throw new ArgumentOutOfRangeException(nameof(mode));
+            }
+
+            TemporaryDirectory temporaryDirectory = new(_directoryService);
+
+            try
+            {
+                IReadOnlyList<StagingCandidate> candidates =
+                    GetCandidates(graph, mode);
+                IReadOnlyList<StagingPlanEntry> plan = CreatePlan(
+                    graph,
+                    temporaryDirectory.Directory,
+                    candidates);
+
+                CopyFiles(graph, plan);
+
+                Dictionary<BaseReference, string?> originalResolvedPaths =
+                    BindManifestReferences(plan);
+                ClickOnceStagedFile[] files = plan
+                    .Select(
+                        entry => new ClickOnceStagedFile(
+                            entry.Candidate.GraphEntry,
+                            entry.Destination,
+                            entry.UpdateDestination,
+                            entry.Candidate.IsUpdateInputOnly))
+                    .ToArray();
+
+                return new ClickOnceStagingResult(
+                    graph,
+                    mode,
+                    temporaryDirectory,
+                    files,
+                    originalResolvedPaths);
+            }
+            catch
+            {
+                temporaryDirectory.Dispose();
+
+                throw;
+            }
+        }
+
+        private static IReadOnlyList<StagingCandidate> GetCandidates(
+            ClickOnceFileGraph graph,
+            ClickOnceSigningMode mode)
+        {
+            List<StagingCandidate> candidates = new();
+            bool isDeploymentInput = graph.DeploymentManifest is not null;
+
+            if (isDeploymentInput)
+            {
+                candidates.Add(
+                    new StagingCandidate(
+                        graph.DeploymentManifest!,
+                        isUpdateInputOnly: false));
+            }
+            else
+            {
+                candidates.Add(
+                    new StagingCandidate(
+                        graph.ApplicationManifest,
+                        isUpdateInputOnly: false));
+            }
+
+            if (mode == ClickOnceSigningMode.NoUpdate)
+            {
+                return candidates;
+            }
+
+            if (isDeploymentInput)
+            {
+                candidates.Add(
+                    new StagingCandidate(
+                        graph.ApplicationManifest,
+                        isUpdateInputOnly:
+                            mode ==
+                            ClickOnceSigningMode.NoSignDependencies));
+
+                if (mode == ClickOnceSigningMode.NoSignDependencies)
+                {
+                    return candidates;
+                }
+            }
+
+            bool dependenciesAreUpdateInputs =
+                mode == ClickOnceSigningMode.NoSignDependencies;
+
+            candidates.AddRange(
+                graph.Payloads.Select(
+                    entry => new StagingCandidate(
+                        entry,
+                        dependenciesAreUpdateInputs)));
+
+            if (mode == ClickOnceSigningMode.Default)
+            {
+                candidates.AddRange(
+                    graph.AdjacentExecutables.Select(
+                        entry => new StagingCandidate(
+                            entry,
+                            isUpdateInputOnly: false)));
+            }
+
+            return candidates;
+        }
+
+        private static IReadOnlyList<StagingPlanEntry> CreatePlan(
+            ClickOnceFileGraph graph,
+            DirectoryInfo stagingDirectory,
+            IReadOnlyList<StagingCandidate> candidates)
+        {
+            string rootPath = EnsureTrailingSeparator(
+                Path.GetFullPath(stagingDirectory.FullName));
+            DestinationAllocator allocator = new(graph, rootPath);
+            StagingCandidate? applicationManifestCandidate =
+                candidates.FirstOrDefault(
+                    candidate =>
+                        candidate.GraphEntry.Kind ==
+                        ClickOnceFileGraphEntryKind.ApplicationManifest);
+            List<StagingPlanEntry> plan = new(candidates.Count);
+            Dictionary<BaseReference, StagingPlanEntry>
+                referenceDestinations =
+                    new(ReferenceEqualityComparer.Instance);
+            string applicationDirectoryPath = rootPath;
+
+            for (int index = 0; index < candidates.Count; ++index)
+            {
+                StagingCandidate candidate = candidates[index];
+                StagingPlanEntry entry = allocator.Allocate(
+                    applicationDirectoryPath,
+                    candidate,
+                    index);
+                AddReferenceDestination(
+                    graph,
+                    referenceDestinations,
+                    entry);
+
+                plan.Add(entry);
+
+                if (ReferenceEquals(candidate, applicationManifestCandidate))
+                {
+                    applicationDirectoryPath =
+                        entry.Destination.Directory!.FullName;
+                }
+            }
+
+            ValidateDestinations(graph, plan);
+
+            return plan;
+        }
+
+        private static void ValidateDestinations(
+            ClickOnceFileGraph graph,
+            IReadOnlyList<StagingPlanEntry> plan)
+        {
+            List<DestinationUse> destinations = new(plan.Count * 2); // Stable and optional update paths.
+
+            foreach (StagingPlanEntry entry in plan)
+            {
+                destinations.Add(
+                    new DestinationUse(
+                        entry.Destination.FullName,
+                        entry,
+                        false));
+
+                if (entry.UpdateDestination is not null)
+                {
+                    destinations.Add(
+                        new DestinationUse(
+                            entry.UpdateDestination.FullName,
+                            entry,
+                            true));
+                }
+            }
+
+            destinations.Sort(DestinationUseComparer.Instance);
+
+            for (int index = 1; index < destinations.Count; ++index)
+            {
+                DestinationUse previous = destinations[index - 1];
+                DestinationUse current = destinations[index];
+
+                if (string.Equals(
+                    previous.Path,
+                    current.Path,
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!AreReusableDuplicates(previous, current))
+                    {
+                        throw CreateCollisionException(
+                            graph,
+                            previous.Entry,
+                            current.Entry);
+                    }
+                }
+                else if (IsFileDirectoryCollision(
+                    previous.Path,
+                    current.Path))
+                {
+                    throw CreateCollisionException(
+                        graph,
+                        previous.Entry,
+                        current.Entry);
+                }
+            }
+        }
+
+        private static bool AreReusableDuplicates(
+            DestinationUse left,
+            DestinationUse right)
+        {
+            return left.IsUpdateDestination == right.IsUpdateDestination &&
+                DestinationClaimComparer.Instance.Equals(
+                    left.Entry.Claim,
+                    right.Entry.Claim) &&
+                PathsEqual(
+                    left.Entry.Candidate.GraphEntry.Source.FullName,
+                    right.Entry.Candidate.GraphEntry.Source.FullName);
+        }
+
+        private static DestinationPaths? TryGetDirectDestinationPaths(
+            string rootPath,
+            string basePath,
+            ClickOnceFileGraphEntry entry)
+        {
+            if (entry.MappingAddedSuffix is string suffix)
+            {
+                string? stablePath = TryGetDirectDestinationPath(
+                    rootPath,
+                    basePath,
+                    entry.TargetPath + suffix);
+                string? updatePath = TryGetDirectDestinationPath(
+                    rootPath,
+                    basePath,
+                    entry.TargetPath);
+
+                return stablePath is null || updatePath is null
+                    ? null
+                    : new DestinationPaths(stablePath, updatePath);
+            }
+
+            string? destinationPath = TryGetDirectDestinationPath(
+                rootPath,
+                basePath,
+                entry.TargetPath);
+
+            return destinationPath is null
+                ? null
+                : new DestinationPaths(destinationPath, null);
+        }
+
+        private static string? TryGetDirectDestinationPath(
+            string rootPath,
+            string basePath,
+            string relativePath)
+        {
+            if (!IsSafeRelativePath(relativePath))
+            {
+                return null;
+            }
+
+            try
+            {
+                string destinationPath = Path.GetFullPath(
+                    Path.Combine(
+                        basePath,
+                        NormalizeSeparators(relativePath)));
+
+                return IsContained(rootPath, destinationPath)
+                    ? destinationPath
+                    : null;
+            }
+            catch (Exception exception) when (
+                exception is ArgumentException or
+                NotSupportedException or
+                PathTooLongException)
+            {
+                return null;
+            }
+        }
+
+        private static bool IsSafeRelativePath(string relativePath)
+        {
+            try
+            {
+                if (Path.IsPathRooted(relativePath) ||
+                    IsWindowsDriveQualified(relativePath) ||
+                    string.IsNullOrWhiteSpace(Path.GetFileName(relativePath)))
+                {
+                    return false;
+                }
+
+                string[] segments = relativePath.Split(
+                    new[]
+                    {
+                        Path.DirectorySeparatorChar,
+                        Path.AltDirectorySeparatorChar
+                    },
+                    StringSplitOptions.None);
+
+                if (segments.Any(
+                    segment =>
+                        segment.Length == 0 ||
+                        segment == "." ||
+                        segment == ".." ||
+                        segment.IndexOfAny(
+                            Path.GetInvalidFileNameChars()) >= 0 ||
+                        segment.EndsWith(' ') ||
+                        segment.EndsWith('.')))
+                {
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception exception) when (
+                exception is ArgumentException or
+                PathTooLongException)
+            {
+                return false;
+            }
+        }
+
+        private static void ValidateMappingSuffix(
+            ClickOnceFileGraph graph,
+            ClickOnceFileGraphEntry entry,
+            string suffix)
+        {
+            int separatorIndex = entry.TargetPath.LastIndexOfAny(
+                new[]
+                {
+                    Path.DirectorySeparatorChar,
+                    Path.AltDirectorySeparatorChar
+                });
+            string targetFileName = entry.TargetPath[(separatorIndex + 1)..];
+
+            if (string.IsNullOrEmpty(suffix) ||
+                entry.ManifestReference is null ||
+                suffix.IndexOfAny(
+                    new[]
+                    {
+                        Path.DirectorySeparatorChar,
+                        Path.AltDirectorySeparatorChar,
+                        ':'
+                    }) >= 0 ||
+                !entry.Source.Name.Equals(
+                    $"{targetFileName}{suffix}",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                throw CreateUnsafePathException(graph, entry);
+            }
+        }
+
+        private static void AddReferenceDestination(
+            ClickOnceFileGraph graph,
+            IDictionary<BaseReference, StagingPlanEntry> destinations,
+            StagingPlanEntry entry)
+        {
+            BaseReference? reference =
+                entry.Candidate.GraphEntry.ManifestReference;
+
+            if (reference is null)
+            {
+                return;
+            }
+
+            if (destinations.TryGetValue(
+                reference,
+                out StagingPlanEntry? existing))
+            {
+                if (!PathsEqual(
+                    existing.Destination.FullName,
+                    entry.Destination.FullName))
+                {
+                    throw CreateReferenceDestinationException(
+                        graph,
+                        existing,
+                        entry);
+                }
+
+                return;
+            }
+
+            destinations.Add(reference, entry);
+        }
+
+
+        private static void CopyFiles(
+            ClickOnceFileGraph graph,
+            IReadOnlyList<StagingPlanEntry> plan)
+        {
+            HashSet<string> copiedDestinations =
+                new(StringComparer.OrdinalIgnoreCase);
+            StagingPlanEntry? currentEntry = null;
+
+            try
+            {
+                foreach (StagingPlanEntry entry in plan)
+                {
+                    currentEntry = entry;
+
+                    if (!copiedDestinations.Add(entry.Destination.FullName))
+                    {
+                        continue;
+                    }
+
+                    entry.Destination.Directory!.Create();
+                    entry.Candidate.GraphEntry.Source.CopyTo(
+                        entry.Destination.FullName,
+                        overwrite: false);
+                }
+            }
+            catch (Exception exception) when (
+                exception is IOException or
+                UnauthorizedAccessException)
+            {
+                throw new ClickOnceFileGraphStagingException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.ClickOnceStagingCopyFailed,
+                        currentEntry?.Candidate.GraphEntry.Source.FullName
+                            ?? string.Empty),
+                    graph.Diagnostics,
+                    exception);
+            }
+        }
+
+        private static Dictionary<BaseReference, string?>
+            BindManifestReferences(IReadOnlyList<StagingPlanEntry> plan)
+        {
+            Dictionary<BaseReference, string?> originalResolvedPaths =
+                new(ReferenceEqualityComparer.Instance);
+
+            foreach (StagingPlanEntry entry in plan)
+            {
+                BaseReference? reference =
+                    entry.Candidate.GraphEntry.ManifestReference;
+
+                if (reference is null)
+                {
+                    continue;
+                }
+
+                originalResolvedPaths.TryAdd(
+                    reference,
+                    reference.ResolvedPath);
+                reference.ResolvedPath = entry.Destination.FullName;
+            }
+
+            return originalResolvedPaths;
+        }
+
+        private static ClickOnceFileGraphStagingException
+            CreateUnsafePathException(
+            ClickOnceFileGraph graph,
+            ClickOnceFileGraphEntry entry,
+            Exception? innerException = null)
+        {
+            return new ClickOnceFileGraphStagingException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resources.ClickOnceStagingUnsafeTargetPath,
+                    entry.TargetPath,
+                    entry.Source.FullName),
+                graph.Diagnostics,
+                innerException);
+        }
+
+        private static ClickOnceFileGraphStagingException
+            CreateCollisionException(
+            ClickOnceFileGraph graph,
+            StagingPlanEntry existing,
+            StagingPlanEntry entry)
+        {
+            return new ClickOnceFileGraphStagingException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resources.ClickOnceStagingDestinationCollision,
+                    existing.Candidate.GraphEntry.Source.FullName,
+                    entry.Candidate.GraphEntry.Source.FullName,
+                    existing.Candidate.GraphEntry.TargetPath,
+                    entry.Candidate.GraphEntry.TargetPath),
+                graph.Diagnostics);
+        }
+
+        private static ClickOnceFileGraphStagingException
+            CreateReferenceDestinationException(
+            ClickOnceFileGraph graph,
+            StagingPlanEntry existing,
+            StagingPlanEntry entry)
+        {
+            return new ClickOnceFileGraphStagingException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resources.ClickOnceStagingReferenceDestinationConflict,
+                    entry.Candidate.GraphEntry.Source.FullName,
+                    existing.Candidate.GraphEntry.TargetPath,
+                    entry.Candidate.GraphEntry.TargetPath),
+                graph.Diagnostics);
+        }
+
+        private static string EnsureTrailingSeparator(string path)
+        {
+            return Path.EndsInDirectorySeparator(path)
+                ? path
+                : $"{path}{Path.DirectorySeparatorChar}";
+        }
+
+        private static bool IsContained(string rootPath, string path)
+        {
+            return path.StartsWith(
+                rootPath,
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsFileDirectoryCollision(string left, string right)
+        {
+            return right.StartsWith(
+                    EnsureTrailingSeparator(left),
+                    StringComparison.OrdinalIgnoreCase) ||
+                left.StartsWith(
+                    EnsureTrailingSeparator(right),
+                    StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsWindowsDriveQualified(string path)
+        {
+            return path.Length >= 2 &&
+                path[1] == ':' &&
+                char.IsAsciiLetter(path[0]);
+        }
+
+        private static string NormalizeSeparators(string path)
+        {
+            return path.Replace(
+                Path.AltDirectorySeparatorChar,
+                Path.DirectorySeparatorChar);
+        }
+
+        private static bool PathsEqual(string left, string right)
+        {
+            return string.Equals(
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(left)),
+                Path.TrimEndingDirectorySeparator(Path.GetFullPath(right)),
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        private sealed class DestinationAllocator
+        {
+            private const string InternalDirectoryPrefix =
+                "__clickonce_internal_";
+            private const string RemappedFileName = "file";
+            private readonly ClickOnceFileGraph _graph;
+            private readonly string _rootPath;
+            private readonly Dictionary<DestinationClaim, StagingPlanEntry>
+                _claims = new(DestinationClaimComparer.Instance);
+
+            internal DestinationAllocator(
+                ClickOnceFileGraph graph,
+                string rootPath)
+            {
+                _graph = graph;
+                _rootPath = rootPath;
+            }
+
+            internal StagingPlanEntry Allocate(
+                string applicationDirectoryPath,
+                StagingCandidate candidate,
+                int candidateIndex)
+            {
+                ClickOnceFileGraphEntry graphEntry = candidate.GraphEntry;
+
+                if (graphEntry.MappingAddedSuffix is string suffix)
+                {
+                    ValidateMappingSuffix(_graph, graphEntry, suffix);
+                }
+
+                string basePath =
+                    graphEntry.Kind == ClickOnceFileGraphEntryKind.Payload
+                        ? applicationDirectoryPath
+                        : _rootPath;
+                DestinationClaim claim = new(
+                    basePath,
+                    NormalizeSeparators(graphEntry.TargetPath),
+                    graphEntry.MappingAddedSuffix ?? string.Empty);
+
+                if (_claims.TryGetValue(
+                    claim,
+                    out StagingPlanEntry? claimedEntry))
+                {
+                    if (!PathsEqual(
+                        claimedEntry.Candidate.GraphEntry.Source.FullName,
+                        graphEntry.Source.FullName))
+                    {
+                        throw CreateCollisionException(
+                            _graph,
+                            claimedEntry,
+                            new StagingPlanEntry(
+                                candidate,
+                                claimedEntry.Destination,
+                                claimedEntry.UpdateDestination,
+                                claimedEntry.IsRemapped,
+                                claim));
+                    }
+
+                    return new StagingPlanEntry(
+                        candidate,
+                        claimedEntry.Destination,
+                        claimedEntry.UpdateDestination,
+                        claimedEntry.IsRemapped,
+                        claim);
+                }
+
+                DestinationPaths? directPaths =
+                    TryGetDirectDestinationPaths(
+                        _rootPath,
+                        basePath,
+                        graphEntry);
+                StagingPlanEntry entry;
+
+                if (directPaths is not null &&
+                    !UsesReservedInternalNamespace(basePath, directPaths.Value))
+                {
+                    entry = CreateEntry(
+                        candidate,
+                        directPaths.Value,
+                        isRemapped: false,
+                        claim);
+                }
+                else
+                {
+                    entry = AllocateRemapped(
+                        candidate,
+                        candidateIndex,
+                        directPaths,
+                        claim);
+                }
+
+                _claims.Add(claim, entry);
+
+                return entry;
+            }
+
+            private StagingPlanEntry AllocateRemapped(
+                StagingCandidate candidate,
+                int candidateIndex,
+                DestinationPaths? directPaths,
+                DestinationClaim claim)
+            {
+                string? mappingAddedSuffix =
+                    candidate.GraphEntry.MappingAddedSuffix;
+                string directoryPath = Path.Combine(
+                    _rootPath,
+                    GetGeneratedNamespace(directPaths),
+                    $"{candidateIndex:x8}");
+                DestinationPaths paths = new(
+                    Path.Combine(
+                        directoryPath,
+                        $"{RemappedFileName}{mappingAddedSuffix}"),
+                    mappingAddedSuffix is not null
+                        ? Path.Combine(directoryPath, RemappedFileName)
+                        : null);
+
+                return CreateEntry(
+                    candidate,
+                    paths,
+                    isRemapped: true,
+                    claim);
+            }
+
+            private string GetGeneratedNamespace(
+                DestinationPaths? directPaths)
+            {
+                string first = $"{InternalDirectoryPrefix}generated0";
+                string second = $"{InternalDirectoryPrefix}generated1";
+
+                if (directPaths is null)
+                {
+                    return first;
+                }
+
+                HashSet<string> directFirstSegments = new(
+                    GetPaths(directPaths.Value).Select(
+                        path =>
+                        {
+                            string relativePath = Path.GetRelativePath(
+                                _rootPath,
+                                path);
+                            int separatorIndex = relativePath.IndexOf(
+                                Path.DirectorySeparatorChar);
+
+                            return separatorIndex < 0
+                                ? relativePath
+                                : relativePath[..separatorIndex];
+                        }),
+                    StringComparer.OrdinalIgnoreCase);
+
+                if (!directFirstSegments.Contains(first))
+                {
+                    return first;
+                }
+
+                return !directFirstSegments.Contains(second)
+                    ? second
+                    : $"{InternalDirectoryPrefix}generated2";
+            }
+
+            private bool UsesReservedInternalNamespace(
+                string basePath,
+                DestinationPaths paths)
+            {
+                if (!PathsEqual(_rootPath, basePath))
+                {
+                    return false;
+                }
+
+                return GetPaths(paths).Any(
+                    path =>
+                    {
+                        string relativePath = Path.GetRelativePath(
+                            _rootPath,
+                            path);
+                        int separatorIndex = relativePath.IndexOf(
+                            Path.DirectorySeparatorChar);
+                        string firstSegment = separatorIndex < 0
+                            ? relativePath
+                            : relativePath[..separatorIndex];
+
+                        return firstSegment.StartsWith(
+                            InternalDirectoryPrefix,
+                            StringComparison.OrdinalIgnoreCase);
+                    });
+            }
+
+            private static string[] GetPaths(DestinationPaths paths)
+            {
+                return paths.UpdatePath is null
+                    ? new[] { paths.StablePath }
+                    : new[] { paths.StablePath, paths.UpdatePath };
+            }
+
+            private static StagingPlanEntry CreateEntry(
+                StagingCandidate candidate,
+                DestinationPaths paths,
+                bool isRemapped,
+                DestinationClaim claim)
+            {
+                return new StagingPlanEntry(
+                    candidate,
+                    new FileInfo(paths.StablePath),
+                    paths.UpdatePath is null
+                        ? null
+                        : new FileInfo(paths.UpdatePath),
+                    isRemapped,
+                    claim);
+            }
+        }
+
+        private sealed class DestinationUseComparer :
+            IComparer<DestinationUse>
+        {
+            internal static readonly DestinationUseComparer Instance = new();
+
+            public int Compare(DestinationUse left, DestinationUse right)
+            {
+                ReadOnlySpan<char> leftPath = left.Path;
+                ReadOnlySpan<char> rightPath = right.Path;
+
+                while (true)
+                {
+                    int leftSeparator = leftPath.IndexOf(
+                        Path.DirectorySeparatorChar);
+                    int rightSeparator = rightPath.IndexOf(
+                        Path.DirectorySeparatorChar);
+                    ReadOnlySpan<char> leftSegment = leftSeparator < 0
+                        ? leftPath
+                        : leftPath[..leftSeparator];
+                    ReadOnlySpan<char> rightSegment = rightSeparator < 0
+                        ? rightPath
+                        : rightPath[..rightSeparator];
+                    int comparison = leftSegment.CompareTo(
+                        rightSegment,
+                        StringComparison.OrdinalIgnoreCase);
+
+                    if (comparison != 0)
+                    {
+                        return comparison;
+                    }
+
+                    if (leftSeparator < 0 || rightSeparator < 0)
+                    {
+                        return leftSeparator.CompareTo(rightSeparator);
+                    }
+
+                    leftPath = leftPath[(leftSeparator + 1)..];
+                    rightPath = rightPath[(rightSeparator + 1)..];
+                }
+            }
+        }
+
+        private sealed class DestinationClaimComparer :
+            IEqualityComparer<DestinationClaim>
+        {
+            internal static readonly DestinationClaimComparer Instance = new();
+
+            public bool Equals(
+                DestinationClaim left,
+                DestinationClaim right)
+            {
+                return string.Equals(
+                        left.BasePath,
+                        right.BasePath,
+                        StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(
+                        left.TargetPath,
+                        right.TargetPath,
+                        StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(
+                        left.MappingAddedSuffix,
+                        right.MappingAddedSuffix,
+                        StringComparison.OrdinalIgnoreCase);
+            }
+
+            public int GetHashCode(DestinationClaim value)
+            {
+                return HashCode.Combine(
+                    StringComparer.OrdinalIgnoreCase.GetHashCode(
+                        value.BasePath),
+                    StringComparer.OrdinalIgnoreCase.GetHashCode(
+                        value.TargetPath),
+                    StringComparer.OrdinalIgnoreCase.GetHashCode(
+                        value.MappingAddedSuffix));
+            }
+        }
+
+        private sealed class StagingCandidate
+        {
+            internal StagingCandidate(
+                ClickOnceFileGraphEntry graphEntry,
+                bool isUpdateInputOnly)
+            {
+                GraphEntry = graphEntry;
+                IsUpdateInputOnly = isUpdateInputOnly;
+            }
+
+            internal ClickOnceFileGraphEntry GraphEntry { get; }
+            internal bool IsUpdateInputOnly { get; }
+        }
+
+        private sealed class StagingPlanEntry
+        {
+            internal StagingPlanEntry(
+                StagingCandidate candidate,
+                FileInfo destination,
+                FileInfo? updateDestination,
+                bool isRemapped,
+                DestinationClaim claim)
+            {
+                Candidate = candidate;
+                Destination = destination;
+                UpdateDestination = updateDestination;
+                IsRemapped = isRemapped;
+                Claim = claim;
+            }
+
+            internal StagingCandidate Candidate { get; }
+            internal FileInfo Destination { get; }
+            internal FileInfo? UpdateDestination { get; }
+            internal bool IsRemapped { get; }
+            internal DestinationClaim Claim { get; }
+        }
+
+        private readonly record struct DestinationUse(
+            string Path,
+            StagingPlanEntry Entry,
+            bool IsUpdateDestination);
+
+        private readonly record struct DestinationPaths(
+            string StablePath,
+            string? UpdatePath);
+
+        private readonly record struct DestinationClaim(
+            string BasePath,
+            string TargetPath,
+            string MappingAddedSuffix);
+    }
+}

--- a/src/Sign.Core/Tools/ClickOnce/ClickOnceFileGraphStagingException.cs
+++ b/src/Sign.Core/Tools/ClickOnce/ClickOnceFileGraphStagingException.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.Core
+{
+    internal sealed class ClickOnceFileGraphStagingException : Exception
+    {
+        internal ClickOnceFileGraphStagingException(
+            string message,
+            IEnumerable<ClickOnceManifestDiagnostic> diagnostics,
+            Exception? innerException = null)
+            : base(message, innerException)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(message, nameof(message));
+            ArgumentNullException.ThrowIfNull(diagnostics, nameof(diagnostics));
+
+            Diagnostics = diagnostics.ToArray();
+        }
+
+        internal IReadOnlyList<ClickOnceManifestDiagnostic> Diagnostics { get; }
+    }
+}

--- a/src/Sign.Core/Tools/ClickOnce/ClickOnceSigningMode.cs
+++ b/src/Sign.Core/Tools/ClickOnce/ClickOnceSigningMode.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+namespace Sign.Core
+{
+    internal enum ClickOnceSigningMode
+    {
+        Default,
+        NoSignDependencies,
+        NoUpdate
+    }
+}

--- a/src/Sign.Core/Tools/ClickOnce/ClickOnceStagedFile.cs
+++ b/src/Sign.Core/Tools/ClickOnce/ClickOnceStagedFile.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
+
+namespace Sign.Core
+{
+    internal sealed class ClickOnceStagedFile
+    {
+        internal ClickOnceStagedFile(
+            ClickOnceFileGraphEntry graphEntry,
+            FileInfo file,
+            FileInfo? manifestUpdateFile,
+            bool isUpdateInputOnly)
+        {
+            ArgumentNullException.ThrowIfNull(graphEntry, nameof(graphEntry));
+            ArgumentNullException.ThrowIfNull(file, nameof(file));
+
+            GraphEntry = graphEntry;
+            File = file;
+            ManifestUpdateFile = manifestUpdateFile;
+            IsUpdateInputOnly = isUpdateInputOnly;
+        }
+
+        internal ClickOnceFileGraphEntry GraphEntry { get; }
+        internal FileInfo Source => GraphEntry.Source;
+        internal FileInfo File { get; }
+        internal FileInfo? ManifestUpdateFile { get; }
+        internal string TargetPath => GraphEntry.TargetPath;
+        internal ClickOnceFileGraphEntryKind Kind => GraphEntry.Kind;
+        internal BaseReference? ManifestReference =>
+            GraphEntry.ManifestReference;
+        internal bool IsUpdateInputOnly { get; }
+    }
+}

--- a/src/Sign.Core/Tools/ClickOnce/ClickOnceStagingResult.cs
+++ b/src/Sign.Core/Tools/ClickOnce/ClickOnceStagingResult.cs
@@ -1,0 +1,330 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System.Globalization;
+using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
+
+namespace Sign.Core
+{
+    internal sealed class ClickOnceStagingResult : IDisposable
+    {
+        private readonly ClickOnceFileGraph _graph;
+        private readonly
+            IReadOnlyDictionary<BaseReference, string?> _originalResolvedPaths;
+        private readonly IReadOnlyList<MappedFile> _mappedFiles;
+        private readonly TemporaryDirectory _temporaryDirectory;
+        private bool _disposed;
+        private bool _manifestUpdateActive;
+
+        internal ClickOnceStagingResult(
+            ClickOnceFileGraph graph,
+            ClickOnceSigningMode mode,
+            TemporaryDirectory temporaryDirectory,
+            IEnumerable<ClickOnceStagedFile> files,
+            IReadOnlyDictionary<BaseReference, string?>
+                originalResolvedPaths)
+        {
+            ArgumentNullException.ThrowIfNull(graph, nameof(graph));
+            ArgumentNullException.ThrowIfNull(
+                temporaryDirectory,
+                nameof(temporaryDirectory));
+            ArgumentNullException.ThrowIfNull(files, nameof(files));
+            ArgumentNullException.ThrowIfNull(
+                originalResolvedPaths,
+                nameof(originalResolvedPaths));
+
+            ClickOnceStagedFile[] stagedFiles = files.ToArray();
+
+            _graph = graph;
+            _temporaryDirectory = temporaryDirectory;
+            _originalResolvedPaths = originalResolvedPaths;
+            _mappedFiles = stagedFiles
+                .Where(file => file.ManifestUpdateFile is not null)
+                .GroupBy(
+                    file => new MappedFilePath(
+                        file.File.FullName,
+                        file.ManifestUpdateFile!.FullName),
+                    MappedFilePathComparer.Instance)
+                .Select(group => new MappedFile(group))
+                .ToArray();
+
+            Mode = mode;
+            Files = stagedFiles;
+        }
+
+        internal ClickOnceSigningMode Mode { get; }
+        internal DirectoryInfo Directory => _temporaryDirectory.Directory;
+        internal IReadOnlyList<ClickOnceStagedFile> Files { get; }
+        internal IReadOnlyList<ClickOnceManifestDiagnostic> Diagnostics =>
+            _graph.Diagnostics;
+
+        internal IDisposable BeginManifestUpdate()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            if (_manifestUpdateActive)
+            {
+                throw new InvalidOperationException();
+            }
+
+            List<MappedFile> movedFiles = new(_mappedFiles.Count);
+            MappedFile? currentFile = null;
+
+            try
+            {
+                foreach (MappedFile mappedFile in _mappedFiles)
+                {
+                    currentFile = mappedFile;
+                    File.Move(
+                        mappedFile.StagedFile.File.FullName,
+                        mappedFile.UpdateFile.FullName);
+                    mappedFile.IsAtUpdatePath = true;
+                    mappedFile.SetResolvedPath(mappedFile.UpdateFile.FullName);
+                    movedFiles.Add(mappedFile);
+                }
+            }
+            catch (Exception exception) when (
+                exception is IOException or
+                UnauthorizedAccessException)
+            {
+                IReadOnlyList<Exception> rollbackExceptions =
+                    RestoreMappedFiles(movedFiles);
+                _manifestUpdateActive =
+                    _mappedFiles.Any(file => file.IsAtUpdatePath);
+                Exception innerException = rollbackExceptions.Count == 0
+                    ? exception
+                    : new AggregateException(
+                        new[] { exception }.Concat(rollbackExceptions));
+
+                throw CreateMappedSuffixException(
+                    currentFile!,
+                    innerException);
+            }
+
+            _manifestUpdateActive = true;
+
+            return new ManifestUpdateScope(owner: this);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            Exception? restoreException = null;
+
+            if (_manifestUpdateActive)
+            {
+                try
+                {
+                    EndManifestUpdate();
+                }
+                catch (Exception exception)
+                {
+                    restoreException = exception;
+                }
+            }
+
+            foreach (
+                KeyValuePair<BaseReference, string?> pair
+                in _originalResolvedPaths)
+            {
+                pair.Key.ResolvedPath = pair.Value;
+            }
+
+            _temporaryDirectory.Dispose();
+            _disposed = true;
+
+            if (restoreException is not null)
+            {
+                throw restoreException;
+            }
+        }
+
+        private void EndManifestUpdate()
+        {
+            if (_disposed || !_manifestUpdateActive)
+            {
+                return;
+            }
+
+            List<ClickOnceFileGraphStagingException> exceptions = new();
+
+            foreach (MappedFile mappedFile in _mappedFiles.Reverse())
+            {
+                if (!mappedFile.IsAtUpdatePath)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    File.Move(
+                        mappedFile.UpdateFile.FullName,
+                        mappedFile.StagedFile.File.FullName);
+                    mappedFile.IsAtUpdatePath = false;
+                    mappedFile.SetResolvedPath(
+                        mappedFile.StagedFile.File.FullName);
+                }
+                catch (Exception exception) when (
+                    exception is IOException or
+                    UnauthorizedAccessException)
+                {
+                    exceptions.Add(
+                        CreateMappedSuffixException(
+                            mappedFile,
+                            exception));
+                }
+            }
+
+            _manifestUpdateActive =
+                _mappedFiles.Any(file => file.IsAtUpdatePath);
+            ThrowRestoreFailures(exceptions);
+        }
+
+        private IReadOnlyList<Exception> RestoreMappedFiles(
+            IEnumerable<MappedFile> movedFiles)
+        {
+            List<Exception> exceptions = new();
+
+            foreach (MappedFile mappedFile in movedFiles.Reverse())
+            {
+                try
+                {
+                    File.Move(
+                        mappedFile.UpdateFile.FullName,
+                        mappedFile.StagedFile.File.FullName);
+                    mappedFile.IsAtUpdatePath = false;
+                    mappedFile.SetResolvedPath(
+                        mappedFile.StagedFile.File.FullName);
+                }
+                catch (Exception exception) when (
+                    exception is IOException or
+                    UnauthorizedAccessException)
+                {
+                    exceptions.Add(
+                        CreateMappedSuffixException(
+                            mappedFile,
+                            exception));
+                }
+            }
+
+            return exceptions;
+        }
+
+        private void ThrowRestoreFailures(
+            IReadOnlyList<ClickOnceFileGraphStagingException> exceptions)
+        {
+            if (exceptions.Count == 0)
+            {
+                return;
+            }
+
+            if (exceptions.Count == 1)
+            {
+                throw exceptions[0];
+            }
+
+            ClickOnceFileGraphStagingException first = exceptions[0];
+
+            throw new ClickOnceFileGraphStagingException(
+                first.Message,
+                Diagnostics,
+                new AggregateException(exceptions));
+        }
+
+        private ClickOnceFileGraphStagingException CreateMappedSuffixException(
+            MappedFile mappedFile,
+            Exception innerException)
+        {
+            return new ClickOnceFileGraphStagingException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    Resources.ClickOnceStagingMappedSuffixFailed,
+                    mappedFile.StagedFile.GraphEntry.TargetPath),
+                Diagnostics,
+                innerException);
+        }
+
+        private sealed class ManifestUpdateScope : IDisposable
+        {
+            private ClickOnceStagingResult? _owner;
+
+            internal ManifestUpdateScope(ClickOnceStagingResult owner)
+            {
+                _owner = owner;
+            }
+
+            public void Dispose()
+            {
+                ClickOnceStagingResult? owner =
+                    Interlocked.Exchange(ref _owner, value: null);
+
+                owner?.EndManifestUpdate();
+            }
+        }
+
+        private sealed class MappedFile
+        {
+            private readonly IReadOnlyList<BaseReference> _manifestReferences;
+
+            internal MappedFile(IEnumerable<ClickOnceStagedFile> stagedFiles)
+            {
+                ClickOnceStagedFile[] files = stagedFiles.ToArray();
+
+                StagedFile = files[0];
+                UpdateFile = StagedFile.ManifestUpdateFile!;
+                _manifestReferences = files
+                    .Select(file => file.ManifestReference!)
+                    .Distinct<BaseReference>(ReferenceEqualityComparer.Instance)
+                    .ToArray();
+            }
+
+            internal ClickOnceStagedFile StagedFile { get; }
+            internal FileInfo UpdateFile { get; }
+            internal bool IsAtUpdatePath { get; set; }
+
+            internal void SetResolvedPath(string path)
+            {
+                foreach (BaseReference reference in _manifestReferences)
+                {
+                    reference.ResolvedPath = path;
+                }
+            }
+        }
+
+        private sealed class MappedFilePathComparer :
+            IEqualityComparer<MappedFilePath>
+        {
+            internal static readonly MappedFilePathComparer Instance = new();
+
+            public bool Equals(MappedFilePath left, MappedFilePath right)
+            {
+                return string.Equals(
+                        left.StablePath,
+                        right.StablePath,
+                        StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(
+                        left.UpdatePath,
+                        right.UpdatePath,
+                        StringComparison.OrdinalIgnoreCase);
+            }
+
+            public int GetHashCode(MappedFilePath value)
+            {
+                return HashCode.Combine(
+                    StringComparer.OrdinalIgnoreCase.GetHashCode(
+                        value.StablePath),
+                    StringComparer.OrdinalIgnoreCase.GetHashCode(
+                        value.UpdatePath));
+            }
+        }
+
+        private readonly record struct MappedFilePath(
+            string StablePath,
+            string UpdatePath);
+    }
+}

--- a/src/Sign.Core/xlf/Resources.cs.xlf
+++ b/src/Sign.Core/xlf/Resources.cs.xlf
@@ -122,6 +122,31 @@
         <target state="translated">Podepisování úlohy Mage pomocí {count} souborů.</target>
         <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
+      <trans-unit id="ClickOnceStagingCopyFailed">
+        <source>Failed to prepare file '{0}' for the signing operation.</source>
+        <target state="new">Failed to prepare file '{0}' for the signing operation.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingDestinationCollision">
+        <source>Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</source>
+        <target state="new">Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</target>
+        <note>{NumberedPlaceholder="{0}"} and {NumberedPlaceholder="{1}"} are source file paths. {NumberedPlaceholder="{2}"} and {NumberedPlaceholder="{3}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingMappedSuffixFailed">
+        <source>Failed to rename file '{0}' while updating manifest file information.</source>
+        <target state="new">Failed to rename file '{0}' while updating manifest file information.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingReferenceDestinationConflict">
+        <source>Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</source>
+        <target state="new">Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path. {NumberedPlaceholder="{1}"} and {NumberedPlaceholder="{2}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingUnsafeTargetPath">
+        <source>Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</source>
+        <target state="new">Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path. {NumberedPlaceholder="{1}"} is a source file path.</note>
+      </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
         <target state="translated">Vytváří se adresář {path}.</target>

--- a/src/Sign.Core/xlf/Resources.de.xlf
+++ b/src/Sign.Core/xlf/Resources.de.xlf
@@ -122,6 +122,31 @@
         <target state="translated">Der Mage-Auftrag wird mit {count} Dateien signiert.</target>
         <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
+      <trans-unit id="ClickOnceStagingCopyFailed">
+        <source>Failed to prepare file '{0}' for the signing operation.</source>
+        <target state="new">Failed to prepare file '{0}' for the signing operation.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingDestinationCollision">
+        <source>Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</source>
+        <target state="new">Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</target>
+        <note>{NumberedPlaceholder="{0}"} and {NumberedPlaceholder="{1}"} are source file paths. {NumberedPlaceholder="{2}"} and {NumberedPlaceholder="{3}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingMappedSuffixFailed">
+        <source>Failed to rename file '{0}' while updating manifest file information.</source>
+        <target state="new">Failed to rename file '{0}' while updating manifest file information.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingReferenceDestinationConflict">
+        <source>Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</source>
+        <target state="new">Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path. {NumberedPlaceholder="{1}"} and {NumberedPlaceholder="{2}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingUnsafeTargetPath">
+        <source>Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</source>
+        <target state="new">Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path. {NumberedPlaceholder="{1}"} is a source file path.</note>
+      </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
         <target state="translated">Das Verzeichnis {path} wird erstellt.</target>

--- a/src/Sign.Core/xlf/Resources.es.xlf
+++ b/src/Sign.Core/xlf/Resources.es.xlf
@@ -122,6 +122,31 @@
         <target state="translated">Firmando el trabajo de Mage con {count} archivos.</target>
         <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
+      <trans-unit id="ClickOnceStagingCopyFailed">
+        <source>Failed to prepare file '{0}' for the signing operation.</source>
+        <target state="new">Failed to prepare file '{0}' for the signing operation.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingDestinationCollision">
+        <source>Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</source>
+        <target state="new">Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</target>
+        <note>{NumberedPlaceholder="{0}"} and {NumberedPlaceholder="{1}"} are source file paths. {NumberedPlaceholder="{2}"} and {NumberedPlaceholder="{3}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingMappedSuffixFailed">
+        <source>Failed to rename file '{0}' while updating manifest file information.</source>
+        <target state="new">Failed to rename file '{0}' while updating manifest file information.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingReferenceDestinationConflict">
+        <source>Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</source>
+        <target state="new">Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path. {NumberedPlaceholder="{1}"} and {NumberedPlaceholder="{2}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingUnsafeTargetPath">
+        <source>Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</source>
+        <target state="new">Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path. {NumberedPlaceholder="{1}"} is a source file path.</note>
+      </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
         <target state="translated">Creando directorio {path}.</target>

--- a/src/Sign.Core/xlf/Resources.fr.xlf
+++ b/src/Sign.Core/xlf/Resources.fr.xlf
@@ -122,6 +122,31 @@
         <target state="translated">Signature du travail Mage avec {count} fichiers.</target>
         <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
+      <trans-unit id="ClickOnceStagingCopyFailed">
+        <source>Failed to prepare file '{0}' for the signing operation.</source>
+        <target state="new">Failed to prepare file '{0}' for the signing operation.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingDestinationCollision">
+        <source>Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</source>
+        <target state="new">Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</target>
+        <note>{NumberedPlaceholder="{0}"} and {NumberedPlaceholder="{1}"} are source file paths. {NumberedPlaceholder="{2}"} and {NumberedPlaceholder="{3}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingMappedSuffixFailed">
+        <source>Failed to rename file '{0}' while updating manifest file information.</source>
+        <target state="new">Failed to rename file '{0}' while updating manifest file information.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingReferenceDestinationConflict">
+        <source>Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</source>
+        <target state="new">Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path. {NumberedPlaceholder="{1}"} and {NumberedPlaceholder="{2}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingUnsafeTargetPath">
+        <source>Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</source>
+        <target state="new">Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path. {NumberedPlaceholder="{1}"} is a source file path.</note>
+      </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
         <target state="translated">Création du répertoire {path}.</target>

--- a/src/Sign.Core/xlf/Resources.it.xlf
+++ b/src/Sign.Core/xlf/Resources.it.xlf
@@ -122,6 +122,31 @@
         <target state="translated">Firma del processo Mage con {count} file.</target>
         <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
+      <trans-unit id="ClickOnceStagingCopyFailed">
+        <source>Failed to prepare file '{0}' for the signing operation.</source>
+        <target state="new">Failed to prepare file '{0}' for the signing operation.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingDestinationCollision">
+        <source>Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</source>
+        <target state="new">Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</target>
+        <note>{NumberedPlaceholder="{0}"} and {NumberedPlaceholder="{1}"} are source file paths. {NumberedPlaceholder="{2}"} and {NumberedPlaceholder="{3}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingMappedSuffixFailed">
+        <source>Failed to rename file '{0}' while updating manifest file information.</source>
+        <target state="new">Failed to rename file '{0}' while updating manifest file information.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingReferenceDestinationConflict">
+        <source>Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</source>
+        <target state="new">Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path. {NumberedPlaceholder="{1}"} and {NumberedPlaceholder="{2}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingUnsafeTargetPath">
+        <source>Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</source>
+        <target state="new">Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path. {NumberedPlaceholder="{1}"} is a source file path.</note>
+      </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
         <target state="translated">Creazione della directory {path}.</target>

--- a/src/Sign.Core/xlf/Resources.ja.xlf
+++ b/src/Sign.Core/xlf/Resources.ja.xlf
@@ -122,6 +122,31 @@
         <target state="translated">{count} 個のファイルを使用して Mage ジョブに署名しています。</target>
         <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
+      <trans-unit id="ClickOnceStagingCopyFailed">
+        <source>Failed to prepare file '{0}' for the signing operation.</source>
+        <target state="new">Failed to prepare file '{0}' for the signing operation.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingDestinationCollision">
+        <source>Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</source>
+        <target state="new">Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</target>
+        <note>{NumberedPlaceholder="{0}"} and {NumberedPlaceholder="{1}"} are source file paths. {NumberedPlaceholder="{2}"} and {NumberedPlaceholder="{3}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingMappedSuffixFailed">
+        <source>Failed to rename file '{0}' while updating manifest file information.</source>
+        <target state="new">Failed to rename file '{0}' while updating manifest file information.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingReferenceDestinationConflict">
+        <source>Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</source>
+        <target state="new">Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path. {NumberedPlaceholder="{1}"} and {NumberedPlaceholder="{2}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingUnsafeTargetPath">
+        <source>Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</source>
+        <target state="new">Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path. {NumberedPlaceholder="{1}"} is a source file path.</note>
+      </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
         <target state="translated">ディレクトリ {path} を作成しています。</target>

--- a/src/Sign.Core/xlf/Resources.ko.xlf
+++ b/src/Sign.Core/xlf/Resources.ko.xlf
@@ -122,6 +122,31 @@
         <target state="translated">{count} 파일로 Mage 작업에 서명하는 중입니다.</target>
         <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
+      <trans-unit id="ClickOnceStagingCopyFailed">
+        <source>Failed to prepare file '{0}' for the signing operation.</source>
+        <target state="new">Failed to prepare file '{0}' for the signing operation.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingDestinationCollision">
+        <source>Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</source>
+        <target state="new">Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</target>
+        <note>{NumberedPlaceholder="{0}"} and {NumberedPlaceholder="{1}"} are source file paths. {NumberedPlaceholder="{2}"} and {NumberedPlaceholder="{3}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingMappedSuffixFailed">
+        <source>Failed to rename file '{0}' while updating manifest file information.</source>
+        <target state="new">Failed to rename file '{0}' while updating manifest file information.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingReferenceDestinationConflict">
+        <source>Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</source>
+        <target state="new">Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path. {NumberedPlaceholder="{1}"} and {NumberedPlaceholder="{2}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingUnsafeTargetPath">
+        <source>Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</source>
+        <target state="new">Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path. {NumberedPlaceholder="{1}"} is a source file path.</note>
+      </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
         <target state="translated">디렉터리 {path}을(를) 생성하는 중입니다.</target>

--- a/src/Sign.Core/xlf/Resources.pl.xlf
+++ b/src/Sign.Core/xlf/Resources.pl.xlf
@@ -122,6 +122,31 @@
         <target state="translated">Podpisywanie zadania Mage przy użyciu {count} plików.</target>
         <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
+      <trans-unit id="ClickOnceStagingCopyFailed">
+        <source>Failed to prepare file '{0}' for the signing operation.</source>
+        <target state="new">Failed to prepare file '{0}' for the signing operation.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingDestinationCollision">
+        <source>Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</source>
+        <target state="new">Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</target>
+        <note>{NumberedPlaceholder="{0}"} and {NumberedPlaceholder="{1}"} are source file paths. {NumberedPlaceholder="{2}"} and {NumberedPlaceholder="{3}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingMappedSuffixFailed">
+        <source>Failed to rename file '{0}' while updating manifest file information.</source>
+        <target state="new">Failed to rename file '{0}' while updating manifest file information.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingReferenceDestinationConflict">
+        <source>Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</source>
+        <target state="new">Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path. {NumberedPlaceholder="{1}"} and {NumberedPlaceholder="{2}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingUnsafeTargetPath">
+        <source>Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</source>
+        <target state="new">Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path. {NumberedPlaceholder="{1}"} is a source file path.</note>
+      </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
         <target state="translated">Tworzenie ścieżki {path} katalogu.</target>

--- a/src/Sign.Core/xlf/Resources.pt-BR.xlf
+++ b/src/Sign.Core/xlf/Resources.pt-BR.xlf
@@ -122,6 +122,31 @@
         <target state="translated">Autenticando o trabalho Mage com {count} arquivos.</target>
         <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
+      <trans-unit id="ClickOnceStagingCopyFailed">
+        <source>Failed to prepare file '{0}' for the signing operation.</source>
+        <target state="new">Failed to prepare file '{0}' for the signing operation.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingDestinationCollision">
+        <source>Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</source>
+        <target state="new">Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</target>
+        <note>{NumberedPlaceholder="{0}"} and {NumberedPlaceholder="{1}"} are source file paths. {NumberedPlaceholder="{2}"} and {NumberedPlaceholder="{3}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingMappedSuffixFailed">
+        <source>Failed to rename file '{0}' while updating manifest file information.</source>
+        <target state="new">Failed to rename file '{0}' while updating manifest file information.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingReferenceDestinationConflict">
+        <source>Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</source>
+        <target state="new">Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path. {NumberedPlaceholder="{1}"} and {NumberedPlaceholder="{2}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingUnsafeTargetPath">
+        <source>Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</source>
+        <target state="new">Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path. {NumberedPlaceholder="{1}"} is a source file path.</note>
+      </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
         <target state="translated">Criando o diretório {path}.</target>

--- a/src/Sign.Core/xlf/Resources.ru.xlf
+++ b/src/Sign.Core/xlf/Resources.ru.xlf
@@ -122,6 +122,31 @@
         <target state="translated">Подписывание задания Mage с несколькими файлами ({count}).</target>
         <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
+      <trans-unit id="ClickOnceStagingCopyFailed">
+        <source>Failed to prepare file '{0}' for the signing operation.</source>
+        <target state="new">Failed to prepare file '{0}' for the signing operation.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingDestinationCollision">
+        <source>Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</source>
+        <target state="new">Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</target>
+        <note>{NumberedPlaceholder="{0}"} and {NumberedPlaceholder="{1}"} are source file paths. {NumberedPlaceholder="{2}"} and {NumberedPlaceholder="{3}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingMappedSuffixFailed">
+        <source>Failed to rename file '{0}' while updating manifest file information.</source>
+        <target state="new">Failed to rename file '{0}' while updating manifest file information.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingReferenceDestinationConflict">
+        <source>Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</source>
+        <target state="new">Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path. {NumberedPlaceholder="{1}"} and {NumberedPlaceholder="{2}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingUnsafeTargetPath">
+        <source>Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</source>
+        <target state="new">Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path. {NumberedPlaceholder="{1}"} is a source file path.</note>
+      </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
         <target state="translated">Идет создание каталога {path}.</target>

--- a/src/Sign.Core/xlf/Resources.tr.xlf
+++ b/src/Sign.Core/xlf/Resources.tr.xlf
@@ -122,6 +122,31 @@
         <target state="translated">Mage işi {count} dosya ile imzalanıyor.</target>
         <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
+      <trans-unit id="ClickOnceStagingCopyFailed">
+        <source>Failed to prepare file '{0}' for the signing operation.</source>
+        <target state="new">Failed to prepare file '{0}' for the signing operation.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingDestinationCollision">
+        <source>Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</source>
+        <target state="new">Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</target>
+        <note>{NumberedPlaceholder="{0}"} and {NumberedPlaceholder="{1}"} are source file paths. {NumberedPlaceholder="{2}"} and {NumberedPlaceholder="{3}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingMappedSuffixFailed">
+        <source>Failed to rename file '{0}' while updating manifest file information.</source>
+        <target state="new">Failed to rename file '{0}' while updating manifest file information.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingReferenceDestinationConflict">
+        <source>Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</source>
+        <target state="new">Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path. {NumberedPlaceholder="{1}"} and {NumberedPlaceholder="{2}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingUnsafeTargetPath">
+        <source>Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</source>
+        <target state="new">Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path. {NumberedPlaceholder="{1}"} is a source file path.</note>
+      </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
         <target state="translated">{path} dizini oluşturuluyor.</target>

--- a/src/Sign.Core/xlf/Resources.zh-Hans.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hans.xlf
@@ -122,6 +122,31 @@
         <target state="translated">正在对包含 {count} 个文件的 Mage 作业进行签名。</target>
         <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
+      <trans-unit id="ClickOnceStagingCopyFailed">
+        <source>Failed to prepare file '{0}' for the signing operation.</source>
+        <target state="new">Failed to prepare file '{0}' for the signing operation.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingDestinationCollision">
+        <source>Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</source>
+        <target state="new">Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</target>
+        <note>{NumberedPlaceholder="{0}"} and {NumberedPlaceholder="{1}"} are source file paths. {NumberedPlaceholder="{2}"} and {NumberedPlaceholder="{3}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingMappedSuffixFailed">
+        <source>Failed to rename file '{0}' while updating manifest file information.</source>
+        <target state="new">Failed to rename file '{0}' while updating manifest file information.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingReferenceDestinationConflict">
+        <source>Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</source>
+        <target state="new">Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path. {NumberedPlaceholder="{1}"} and {NumberedPlaceholder="{2}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingUnsafeTargetPath">
+        <source>Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</source>
+        <target state="new">Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path. {NumberedPlaceholder="{1}"} is a source file path.</note>
+      </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
         <target state="translated">正在创建目录 {path}。</target>

--- a/src/Sign.Core/xlf/Resources.zh-Hant.xlf
+++ b/src/Sign.Core/xlf/Resources.zh-Hant.xlf
@@ -122,6 +122,31 @@
         <target state="translated">正在簽署具有 {count} 個檔案的 Mage 工作。</target>
         <note>{Locked="Mage"} is another signing tool.  {Placeholder="{count}"} is the number of files to be signed.</note>
       </trans-unit>
+      <trans-unit id="ClickOnceStagingCopyFailed">
+        <source>Failed to prepare file '{0}' for the signing operation.</source>
+        <target state="new">Failed to prepare file '{0}' for the signing operation.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingDestinationCollision">
+        <source>Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</source>
+        <target state="new">Source files '{0}' and '{1}' have conflicting target paths '{2}' and '{3}'.</target>
+        <note>{NumberedPlaceholder="{0}"} and {NumberedPlaceholder="{1}"} are source file paths. {NumberedPlaceholder="{2}"} and {NumberedPlaceholder="{3}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingMappedSuffixFailed">
+        <source>Failed to rename file '{0}' while updating manifest file information.</source>
+        <target state="new">Failed to rename file '{0}' while updating manifest file information.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingReferenceDestinationConflict">
+        <source>Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</source>
+        <target state="new">Source file '{0}' is referenced with conflicting target paths '{1}' and '{2}'.</target>
+        <note>{NumberedPlaceholder="{0}"} is a source file path. {NumberedPlaceholder="{1}"} and {NumberedPlaceholder="{2}"} are manifest target paths.</note>
+      </trans-unit>
+      <trans-unit id="ClickOnceStagingUnsafeTargetPath">
+        <source>Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</source>
+        <target state="new">Manifest target path '{0}' for source file '{1}' is invalid or unsupported.</target>
+        <note>{NumberedPlaceholder="{0}"} is a manifest target path. {NumberedPlaceholder="{1}"} is a source file path.</note>
+      </trans-unit>
       <trans-unit id="CreatingDirectory">
         <source>Creating directory {path}.</source>
         <target state="translated">正在建立目錄 {path}。</target>

--- a/test/Sign.Core.Test/Tools/ClickOnce/ClickOnceFileGraphStagerTests.cs
+++ b/test/Sign.Core.Test/Tools/ClickOnce/ClickOnceFileGraphStagerTests.cs
@@ -1,0 +1,1667 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE.txt file in the project root for more information.
+
+using System.Reflection;
+using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
+using NSubstitute;
+
+namespace Sign.Core.Test
+{
+    public sealed class ClickOnceFileGraphStagerTests : IDisposable
+    {
+        private const string ApplicationDirectory =
+            @"Application Files\App_1_0_0_0";
+        private const string ApplicationManifestFileName = "App.exe.manifest";
+        private const string DeploySuffix = ".deploy";
+        private const string DeploymentManifestFileName = "App.application";
+        private const string FileContents = "contents";
+        private const string LauncherFileName = "Launcher.exe";
+        private const string PayloadFileName = "payload.dll";
+        private const string SetupFileName = "setup.exe";
+        private const string WarningMessageName =
+            "GenerateManifest.ResolveFailedInReadWriteMode";
+        private const string WarningTargetPath = "warning.txt";
+
+        private readonly DirectoryServiceStub _directoryService;
+        private readonly ClickOnceFileGraphStager _stager;
+
+        public ClickOnceFileGraphStagerTests()
+        {
+            _directoryService = new DirectoryServiceStub();
+            _stager = new ClickOnceFileGraphStager(_directoryService);
+        }
+
+        public void Dispose()
+        {
+            _directoryService.Dispose();
+        }
+
+        [Fact]
+        public void Stage_DefaultDeployment_StagesGraphAndRebindsReferences()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo deploymentManifest = CreateFile(
+                sourceDirectory,
+                DeploymentManifestFileName);
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                Path.Combine(
+                    ApplicationDirectory,
+                    ApplicationManifestFileName));
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                Path.Combine(ApplicationDirectory, PayloadFileName));
+            FileInfo competingPayload = CreateFile(
+                sourceDirectory,
+                Path.Combine("competing", PayloadFileName));
+            FileInfo setup = CreateFile(sourceDirectory, SetupFileName);
+            AssemblyReference applicationReference = new()
+            {
+                ResolvedPath = applicationManifest.FullName,
+                TargetPath = Path.Combine(
+                    ApplicationDirectory,
+                    ApplicationManifestFileName)
+            };
+            FileReference payloadReference = new()
+            {
+                ResolvedPath = competingPayload.FullName,
+                SourcePath = competingPayload.FullName,
+                TargetPath = PayloadFileName
+            };
+            ClickOnceFileGraph graph = CreateDeploymentGraph(
+                deploymentManifest,
+                applicationManifest,
+                applicationReference,
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        payloadReference)
+                },
+                new[]
+                {
+                    CreateEntry(
+                        setup,
+                        SetupFileName,
+                        ClickOnceFileGraphEntryKind.Setup)
+                });
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+
+            Assert.Equal(4, result.Files.Count);
+            Assert.All(
+                result.Files,
+                file => Assert.False(file.IsUpdateInputOnly));
+            AssertFile(
+                result.Directory,
+                DeploymentManifestFileName,
+                FileContents);
+            AssertFile(
+                result.Directory,
+                Path.Combine(
+                    ApplicationDirectory,
+                    ApplicationManifestFileName),
+                FileContents);
+            AssertFile(
+                result.Directory,
+                Path.Combine(ApplicationDirectory, PayloadFileName),
+                FileContents);
+            AssertFile(result.Directory, SetupFileName, FileContents);
+            Assert.Equal(
+                Path.Combine(
+                    result.Directory.FullName,
+                    ApplicationDirectory,
+                    ApplicationManifestFileName),
+                applicationReference.ResolvedPath);
+            Assert.Equal(
+                Path.Combine(
+                    result.Directory.FullName,
+                    ApplicationDirectory,
+                    PayloadFileName),
+                payloadReference.ResolvedPath);
+        }
+
+        [Fact]
+        public void
+            Stage_NoSignDependenciesForApplication_StagesReadOnlyInputs()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                PayloadFileName);
+            FileReference payloadReference = new()
+            {
+                ResolvedPath = payload.FullName,
+                TargetPath = PayloadFileName
+            };
+            IApplicationManifest applicationModel =
+                Substitute.For<IApplicationManifest>();
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                applicationModel,
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        payloadReference)
+                });
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.NoSignDependencies);
+
+            Assert.Equal(2, result.Files.Count);
+            Assert.False(
+                Assert.Single(
+                    result.Files,
+                    file =>
+                        file.Kind ==
+                        ClickOnceFileGraphEntryKind.ApplicationManifest)
+                .IsUpdateInputOnly);
+            Assert.True(
+                Assert.Single(
+                    result.Files,
+                    file =>
+                        file.Kind ==
+                        ClickOnceFileGraphEntryKind.Payload)
+                .IsUpdateInputOnly);
+            applicationModel.DidNotReceive().UpdateFileInfo();
+            applicationModel.DidNotReceive().Write(
+                Arg.Any<FileInfo>());
+        }
+
+        [Fact]
+        public void
+            Stage_NoSignDependenciesForDeployment_StagesOnlyRequiredInput()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo deploymentManifest = CreateFile(
+                sourceDirectory,
+                DeploymentManifestFileName);
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                PayloadFileName);
+            FileInfo launcher = CreateFile(
+                sourceDirectory,
+                LauncherFileName);
+            AssemblyReference applicationReference = new()
+            {
+                ResolvedPath = applicationManifest.FullName,
+                TargetPath = ApplicationManifestFileName
+            };
+            ClickOnceFileGraph graph = CreateDeploymentGraph(
+                deploymentManifest,
+                applicationManifest,
+                applicationReference,
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference())
+                },
+                new[]
+                {
+                    CreateEntry(
+                        launcher,
+                        LauncherFileName,
+                        ClickOnceFileGraphEntryKind.Launcher)
+                });
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.NoSignDependencies);
+
+            Assert.Collection(
+                result.Files.OrderBy(file => file.Kind),
+                file =>
+                {
+                    Assert.Equal(
+                        ClickOnceFileGraphEntryKind.DeploymentManifest,
+                        file.Kind);
+                    Assert.False(file.IsUpdateInputOnly);
+                },
+                file =>
+                {
+                    Assert.Equal(
+                        ClickOnceFileGraphEntryKind.ApplicationManifest,
+                        file.Kind);
+                    Assert.True(file.IsUpdateInputOnly);
+                });
+            Assert.False(
+                File.Exists(
+                    Path.Combine(
+                        result.Directory.FullName,
+                        PayloadFileName)));
+            Assert.False(
+                File.Exists(
+                    Path.Combine(
+                        result.Directory.FullName,
+                        LauncherFileName)));
+        }
+
+        [Fact]
+        public void Stage_NoUpdate_StagesOnlyExplicitManifest()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo deploymentManifest = CreateFile(
+                sourceDirectory,
+                DeploymentManifestFileName);
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            AssemblyReference applicationReference = new()
+            {
+                ResolvedPath = applicationManifest.FullName,
+                TargetPath = ApplicationManifestFileName
+            };
+            ClickOnceFileGraph graph = CreateDeploymentGraph(
+                deploymentManifest,
+                applicationManifest,
+                applicationReference,
+                new[]
+                {
+                    CreateEntry(
+                        new FileInfo(
+                            Path.Combine(
+                                sourceDirectory.FullName,
+                                "missing.dll")),
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference())
+                });
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.NoUpdate);
+
+            ClickOnceStagedFile stagedFile = Assert.Single(result.Files);
+
+            Assert.Equal(
+                ClickOnceFileGraphEntryKind.DeploymentManifest,
+                stagedFile.Kind);
+            Assert.Equal(
+                applicationManifest.FullName,
+                applicationReference.ResolvedPath);
+        }
+
+        [Fact]
+        public void Stage_NoUpdateApplication_StagesOnlyExplicitManifest()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        new FileInfo(
+                            Path.Combine(
+                                sourceDirectory.FullName,
+                                "missing.dll")),
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference())
+                });
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.NoUpdate);
+
+            ClickOnceStagedFile stagedFile = Assert.Single(result.Files);
+
+            Assert.Equal(
+                ClickOnceFileGraphEntryKind.ApplicationManifest,
+                stagedFile.Kind);
+        }
+
+        [Theory]
+        [InlineData(@"..\payload.dll")]
+        [InlineData(@"sub\..\payload.dll")]
+        [InlineData(@"sub\.\payload.dll")]
+        [InlineData(@"\payload.dll")]
+        [InlineData(@"C:\payload.dll")]
+        [InlineData(@"C:payload.dll")]
+        [InlineData(@"\\server\share\payload.dll")]
+        [InlineData(@"\\?\C:\payload.dll")]
+        [InlineData(@"\\.\NUL")]
+        [InlineData("payload.dll:stream")]
+        [InlineData("payload.dll.")]
+        [InlineData("payload.dll ")]
+        [InlineData(".")]
+        public void Stage_UnsafeTargetPath_IsRemapped(string targetPath)
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                PayloadFileName);
+            ClickOnceManifestDiagnostic diagnostic = CreateDiagnostic();
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        targetPath,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference())
+                },
+                new[] { diagnostic });
+
+            FileReference reference =
+                (FileReference)Assert.Single(graph.Payloads)
+                    .ManifestReference!;
+            reference.TargetPath = targetPath;
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+
+            ClickOnceStagedFile stagedFile = Assert.Single(
+                result.Files,
+                file => file.Kind == ClickOnceFileGraphEntryKind.Payload);
+            string rootPath = Path.GetFullPath(result.Directory.FullName) +
+                Path.DirectorySeparatorChar;
+            string destinationPath = Path.GetFullPath(stagedFile.File.FullName);
+
+            Assert.StartsWith(
+                rootPath,
+                destinationPath,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(
+                "__clickonce_internal_",
+                destinationPath,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(targetPath, stagedFile.TargetPath);
+            Assert.Equal(targetPath, reference.TargetPath);
+            Assert.Equal(destinationPath, reference.ResolvedPath);
+            Assert.Equal(FileContents, File.ReadAllText(destinationPath));
+            Assert.Same(diagnostic, Assert.Single(result.Diagnostics));
+            Assert.Equal(FileContents, File.ReadAllText(payload.FullName));
+        }
+
+        [Theory]
+        [InlineData("CON")]
+        [InlineData("CON.txt")]
+        [InlineData("PRN")]
+        [InlineData("AUX.dll")]
+        [InlineData("NUL")]
+        [InlineData("COM1")]
+        [InlineData("COM1.dll")]
+        [InlineData("COM\u00b9")]
+        [InlineData("COM\u00b9.dll")]
+        [InlineData("COM\u00b2")]
+        [InlineData("COM\u00b2.dll")]
+        [InlineData("COM\u00b3")]
+        [InlineData("COM\u00b3.dll")]
+        [InlineData("LPT\u00b9")]
+        [InlineData("LPT\u00b9.dll")]
+        [InlineData("LPT\u00b2")]
+        [InlineData("LPT\u00b2.dll")]
+        [InlineData("LPT\u00b3")]
+        [InlineData("LPT\u00b3.dll")]
+        public void Stage_LegacyWindowsDeviceName_UsesDotNetPathSemantics(
+            string targetPath)
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                PayloadFileName);
+            FileReference reference = new();
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        targetPath,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        reference)
+                });
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+
+            ClickOnceStagedFile stagedFile = Assert.Single(
+                result.Files,
+                file => file.Kind == ClickOnceFileGraphEntryKind.Payload);
+
+            Assert.Equal(targetPath, stagedFile.TargetPath);
+            Assert.Equal(stagedFile.File.FullName, reference.ResolvedPath);
+            Assert.Equal(
+                FileContents,
+                File.ReadAllText(stagedFile.File.FullName));
+        }
+
+        [Fact]
+        public void Stage_UnsafeTargetPath_RemappingIsDeterministic()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                PayloadFileName);
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        @"..\payload.dll",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference())
+                });
+
+            string firstRelativePath;
+
+            using (ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default))
+            {
+                firstRelativePath = Path.GetRelativePath(
+                    result.Directory.FullName,
+                    Assert.Single(
+                        result.Files,
+                        file =>
+                            file.Kind ==
+                            ClickOnceFileGraphEntryKind.Payload)
+                    .File.FullName);
+            }
+
+            ClickOnceFileGraph secondGraph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        @"C:\different.dll",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference())
+                });
+            using ClickOnceStagingResult secondResult = _stager.Stage(
+                secondGraph,
+                ClickOnceSigningMode.Default);
+            string secondRelativePath = Path.GetRelativePath(
+                secondResult.Directory.FullName,
+                Assert.Single(
+                    secondResult.Files,
+                    file =>
+                        file.Kind ==
+                        ClickOnceFileGraphEntryKind.Payload)
+                .File.FullName);
+
+            Assert.Equal(firstRelativePath, secondRelativePath);
+        }
+
+        [Fact]
+        public void Stage_DuplicateUnsafeTarget_ReusesDestination()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                PayloadFileName);
+            FileReference firstReference = new();
+            FileReference secondReference = new();
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        @"..\payload.dll",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        firstReference),
+                    CreateEntry(
+                        payload,
+                        @"..\payload.dll",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        secondReference)
+                });
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+
+            Assert.Equal(
+                firstReference.ResolvedPath,
+                secondReference.ResolvedPath);
+            Assert.True(File.Exists(firstReference.ResolvedPath));
+        }
+
+        [Fact]
+        public void Stage_DuplicateUnsafeTargetWithDifferentSources_Fails()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo firstPayload = CreateFile(
+                sourceDirectory,
+                Path.Combine("one", PayloadFileName));
+            FileInfo secondPayload = CreateFile(
+                sourceDirectory,
+                Path.Combine("two", PayloadFileName));
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        firstPayload,
+                        @"..\payload.dll",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference()),
+                    CreateEntry(
+                        secondPayload,
+                        @"..\payload.dll",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference())
+                });
+
+            Assert.Throws<ClickOnceFileGraphStagingException>(
+                () => _stager.Stage(
+                    graph,
+                    ClickOnceSigningMode.Default));
+            Assert.False(_directoryService.Directories[^1].Exists);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Stage_GeneratedNamespace_IsIndependentOfCandidateOrder(
+            bool unsafeFirst)
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo unsafePayload = CreateFile(
+                sourceDirectory,
+                Path.Combine("one", PayloadFileName));
+            FileInfo directPayload = CreateFile(
+                sourceDirectory,
+                Path.Combine("two", PayloadFileName));
+            string directTarget = Path.Combine(
+                "__clickonce_internal_generated0",
+                $"{(unsafeFirst ? 2 : 1):x8}",
+                "file");
+            ClickOnceFileGraphEntry unsafeEntry = CreateEntry(
+                unsafePayload,
+                @"..\payload.dll",
+                ClickOnceFileGraphEntryKind.Payload,
+                new FileReference());
+            ClickOnceFileGraphEntry directEntry = CreateEntry(
+                directPayload,
+                directTarget,
+                ClickOnceFileGraphEntryKind.Payload,
+                new FileReference());
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                unsafeFirst
+                    ? new[] { unsafeEntry, directEntry }
+                    : new[] { directEntry, unsafeEntry });
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+            ClickOnceStagedFile[] payloads = result.Files
+                .Where(
+                    file =>
+                        file.Kind ==
+                        ClickOnceFileGraphEntryKind.Payload)
+                .ToArray();
+
+            Assert.Equal(2, payloads.Length);
+            ClickOnceStagedFile stagedDirect = Assert.Single(
+                payloads,
+                file => string.Equals(
+                    file.Source.FullName,
+                    directPayload.FullName,
+                    StringComparison.OrdinalIgnoreCase));
+            ClickOnceStagedFile stagedUnsafe = Assert.Single(
+                payloads,
+                file => string.Equals(
+                    file.Source.FullName,
+                    unsafePayload.FullName,
+                    StringComparison.OrdinalIgnoreCase));
+
+            Assert.NotEqual(
+                stagedDirect.File.FullName,
+                stagedUnsafe.File.FullName);
+            Assert.NotEqual(
+                Path.Combine(result.Directory.FullName, directTarget),
+                stagedDirect.File.FullName);
+            Assert.Equal(directTarget, stagedDirect.TargetPath);
+            Assert.Equal(@"..\payload.dll", stagedUnsafe.TargetPath);
+            Assert.All(payloads, file => Assert.True(file.File.Exists));
+        }
+
+        [Fact]
+        public void Stage_CaseOnlyDestinationCollision_FailsBeforeCopying()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo firstPayload = CreateFile(
+                sourceDirectory,
+                Path.Combine("one", PayloadFileName));
+            FileInfo secondPayload = CreateFile(
+                sourceDirectory,
+                Path.Combine("two", PayloadFileName));
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        firstPayload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference()),
+                    CreateEntry(
+                        secondPayload,
+                        PayloadFileName.ToUpperInvariant(),
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference())
+                });
+
+            ClickOnceFileGraphStagingException exception =
+                Assert.Throws<ClickOnceFileGraphStagingException>(
+                    () => _stager.Stage(
+                        graph,
+                        ClickOnceSigningMode.Default));
+
+            Assert.Contains(firstPayload.FullName, exception.Message);
+            Assert.Contains(secondPayload.FullName, exception.Message);
+            Assert.Contains(PayloadFileName, exception.Message);
+            Assert.Contains(
+                PayloadFileName.ToUpperInvariant(),
+                exception.Message);
+            Assert.DoesNotContain(
+                "staging",
+                exception.Message,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.False(_directoryService.Directories[^1].Exists);
+        }
+
+        [Fact]
+        public void Stage_MappedUpdateDestinationCollision_FailsBeforeCopying()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo mappedPayload = CreateFile(
+                sourceDirectory,
+                $"{PayloadFileName}{DeploySuffix}");
+            FileInfo unmappedPayload = CreateFile(
+                sourceDirectory,
+                Path.Combine("other", PayloadFileName));
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        mappedPayload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference(),
+                        DeploySuffix),
+                    CreateEntry(
+                        unmappedPayload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference())
+                });
+
+            Assert.Throws<ClickOnceFileGraphStagingException>(
+                () => _stager.Stage(
+                    graph,
+                    ClickOnceSigningMode.Default));
+            Assert.False(_directoryService.Directories[^1].Exists);
+        }
+
+        [Fact]
+        public void
+            Stage_MixedMappedAndUnmappedSameDestination_FailsBeforeCopying()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                $"{PayloadFileName}{DeploySuffix}");
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference(),
+                        DeploySuffix),
+                    CreateEntry(
+                        payload,
+                        $"{PayloadFileName}{DeploySuffix}",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference())
+                });
+
+            Assert.Throws<ClickOnceFileGraphStagingException>(
+                () => _stager.Stage(
+                    graph,
+                    ClickOnceSigningMode.Default));
+            Assert.False(_directoryService.Directories[^1].Exists);
+        }
+
+        [Fact]
+        public void Stage_OneReferenceWithMultipleDestinations_FailsBeforeCopying()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                PayloadFileName);
+            FileReference reference = new();
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        Path.Combine("one", PayloadFileName),
+                        ClickOnceFileGraphEntryKind.Payload,
+                        reference),
+                    CreateEntry(
+                        payload,
+                        Path.Combine("two", PayloadFileName),
+                        ClickOnceFileGraphEntryKind.Payload,
+                        reference)
+                });
+
+            ClickOnceFileGraphStagingException exception =
+                Assert.Throws<ClickOnceFileGraphStagingException>(
+                    () => _stager.Stage(
+                        graph,
+                        ClickOnceSigningMode.Default));
+
+            Assert.Contains(payload.FullName, exception.Message);
+            Assert.Contains(
+                Path.Combine("one", PayloadFileName),
+                exception.Message);
+            Assert.Contains(
+                Path.Combine("two", PayloadFileName),
+                exception.Message);
+            Assert.DoesNotContain(
+                "staging",
+                exception.Message,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.False(_directoryService.Directories[^1].Exists);
+        }
+
+        [Fact]
+        public void Stage_MappedTrailingDotTarget_IsRemapped()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            const string TargetPath = "payload.";
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                $"{TargetPath}{DeploySuffix}");
+            FileReference reference = new()
+            {
+                TargetPath = TargetPath
+            };
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        TargetPath,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        reference,
+                        DeploySuffix)
+                });
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+            ClickOnceStagedFile stagedFile = Assert.Single(
+                result.Files,
+                file => file.Kind == ClickOnceFileGraphEntryKind.Payload);
+
+            Assert.Equal(TargetPath, stagedFile.TargetPath);
+            Assert.Equal(TargetPath, reference.TargetPath);
+            Assert.NotNull(stagedFile.ManifestUpdateFile);
+            Assert.Equal(
+                $"{stagedFile.ManifestUpdateFile!.FullName}{DeploySuffix}",
+                stagedFile.File.FullName);
+            Assert.Equal(stagedFile.File.FullName, reference.ResolvedPath);
+
+            using (result.BeginManifestUpdate())
+            {
+                Assert.False(stagedFile.File.Exists);
+                stagedFile.ManifestUpdateFile!.Refresh();
+                Assert.True(stagedFile.ManifestUpdateFile.Exists);
+                Assert.Equal(
+                    stagedFile.ManifestUpdateFile.FullName,
+                    reference.ResolvedPath);
+            }
+
+            stagedFile.File.Refresh();
+            stagedFile.ManifestUpdateFile!.Refresh();
+            Assert.True(stagedFile.File.Exists);
+            Assert.False(stagedFile.ManifestUpdateFile.Exists);
+            Assert.Equal(stagedFile.File.FullName, reference.ResolvedPath);
+        }
+
+        [Fact]
+        public void Stage_PathTooLong_IsRemappedAndPreservesDiagnostics()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                PayloadFileName);
+            ClickOnceManifestDiagnostic diagnostic = CreateDiagnostic();
+            string targetPath = string.Join(
+                Path.DirectorySeparatorChar,
+                Enumerable.Repeat("segment", 5000));
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        targetPath,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference())
+                },
+                new[] { diagnostic });
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+            ClickOnceStagedFile stagedFile = Assert.Single(
+                result.Files,
+                file => file.Kind == ClickOnceFileGraphEntryKind.Payload);
+
+            Assert.Equal(targetPath, stagedFile.TargetPath);
+            Assert.True(stagedFile.File.Exists);
+            Assert.Same(diagnostic, Assert.Single(result.Diagnostics));
+        }
+
+        [Fact]
+        public void Stage_FileDirectoryCollision_FailsBeforeCopying()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo firstPayload = CreateFile(
+                sourceDirectory,
+                Path.Combine("one", "payload"));
+            FileInfo secondPayload = CreateFile(
+                sourceDirectory,
+                Path.Combine("two", PayloadFileName));
+            FileInfo interveningPayload = CreateFile(
+                sourceDirectory,
+                Path.Combine("three", PayloadFileName));
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        firstPayload,
+                        "directory",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference()),
+                    CreateEntry(
+                        interveningPayload,
+                        "directory0",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference()),
+                    CreateEntry(
+                        secondPayload,
+                        Path.Combine("directory", PayloadFileName),
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference())
+                });
+
+            Assert.Throws<ClickOnceFileGraphStagingException>(
+                () => _stager.Stage(
+                    graph,
+                    ClickOnceSigningMode.Default));
+            Assert.False(_directoryService.Directories[^1].Exists);
+        }
+
+        [Fact]
+        public void
+            BeginManifestUpdate_RemappedTargetEndingInSuffix_UsesExactSuffix()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            string targetPath = Path.Combine("..", "payload.deploy");
+
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                $"payload.deploy{DeploySuffix}");
+            FileReference payloadReference = new()
+            {
+                ResolvedPath = payload.FullName,
+                TargetPath = targetPath
+            };
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        targetPath,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        payloadReference,
+                        DeploySuffix)
+                });
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+
+            ClickOnceStagedFile stagedFile = Assert.Single(
+                result.Files,
+                file => file.Kind == ClickOnceFileGraphEntryKind.Payload);
+            FileInfo updateFile = Assert.IsType<FileInfo>(
+                stagedFile.ManifestUpdateFile);
+            string stagedPath = stagedFile.File.FullName;
+            string updatePath = updateFile.FullName;
+
+            Assert.Equal(targetPath, stagedFile.TargetPath);
+            Assert.Equal(targetPath, payloadReference.TargetPath);
+            Assert.Equal($"{updatePath}{DeploySuffix}", stagedPath);
+            Assert.Equal(
+                $"{updateFile.Name}{DeploySuffix}",
+                stagedFile.File.Name);
+            Assert.True(File.Exists(stagedPath));
+            Assert.Equal(stagedPath, payloadReference.ResolvedPath);
+
+            using (result.BeginManifestUpdate())
+            {
+                Assert.False(File.Exists(stagedPath));
+                Assert.True(File.Exists(updatePath));
+                Assert.Equal(updatePath, payloadReference.ResolvedPath);
+            }
+
+            Assert.True(File.Exists(stagedPath));
+            Assert.False(File.Exists(updatePath));
+            Assert.Equal(stagedPath, payloadReference.ResolvedPath);
+            Assert.True(payload.Exists);
+            Assert.Equal(FileContents, File.ReadAllText(payload.FullName));
+        }
+
+        [Fact]
+        public void BeginManifestUpdate_WhenRenameFails_RollsBackEarlierFiles()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo firstPayload = CreateFile(
+                sourceDirectory,
+                $"one.dll{DeploySuffix}");
+            FileInfo secondPayload = CreateFile(
+                sourceDirectory,
+                $"two.dll{DeploySuffix}");
+            FileReference firstReference = new();
+            FileReference secondReference = new();
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        firstPayload,
+                        "one.dll",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        firstReference,
+                        DeploySuffix),
+                    CreateEntry(
+                        secondPayload,
+                        "two.dll",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        secondReference,
+                        DeploySuffix)
+                });
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+
+            string firstStagedPath = Path.Combine(
+                result.Directory.FullName,
+                $"one.dll{DeploySuffix}");
+            string secondStagedPath = Path.Combine(
+                result.Directory.FullName,
+                $"two.dll{DeploySuffix}");
+            string secondUpdatePath = Path.Combine(
+                result.Directory.FullName,
+                "two.dll");
+
+            File.WriteAllText(secondUpdatePath, FileContents);
+
+            ClickOnceFileGraphStagingException exception =
+                Assert.Throws<ClickOnceFileGraphStagingException>(
+                    result.BeginManifestUpdate);
+
+            Assert.Contains("two.dll", exception.Message);
+            Assert.IsType<IOException>(exception.InnerException);
+            Assert.DoesNotContain(
+                "staging",
+                exception.Message,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.Exists(firstStagedPath));
+            Assert.True(File.Exists(secondStagedPath));
+            Assert.Equal(firstStagedPath, firstReference.ResolvedPath);
+            Assert.Equal(secondStagedPath, secondReference.ResolvedPath);
+        }
+
+        [Fact]
+        public void BeginManifestUpdate_WhenAlreadyActive_Throws()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                $"{PayloadFileName}{DeploySuffix}");
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference(),
+                        DeploySuffix)
+                });
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+            using IDisposable update = result.BeginManifestUpdate();
+
+            Assert.Throws<InvalidOperationException>(
+                result.BeginManifestUpdate);
+        }
+
+        [Fact]
+        public void BeginManifestUpdate_WhenResultIsDisposed_Throws()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>());
+            ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+
+            result.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(
+                result.BeginManifestUpdate);
+        }
+
+        [Fact]
+        public void ManifestUpdateScope_WhenDisposedTwice_DoesNothing()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                $"{PayloadFileName}{DeploySuffix}");
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference(),
+                        DeploySuffix)
+                });
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+            IDisposable update = result.BeginManifestUpdate();
+
+            update.Dispose();
+            update.Dispose();
+        }
+
+        [Fact]
+        public void ManifestUpdateScope_WhenOwnerIsDisposed_DoesNothing()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                $"{PayloadFileName}{DeploySuffix}");
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference(),
+                        DeploySuffix)
+                });
+            ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+            IDisposable update = result.BeginManifestUpdate();
+
+            result.Dispose();
+            update.Dispose();
+        }
+
+        [Fact]
+        public void EndManifestUpdate_WhenMultipleRestoresFail_AttemptsAll()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo firstPayload = CreateFile(
+                sourceDirectory,
+                $"one.dll{DeploySuffix}");
+            FileInfo secondPayload = CreateFile(
+                sourceDirectory,
+                $"two.dll{DeploySuffix}");
+            FileReference firstReference = new();
+            FileReference secondReference = new();
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        firstPayload,
+                        "one.dll",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        firstReference,
+                        DeploySuffix),
+                    CreateEntry(
+                        secondPayload,
+                        "two.dll",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        secondReference,
+                        DeploySuffix)
+                });
+            ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+            IDisposable update = result.BeginManifestUpdate();
+            ClickOnceStagedFile[] mappedFiles = result.Files
+                .Where(file => file.ManifestUpdateFile is not null)
+                .ToArray();
+
+            foreach (ClickOnceStagedFile mappedFile in mappedFiles)
+            {
+                File.WriteAllText(mappedFile.File.FullName, FileContents);
+            }
+
+            ClickOnceFileGraphStagingException exception =
+                Assert.Throws<ClickOnceFileGraphStagingException>(
+                    update.Dispose);
+            AggregateException aggregate =
+                Assert.IsType<AggregateException>(exception.InnerException);
+
+            Assert.Equal(2, aggregate.InnerExceptions.Count);
+            Assert.All(
+                aggregate.InnerExceptions,
+                inner => Assert.IsType<ClickOnceFileGraphStagingException>(
+                    inner));
+            Assert.All(
+                mappedFiles,
+                mappedFile =>
+                {
+                    mappedFile.ManifestUpdateFile!.Refresh();
+                    Assert.True(mappedFile.ManifestUpdateFile.Exists);
+                    Assert.Equal(
+                        mappedFile.ManifestUpdateFile.FullName,
+                        mappedFile.ManifestReference!.ResolvedPath);
+                    File.Delete(mappedFile.File.FullName);
+                });
+
+            result.Dispose();
+        }
+
+        [Fact]
+        public void Dispose_WhenActiveUpdateCannotRestore_CleansUp()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                $"{PayloadFileName}{DeploySuffix}");
+            FileReference reference = new()
+            {
+                ResolvedPath = payload.FullName
+            };
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        reference,
+                        DeploySuffix)
+                });
+            ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+            DirectoryInfo stagingDirectory = result.Directory;
+            result.BeginManifestUpdate();
+            string stablePath = Path.Combine(
+                stagingDirectory.FullName,
+                $"{PayloadFileName}{DeploySuffix}");
+            File.WriteAllText(stablePath, FileContents);
+
+            Assert.Throws<ClickOnceFileGraphStagingException>(
+                result.Dispose);
+
+            stagingDirectory.Refresh();
+            Assert.False(stagingDirectory.Exists);
+            Assert.Equal(payload.FullName, reference.ResolvedPath);
+        }
+
+        [Fact]
+        public void Dispose_RestoresReferencesAndDeletesStagingDirectory()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                PayloadFileName);
+            FileReference payloadReference = new()
+            {
+                ResolvedPath = payload.FullName,
+                TargetPath = PayloadFileName
+            };
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        payloadReference)
+                });
+            ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+            DirectoryInfo stagingDirectory = result.Directory;
+
+            Assert.NotEqual(
+                payload.FullName,
+                payloadReference.ResolvedPath);
+
+            result.Dispose();
+            stagingDirectory.Refresh();
+
+            Assert.Equal(payload.FullName, payloadReference.ResolvedPath);
+            Assert.False(stagingDirectory.Exists);
+        }
+
+        [Fact]
+        public void Stage_CopyFailure_CleansUpAndPreservesDiagnostics()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo missingPayload = new(
+                Path.Combine(sourceDirectory.FullName, PayloadFileName));
+            ClickOnceManifestDiagnostic diagnostic = CreateDiagnostic();
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        missingPayload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        new FileReference())
+                },
+                new[] { diagnostic });
+
+            ClickOnceFileGraphStagingException exception =
+                Assert.Throws<ClickOnceFileGraphStagingException>(
+                    () => _stager.Stage(
+                        graph,
+                        ClickOnceSigningMode.Default));
+
+            Assert.Contains(missingPayload.FullName, exception.Message);
+            Assert.DoesNotContain(
+                "staging",
+                exception.Message,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.Same(diagnostic, Assert.Single(exception.Diagnostics));
+            Assert.False(_directoryService.Directories[^1].Exists);
+        }
+
+        [Fact]
+        public void Stage_DuplicateSameSourceAndDestination_BindsAllReferences()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                PayloadFileName);
+            FileReference firstReference = new();
+            FileReference secondReference = new();
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        firstReference),
+                    CreateEntry(
+                        payload,
+                        PayloadFileName,
+                        ClickOnceFileGraphEntryKind.Payload,
+                        secondReference)
+                });
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+
+            string stagedPath = Path.Combine(
+                result.Directory.FullName,
+                PayloadFileName);
+
+            Assert.Equal(stagedPath, firstReference.ResolvedPath);
+            Assert.Equal(stagedPath, secondReference.ResolvedPath);
+            Assert.Equal(FileContents, File.ReadAllText(stagedPath));
+        }
+
+        [Fact]
+        public void
+            Stage_SeparatorEquivalentSameSourceAndDestination_BindsAllReferences()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            FileInfo payload = CreateFile(
+                sourceDirectory,
+                PayloadFileName);
+            FileReference firstReference = new();
+            FileReference secondReference = new();
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>(),
+                new[]
+                {
+                    CreateEntry(
+                        payload,
+                        $"sub/{PayloadFileName}",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        firstReference),
+                    CreateEntry(
+                        payload,
+                        $@"sub\{PayloadFileName}",
+                        ClickOnceFileGraphEntryKind.Payload,
+                        secondReference)
+                });
+
+            using ClickOnceStagingResult result = _stager.Stage(
+                graph,
+                ClickOnceSigningMode.Default);
+
+            Assert.Equal(
+                firstReference.ResolvedPath,
+                secondReference.ResolvedPath);
+            Assert.Equal(
+                FileContents,
+                File.ReadAllText(firstReference.ResolvedPath));
+        }
+
+        [Fact]
+        public void Stage_InvalidMode_Throws()
+        {
+            DirectoryInfo sourceDirectory =
+                _directoryService.CreateTemporaryDirectory();
+            FileInfo applicationManifest = CreateFile(
+                sourceDirectory,
+                ApplicationManifestFileName);
+            ClickOnceFileGraph graph = CreateApplicationGraph(
+                applicationManifest,
+                Substitute.For<IApplicationManifest>());
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => _stager.Stage(
+                    graph,
+                    (ClickOnceSigningMode)int.MaxValue));
+        }
+
+        private static ClickOnceFileGraph CreateApplicationGraph(
+            FileInfo applicationManifest,
+            IApplicationManifest applicationModel,
+            IEnumerable<ClickOnceFileGraphEntry>? payloads = null,
+            IEnumerable<ClickOnceManifestDiagnostic>? diagnostics = null)
+        {
+            return new ClickOnceFileGraph(
+                deploymentManifest: null,
+                deployManifest: null,
+                CreateEntry(
+                    applicationManifest,
+                    applicationManifest.Name,
+                    ClickOnceFileGraphEntryKind.ApplicationManifest),
+                applicationModel,
+                payloads ?? Array.Empty<ClickOnceFileGraphEntry>(),
+                adjacentExecutables: Array.Empty<ClickOnceFileGraphEntry>(),
+                diagnostics ?? Array.Empty<ClickOnceManifestDiagnostic>());
+        }
+
+        private static ClickOnceFileGraph CreateDeploymentGraph(
+            FileInfo deploymentManifest,
+            FileInfo applicationManifest,
+            AssemblyReference applicationReference,
+            IEnumerable<ClickOnceFileGraphEntry>? payloads = null,
+            IEnumerable<ClickOnceFileGraphEntry>? adjacentExecutables = null)
+        {
+            return new ClickOnceFileGraph(
+                CreateEntry(
+                    deploymentManifest,
+                    deploymentManifest.Name,
+                    ClickOnceFileGraphEntryKind.DeploymentManifest),
+                Substitute.For<IDeployManifest>(),
+                CreateEntry(
+                    applicationManifest,
+                    applicationReference.TargetPath,
+                    ClickOnceFileGraphEntryKind.ApplicationManifest,
+                    applicationReference),
+                Substitute.For<IApplicationManifest>(),
+                payloads ?? Array.Empty<ClickOnceFileGraphEntry>(),
+                adjacentExecutables ?? Array.Empty<ClickOnceFileGraphEntry>(),
+                diagnostics: Array.Empty<ClickOnceManifestDiagnostic>());
+        }
+
+        private static ClickOnceFileGraphEntry CreateEntry(
+            FileInfo source,
+            string targetPath,
+            ClickOnceFileGraphEntryKind kind,
+            BaseReference? reference = null,
+            string? mappingAddedSuffix = null)
+        {
+            return new ClickOnceFileGraphEntry(
+                source,
+                targetPath,
+                kind,
+                reference,
+                mappingAddedSuffix);
+        }
+
+        private static FileInfo CreateFile(
+            DirectoryInfo root,
+            string relativePath)
+        {
+            FileInfo file = new(
+                Path.Combine(root.FullName, relativePath));
+
+            file.Directory!.Create();
+            File.WriteAllText(file.FullName, FileContents);
+            file.Refresh();
+
+            return file;
+        }
+
+        private static void AssertFile(
+            DirectoryInfo root,
+            string relativePath,
+            string expectedContents)
+        {
+            string path = Path.Combine(root.FullName, relativePath);
+
+            Assert.True(File.Exists(path));
+            Assert.Equal(expectedContents, File.ReadAllText(path));
+        }
+
+        private static ClickOnceManifestDiagnostic CreateDiagnostic()
+        {
+            DeployManifest manifest = new();
+            MethodInfo addWarning = typeof(OutputMessageCollection).GetMethod(
+                name: "AddWarningMessage",
+                bindingAttr:
+                    BindingFlags.Instance |
+                    BindingFlags.NonPublic)!;
+
+            addWarning.Invoke(
+                obj: manifest.OutputMessages,
+                parameters: new object[]
+                {
+                    WarningMessageName,
+                    new[] { WarningTargetPath }
+                });
+
+            return new ClickOnceManifestDiagnostic(
+                Assert.Single(
+                    manifest.OutputMessages.Cast<OutputMessage>()));
+        }
+    }
+}


### PR DESCRIPTION
Part of #1049.

## Summary

- Add dormant staging for `ResolvedClickOncePublishLayout` while preserving its typed deployment, application, payload, and adjacent-executable associations.
- Build an immutable staging plan and validate every destination before performing filesystem or manifest-reference changes.
- Reject rooted, traversing, escaping, colliding, and otherwise unrepresentable staging paths while preserving manifest-relative target paths.
- Copy the resolved publish layout into an isolated temporary directory and bind manifest references only to staged files.
- Temporarily remove only explicitly mapping-added `.deploy` suffixes while manifest file information is updated, then restore both filenames and references.
- Restore manifest references and clean up staged files during normal disposal and failure rollback.

## Design

Staging is mode-neutral. Signing and manifest-update policy remain responsibilities of the later application and deployment orchestration changes.

Planning and execution are separated: `ClickOnceStagingPlanBuilder` performs pure allocation and validation, while `ClickOncePublishLayoutStager` performs copying and reference binding. `ClickOnceStagingSession` owns the temporary staging lifecycle and mapped-suffix update scope.

## Behavior

No production signing behavior or CLI surface is changed. The staging implementation remains dormant until it is integrated by later ClickOnce signing changes.

## Testing

- Release restore, build, and all unit-test projects: 947 total, 946 passed, 1 skipped, 0 failed.
- Build completed with 0 warnings and 0 errors.
- Diff hygiene and stale staging-terminology checks passed.