### PR TITLE
Escape '#' in OPC part names so signature references aren't truncated

### DIFF
--- a/src/Sign.Core/Tools/VsixSignTool/OpcPart.cs
+++ b/src/Sign.Core/Tools/VsixSignTool/OpcPart.cs
@@ -18,7 +18,7 @@ namespace Sign.Core
 
         internal OpcPart(OpcPackage package, string path, ZipArchiveEntry entry, OpcPackageFileMode mode)
         {
-            Uri = new Uri(OpcPackage.BasePackageUri, path);
+            Uri = new Uri(OpcPackage.BasePackageUri, UriHelpers.EscapePartPath(path));
             Package = package;
             _path = path;
             Entry = entry;
@@ -86,7 +86,7 @@ namespace Sign.Core
             var path = GetRelationshipFilePath();
             var entry = Package.Archive.GetEntry(path);
             var readOnlyMode = _mode != OpcPackageFileMode.ReadWrite;
-            var location = new Uri(OpcPackage.BasePackageUri, path);
+            var location = new Uri(OpcPackage.BasePackageUri, UriHelpers.EscapePartPath(path));
             if (entry == null)
             {
                 return new OpcRelationships(location, readOnlyMode);

--- a/src/Sign.Core/Tools/VsixSignTool/UriHelpers.cs
+++ b/src/Sign.Core/Tools/VsixSignTool/UriHelpers.cs
@@ -12,6 +12,27 @@ namespace Sign.Core
         private static readonly Uri _packageBaseUri = new Uri("package:///", UriKind.Absolute);
         private static readonly Uri _rootedPackageBaseUri = new Uri("package:", UriKind.Absolute);
 
+        /// <summary>
+        /// Escapes a raw part or relationship path (as read from a zip entry name) so that
+        /// characters which are valid in file names but reserved in URIs (such as '#', '?',
+        /// and '%') do not get misinterpreted as URI delimiters (for example, a literal '#'
+        /// would otherwise be parsed as introducing a URI fragment, silently truncating the
+        /// path). Each '/'-delimited segment is escaped independently so the separators
+        /// themselves are preserved.
+        /// </summary>
+        /// <param name="path">The raw, unescaped path.</param>
+        /// <returns>A path with reserved characters in each segment percent-encoded.</returns>
+        public static string EscapePartPath(string path)
+        {
+            var segments = path.Split('/');
+
+            for (var i = 0; i < segments.Length; i++)
+            {
+                segments[i] = Uri.EscapeDataString(segments[i]);
+            }
+
+            return string.Join('/', segments);
+        }
 
         /// <summary>
         /// Converts a package URI to a path within the package zip file.
@@ -28,14 +49,17 @@ namespace Sign.Core
         }
 
         /// <summary>
-        /// Converts a package URI to a qualified path within the package zip file.
+        /// Converts a package URI to a qualified path within the package zip file, suitable
+        /// for use as a URI reference in signature and relationship XML (properly escaped per
+        /// RFC 3986, so reserved characters like '#' remain percent-encoded rather than being
+        /// decoded back into syntax-breaking literals).
         /// </summary>
         /// <param name="partUri">The URI to convert.</param>
         /// <returns>A string to the qualified path in the zip file.</returns>
         public static string ToQualifiedPath(this Uri partUri)
         {
             var absolute = partUri.IsAbsoluteUri ? partUri : new Uri(_rootedPackageBaseUri, partUri);
-            var pathUri = new Uri(absolute.GetComponents(UriComponents.SchemeAndServer | UriComponents.PathAndQuery, UriFormat.Unescaped), UriKind.Absolute);
+            var pathUri = new Uri(absolute.GetComponents(UriComponents.SchemeAndServer | UriComponents.PathAndQuery, UriFormat.UriEscaped), UriKind.Absolute);
             var resolved = _rootedPackageBaseUri.MakeRelativeUri(pathUri);
 
             return resolved.ToString();

--- a/test/Sign.Core.Test/Tools/VSIXSignTool/OpcPackageSigningTests.cs
+++ b/test/Sign.Core.Test/Tools/VSIXSignTool/OpcPackageSigningTests.cs
@@ -3,8 +3,10 @@
 // See the LICENSE.txt file in the project root for more information.
 
 using System.Globalization;
+using System.IO.Compression;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Xml;
 using Sign.Core.Timestamp;
 using Xunit.Abstractions;
@@ -94,6 +96,78 @@ namespace Sign.Core.Test
                     Assert.Equal(TimestampResult.Success, result);
                 }
             }
+        }
+
+        [Fact]
+        public void ShouldSignPartWithOctothorpeInName()
+        {
+            // Regression test for https://github.com/dotnet/sign/issues/998: a part whose
+            // name contains '#' must not have its manifest Reference URI silently truncated
+            // at the '#' (which System.Uri parses as a fragment delimiter unless escaped).
+            const string specialPartName = "ab#c.txt";
+            const string specialPartContents = "content with an octothorpe in the part name";
+
+            string temp = Path.GetTempFileName();
+            _shadowFiles.Add(temp);
+            File.Copy(SamplePackage, temp, overwrite: true);
+
+            using (ZipArchive archive = ZipFile.Open(temp, ZipArchiveMode.Update))
+            {
+                ZipArchiveEntry entry = archive.CreateEntry(specialPartName);
+                using StreamWriter writer = new(entry.Open(), Encoding.UTF8);
+                writer.Write(specialPartContents);
+            }
+
+            byte[] expectedDigest;
+            using (SHA256 sha256 = SHA256.Create())
+            {
+                expectedDigest = sha256.ComputeHash(Encoding.UTF8.GetBytes(specialPartContents));
+            }
+
+            string? referenceUri = null;
+            string? digestValueBase64 = null;
+
+            using (OpcPackage package = OpcPackage.Open(temp, OpcPackageFileMode.ReadWrite))
+            {
+                OpcPart? specialPart = package.GetParts().FirstOrDefault(p => p.Uri.ToPackagePath() == specialPartName);
+
+                Assert.NotNull(specialPart);
+                Assert.Equal(string.Empty, specialPart!.Uri.Fragment);
+
+                OpcPackageSignatureBuilder signerBuilder = package.CreateSignatureBuilder();
+                signerBuilder.EnqueueNamedPreset<VSIXSignatureBuilderPreset>();
+
+                using (X509Certificate2 certificate = _pfxFilesFixture.GetPfx(keySizeInBits: 2048, HashAlgorithmName.SHA256))
+                using (RSA? rsaPrivateKey = certificate.GetRSAPrivateKey())
+                {
+                    OpcSignature signature = signerBuilder.Sign(
+                        new SignConfigurationSet(
+                            publicCertificate: certificate,
+                            signatureDigestAlgorithm: HashAlgorithmName.SHA256,
+                            fileDigestAlgorithm: HashAlgorithmName.SHA256,
+                            signingKey: rsaPrivateKey!));
+
+                    using Stream sigStream = signature.Part!.Open();
+                    var document = new XmlDocument();
+                    document.Load(sigStream);
+
+                    var nsmgr = new XmlNamespaceManager(document.NameTable);
+                    nsmgr.AddNamespace("ds", "http://www.w3.org/2000/09/xmldsig#");
+
+                    XmlNode? reference = document.SelectSingleNode("//ds:Reference[contains(@URI, 'ab')]", nsmgr);
+
+                    Assert.NotNull(reference);
+                    referenceUri = reference!.Attributes?["URI"]?.Value;
+                    digestValueBase64 = reference.SelectSingleNode("ds:DigestValue", nsmgr)?.InnerText;
+                }
+            }
+
+            Assert.NotNull(referenceUri);
+            Assert.DoesNotContain('#', referenceUri);
+            Assert.Contains("%23", referenceUri, StringComparison.OrdinalIgnoreCase);
+
+            byte[] actualDigest = Convert.FromBase64String(digestValueBase64 ?? string.Empty);
+            Assert.Equal(expectedDigest, actualDigest);
         }
 
         [Fact]

--- a/test/Sign.Core.Test/Tools/VSIXSignTool/OpcPackageSigningTests.cs
+++ b/test/Sign.Core.Test/Tools/VSIXSignTool/OpcPackageSigningTests.cs
@@ -111,17 +111,19 @@ namespace Sign.Core.Test
             _shadowFiles.Add(temp);
             File.Copy(SamplePackage, temp, overwrite: true);
 
+            byte[] contentBytes = Encoding.UTF8.GetBytes(specialPartContents);
+
             using (ZipArchive archive = ZipFile.Open(temp, ZipArchiveMode.Update))
             {
                 ZipArchiveEntry entry = archive.CreateEntry(specialPartName);
-                using StreamWriter writer = new(entry.Open(), Encoding.UTF8);
-                writer.Write(specialPartContents);
+                using Stream entryStream = entry.Open();
+                entryStream.Write(contentBytes, 0, contentBytes.Length);
             }
 
             byte[] expectedDigest;
             using (SHA256 sha256 = SHA256.Create())
             {
-                expectedDigest = sha256.ComputeHash(Encoding.UTF8.GetBytes(specialPartContents));
+                expectedDigest = sha256.ComputeHash(contentBytes);
             }
 
             string? referenceUri = null;


### PR DESCRIPTION
Fixes #998.

## Root cause

`OpcPart` builds its `Uri` directly from the raw zip entry name:

```csharp
Uri = new Uri(OpcPackage.BasePackageUri, path);
```

`System.Uri` treats an unescaped `#` as introducing a URI fragment. So a content file named e.g. `ab#c.txt` gets silently split into path `ab` + fragment `c.txt` the moment the part is constructed — corrupting everything derived from that `Uri`: the signature manifest's `Reference/@URI`, relationship `Target` paths, and part identity/equality (`OpcPart.Equals`/`GetHashCode`).

Escaping the raw path before constructing the `Uri` fixes the parsing side, but `UriHelpers.ToQualifiedPath()` — used to serialize the `Uri` back into the `Reference/@URI` and relationship `Target` XML attributes — used `UriFormat.Unescaped`, which decodes the escape straight back into a literal `#` when building the string. So the escape alone doesn't survive into the signed XML; the same truncation would reappear at serialization time. This matches what the issue reporter described: a first attempt to percent-encode `#` didn't fix verification, because something downstream was still emitting an unescaped value.

## Fix

- `OpcPart.cs`: escape the raw path (`UriHelpers.EscapePartPath`, new helper) before constructing both the part's `Uri` and its relationship-file location `Uri`.
- `UriHelpers.cs`: `ToQualifiedPath()` now uses `UriFormat.UriEscaped` instead of `UriFormat.Unescaped`, so `#` stays encoded as `%23` in the `Reference/@URI` and relationship `Target` values it produces. `ToPackagePath()` is untouched — it's used for actual zip-entry lookups and must keep returning the raw, unescaped path to match real entry names.

## Testing

Added `ShouldSignPartWithOctothorpeInName` to `OpcPackageSigningTests`: signs a package containing a part named `ab#c.txt`, parses the resulting signature XML, and asserts the `Reference/@URI` contains `%23` (not a raw `#`) and that its `DigestValue` matches the SHA-256 of the actual file contents (i.e. the reference resolves to the right part, not a truncated one).

**Disclosure on verification**: I was unable to execute this repo's test suite locally. `Directory.Build.props` pins `RuntimeIdentifier=win-x64` repo-wide, so the built `Sign.Core.dll` is a genuine Windows-x64 binary that macOS refuses to load (`FileLoadException: The assembly architecture is not compatible with the current process architecture`) — not a missing-tool problem, a hard OS/CPU mismatch. `Sign.Core.csproj` itself **does** build cleanly (0 warnings/errors) with this change. The new test was written by tracing the fixed code path by hand against `System.Uri`/`UriBuilder` documented behavior for `UriComponents`/`UriFormat`, and by manually checking every existing case in `UriHelpersTests.cs` against the changed format flag (none use reserved characters, so none of their assertions change) — but it has not actually been run. Flagging this plainly rather than implying it passed CI locally; happy to iterate on any failures your Windows build turns up.